### PR TITLE
Simple WL implementation of SetReplace

### DIFF
--- a/SetReplace.wl
+++ b/SetReplace.wl
@@ -112,8 +112,7 @@ $ToNormalRules[rules_List] := Join @@ $ToNormalRules /@ rules
 (*TODO(maxitg): Implement checking of arguments*)
 
 
-(* ::Text:: *)
-(*TODO(maxitg): Implement SyntaxInformation*)
+SyntaxInformation[SetReplace] = {"ArgumentsPattern" -> {_, _, _.}};
 
 
 SetReplace[set_UnorderedSet, rules_, n_] := UnorderedSet @@ Quiet[
@@ -124,7 +123,10 @@ SetReplace[set_UnorderedSet, rules_, n_] := UnorderedSet @@ Quiet[
 SetReplace[set_UnorderedSet, rules_] := SetReplace[set, rules, 1]
 
 
-SetReplaceList[set_UnorderedSet, rules_, n_] := FixedPointList[
+SyntaxInformation[SetReplaceList] = {"ArgumentsPattern" -> {_, _, _}};
+
+
+SetReplaceList[set_UnorderedSet, rules_, n_] := UnorderedSet @@@ FixedPointList[
 	Replace[#, $ToNormalRules @ rules] &,
 	List @@ set, n]
 
@@ -133,14 +135,28 @@ SetReplaceList[set_UnorderedSet, rules_, n_] := FixedPointList[
 (*TODO(maxitg): There is a potential issue that has to do with the order of elements in the set being rearranged at each replacement (even if the set contents are not changing), which will prevent FixedPoint from stopping. Possible solution: use custom comparison for FixedPoint.*)
 
 
-SetReplaceFixedPoint[set_UnorderedSet, rules_] := SetReplace[set, rules, \[Infinity]]
+SyntaxInformation[SetReplaceFixedPoint] = {"ArgumentsPattern" -> {_, _}};
 
 
-SetReplaceFixedPointList[set_UnorderedSet, rules_] := SetReplaceList[set, rules, \[Infinity]]
+SetReplaceFixedPoint[set_UnorderedSet, rules_] := UnorderedSet @@
+	SetReplace[set, rules, \[Infinity]]
+
+
+SyntaxInformation[SetReplaceFixedPointList] = {"ArgumentsPattern" -> {_, _}};
+
+
+SetReplaceFixedPointList[set_UnorderedSet, rules_] := UnorderedSet @@@
+	SetReplaceList[set, rules, \[Infinity]]
 
 
 (* ::Text:: *)
 (*We might want to visualize the list-elements of the set as directed hyperedges. We can do that by drawing each hyperedge as a sequence of same-color normal 2-edges.*)
+
+
+Options[UnorderedSetPlot] = Options[Graph];
+
+
+SyntaxInformation[UnorderedSetPlot] = {"ArgumentsPattern" -> {_, OptionsPattern[]}};
 
 
 UnorderedSetPlot[UnorderedSet[edges___List], o___] := Module[

--- a/SetReplace.wl
+++ b/SetReplace.wl
@@ -17,7 +17,7 @@ BeginPackage["SetReplace`"];
 
 SetReplace`Private`$PublicSymbols = {
 	SetReplace, SetReplaceList, SetReplaceFixedPoint, SetReplaceFixedPointList,
-	HypergraphPlot};
+	HypergraphPlot, ColoredEdgeShapeFunction};
 
 
 Unprotect @@ SetReplace`Private`$PublicSymbols;
@@ -357,7 +357,15 @@ HypergraphPlot::usage = UsageString[
 	"Graph options `opts` can be used."];
 
 
-Options[HypergraphPlot] = Join[Options[Graph], {PlotStyle -> ColorData[97]}];
+ColoredEdgeShapeFunction::usage = UsageString[
+	"ColoredEdgeShapeFunction is an argument for HypergraphPlot, which specifies a ",
+	"function used to draw an edge after appropriate ",
+	"color has already been applied to it. ",
+	"Some possible choices are (Line[#1] &) and (Arrow[#1] &)."];
+
+
+Options[HypergraphPlot] = Join[Options[Graph], {
+	PlotStyle -> ColorData[97], ColoredEdgeShapeFunction -> (Arrow[#1] &)}];
 
 
 (* ::Subsubsection:: *)
@@ -422,7 +430,8 @@ HypergraphPlot[edges : {___List}, o : OptionsPattern[]] /;
 		Association @ Thread[shapeHashes[[All, 2]] -> edgeColors[[All, 2]]];
 	Graph[DirectedEdge @@@ Flatten[normalEdges, 1], Join[
 		FilterRules[{o}, Options[Graph]],
-		{EdgeShapeFunction -> ({hashesToColors[Hash[#1]], Line[#1]} &)}]]
+		{EdgeShapeFunction -> ({
+			hashesToColors[Hash[#1]], OptionValue[ColoredEdgeShapeFunction][##]} &)}]]
 ]
 
 

--- a/SetReplace.wl
+++ b/SetReplace.wl
@@ -51,6 +51,11 @@ SetReplaceFixedPointList::usage =
 	"the set no longer changes, and returns the list of all intermediate sets.";
 
 
+UnorderedSetPlot::usage=
+"UnorderedSetPlot[s, opts] plots a set of lists s as a directed hypergraph with each "~~
+	"hyperedge represented as a sequence of same-color arrows.";
+
+
 Begin["`Private`"];
 
 
@@ -132,6 +137,20 @@ SetReplaceFixedPoint[set_UnorderedSet, rules_] := SetReplace[set, rules, \[Infin
 
 
 SetReplaceFixedPointList[set_UnorderedSet, rules_] := SetReplaceList[set, rules, \[Infinity]]
+
+
+(* ::Text:: *)
+(*We might want to visualize the list-elements of the set as directed hyperedges. We can do that by drawing each hyperedge as a sequence of same-color normal 2-edges.*)
+
+
+UnorderedSetPlot[UnorderedSet[edges___List], o___] := Module[
+		{normalEdges, styledEdges},
+	normalEdges = Partition[#, 2, 1] & /@ {edges};
+	styledEdges =
+		With[{color = RandomColor[]}, Style[DirectedEdge @@ #, color] & /@ #] & /@
+			normalEdges;
+	Graph[Flatten[styledEdges], o]
+]
 
 
 End[];

--- a/SetReplace.wl
+++ b/SetReplace.wl
@@ -1,74 +1,60 @@
 (* ::Package:: *)
 
 (* ::Title:: *)
-(*Implementation of*)
-(*Set Substitution System*)
+(*SetReplace*)
+
+
+(* ::Section:: *)
+(*Begin*)
 
 
 (* ::Text:: *)
-(*See https://github.com/maxitg/set-replace.*)
+(*See on GitHub: https://github.com/maxitg/SetReplace.*)
 
 
 BeginPackage["SetReplace`"];
 
 
-UnorderedSet::usage =
-"UnorderedSet[\!\(\*SubscriptBox[\(e\), \(1\)]\), "~~
-	"\!\(\*SubscriptBox[\(e\), \(2\)]\), \[Ellipsis]] is an unordered collection of elements.";
+SetReplace`Private`$PublicSymbols = {
+	SetReplace, SetReplaceList, SetReplaceFixedPoint, SetReplaceFixedPointList,
+	HypergraphPlot};
 
 
-SetReplace::usage =
-"SetReplace[s, {\!\(\*SubscriptBox[\(i\), \(1\)]\) \[Rule] "~~
-	"\!\(\*SubscriptBox[\(o\), \(1\)]\), \!\(\*SubscriptBox[\(i\), \(2\)]\) \[Rule] "~~
-	"\!\(\*SubscriptBox[\(o\), \(2\)]\), \[Ellipsis]}] attempts to replace a subset "~~
-	"\!\(\*SubscriptBox[\(i\), \(1\)]\) of s with \!\(\*SubscriptBox[\(o\), \(1\)]\). "~~
-	"If not found, replaces \!\(\*SubscriptBox[\(i\), \(2\)]\) with "~~
-	"\!\(\*SubscriptBox[\(o\), \(2\)]\), etc.
-SetReplace[s, {\!\(\*SubscriptBox[\(i\), \(1\)]\) \[Rule] "~~
-	"\!\(\*SubscriptBox[\(o\), \(1\)]\), \!\(\*SubscriptBox[\(i\), \(2\)]\) \[Rule] "~~
-	"\!\(\*SubscriptBox[\(o\), \(2\)]\), \[Ellipsis]}, n] performs replacement n times "~~
-	"and returns the result.";
+Unprotect @@ SetReplace`Private`$PublicSymbols;
+ClearAll @@ SetReplace`Private`$PublicSymbols;
 
 
-SetReplaceList::usage =
-"SetReplaceList[s, {\!\(\*SubscriptBox[\(i\), \(1\)]\) \[Rule] "~~
-	"\!\(\*SubscriptBox[\(o\), \(1\)]\), \!\(\*SubscriptBox[\(i\), \(2\)]\) \[Rule] "~~
-	"\!\(\*SubscriptBox[\(o\), \(2\)]\), \[Ellipsis]}, n] performs SetReplace n times "~~
-	"and returns the list of all intermediate sets.";
+(* ::Section:: *)
+(*Dependencies*)
 
 
-SetReplaceFixedPoint::usage =
-"SetReplaceList[s, {\!\(\*SubscriptBox[\(i\), \(1\)]\) \[Rule] "~~
-	"\!\(\*SubscriptBox[\(o\), \(1\)]\), \!\(\*SubscriptBox[\(i\), \(2\)]\) \[Rule] "~~
-	"\!\(\*SubscriptBox[\(o\), \(2\)]\), \[Ellipsis]}] performs SetReplace repeatedly until "~~
-	"the set no longer changes, and returns the final set.";
+(* ::Subsection:: *)
+(*UsageString*)
 
 
-SetReplaceFixedPointList::usage =
-"SetReplaceList[s, {\!\(\*SubscriptBox[\(i\), \(1\)]\) \[Rule] "~~
-	"\!\(\*SubscriptBox[\(o\), \(1\)]\), \!\(\*SubscriptBox[\(i\), \(2\)]\) \[Rule] "~~
-	"\!\(\*SubscriptBox[\(o\), \(2\)]\), \[Ellipsis]}] performs SetReplace repeatedly until "~~
-	"the set no longer changes, and returns the list of all intermediate sets.";
+Get["https://raw.githubusercontent.com/maxitg/WLUsageString/master/UsageString.wl"]
 
 
-UnorderedSetPlot::usage=
-"UnorderedSetPlot[s, opts] plots a set of lists s as a directed hypergraph with each "~~
-	"hyperedge represented as a sequence of same-color arrows.";
+(* ::Section:: *)
+(*Implementation*)
 
 
 Begin["`Private`"];
 
 
+(* ::Subsection:: *)
+(*$ToNormalRules*)
+
+
 (* ::Text:: *)
-(*We are going to transform set substitution rules into a list of n! normal rules, where elements of the input*)
-(*subset are arranged in every possible order with blank null sequences in between.*)
+(*We are going to transform set substitution rules into a list of n! normal rules, where elements of the input subset are arranged in every possible order with blank null sequences in between.*)
 
 
 (* ::Text:: *)
 (*This is for the case of no new vertices being created, so there is no need for a Module in the output*)
 
 
-$ToNormalRules[input_ :> output_UnorderedSet] := Module[
+$ToNormalRules[(input_List :> output_List) | (input_List -> output_List)] := Module[
 		{inputLength, untouchedElements, untouchedPatterns,
 		 inputPermutations, inputsWithUntouchedElements, outputWithUntouchedElements},
 	inputLength = Length @ input;
@@ -84,11 +70,10 @@ $ToNormalRules[input_ :> output_UnorderedSet] := Module[
 
 
 (* ::Text:: *)
-(*Now, if there are new vertices that need to be created, we will disassemble the Module remembering which*)
-(*variables it applies to, and then reassemble it for the output.*)
+(*Now, if there are new vertices that need to be created, we will disassemble the Module remembering which variables it applies to, and then reassemble it for the output.*)
 
 
-$ToNormalRules[input_ :> output_Module] := With[
+$ToNormalRules[input_List :> output_Module] := With[
 		{ruleInputOriginal = input,
 		 moduleInputContents = Hold[output][[1, 2]]},
 	With[{ruleInputFinal = #[[1]],
@@ -100,84 +85,343 @@ $ToNormalRules[input_ :> output_Module] := With[
 
 
 (* ::Text:: *)
+(*If input is not a list, we assume it is a single element set, so we put it into a single element list.*)
+
+
+$ToNormalRules[(input_ :> output_) | (input_ -> output_)] /; !ListQ[input] :=
+	$ToNormalRules[{input} :> output]
+
+
+$ToNormalRules[(input_ :> output_) | (input_ -> output_)] /; !ListQ[output] :=
+	$ToNormalRules[input :> {output}]
+
+
+(* ::Text:: *)
 (*If there are multiple rules, we just join them*)
 
 
 $ToNormalRules[rules_List] := Join @@ $ToNormalRules /@ rules
 
 
+(* ::Subsection:: *)
+(*SetReplace*)
+
+
 (* ::Text:: *)
 (*Now, we can use that to implement SetReplace*)
 
 
-(* ::Text:: *)
-(*TODO(maxitg): Implement checking of arguments*)
+(* ::Subsubsection:: *)
+(*Documentation*)
+
+
+SetReplace::usage = UsageString[
+	"SetReplace[`s`, {\!\(\*SubscriptBox[\(`i`\), \(`1`\)]\) \[Rule] ",
+	"\!\(\*SubscriptBox[\(`o`\), \(`1`\)]\), ",
+	"\!\(\*SubscriptBox[\(`i`\), \(`2`\)]\) \[Rule] ",
+	"\!\(\*SubscriptBox[\(`o`\), \(`2`\)]\), `\[Ellipsis]`}] attempts to replace a subset ",
+	"\!\(\*SubscriptBox[\(`i`\), \(`1`\)]\) of list s with ",
+	"\!\(\*SubscriptBox[\(`o`\), \(`1`\)]\). ",
+	"If not found, replaces \!\(\*SubscriptBox[\(`i`\), \(`2`\)]\) with ",
+	"\!\(\*SubscriptBox[\(`o`\), \(`2`\)]\), etc. ",
+	"Elements of \!\(\*SubscriptBox[\(`i`\), \(`k`\)]\) can appear in `s` in any ",
+	"order, however the elements closest to the beginning of `s` will be replaced, ",
+	"and the elements of \!\(\*SubscriptBox[\(`o`\), \(`k`\)]\) ",
+	"will be put at the end.",
+	"\n",
+	"SetReplace[`s`, {\!\(\*SubscriptBox[\(`i`\), \(`1`\)]\) \[Rule] ",
+	"\!\(\*SubscriptBox[\(`o`\), \(`1`\)]\), ",
+	"\!\(\*SubscriptBox[\(`i`\), \(`2`\)]\) \[Rule] ",
+	"\!\(\*SubscriptBox[\(`o`\), \(`2`\)]\), \[Ellipsis]}, `n`] performs replacement ",
+	"`n` times and returns the result."];
+
+
+(* ::Subsubsection:: *)
+(*Syntax*)
 
 
 SyntaxInformation[SetReplace] = {"ArgumentsPattern" -> {_, _, _.}};
 
 
-SetReplace[set_UnorderedSet, rules_, n_] := UnorderedSet @@ Quiet[
-	ReplaceRepeated[List @@ set, $ToNormalRules @ rules, MaxIterations -> n],
-	ReplaceRepeated::rrlim]
+SetReplace[args___] := 0 /;
+	!Developer`CheckArgumentCount[SetReplace[args], 2, 3] && False
 
 
-SetReplace[set_UnorderedSet, rules_] := SetReplace[set, rules, 1]
+SetReplace::setNotList = "The first argument of `` must be a List.";
+SetReplace[set_, rules_, n_] := 0 /; !ListQ[set] &&
+	Message[SetReplace::setNotList, SetReplace]
+SetReplace[set_, rules_] := 0 /; !ListQ[set] &&
+	Message[SetReplace::setNotList, SetReplace]
+
+
+$SetReplaceRulesQ[rules_] :=
+	MatchQ[rules, {(_Rule | _RuleDelayed)..} | _Rule | _RuleDelayed]
+SetReplace::invalidRules =
+	"The second argument of `` must be either a Rule, RuleDelayed, or " ~~
+	"a List of them.";
+SetReplace[set_, rules_, n_] := 0 /;
+	!$SetReplaceRulesQ[rules] && Message[SetReplace::invalidRules, SetReplace]
+SetReplace[set_, rules_] := 0 /;
+	!$SetReplaceRulesQ[rules] && Message[SetReplace::invalidRules, SetReplace]
+
+
+$StepCountQ[n_] := IntegerQ[n] && n >= 0 || n == \[Infinity]
+SetReplace::nonIntegerIterations =
+	"The third argument `2` of `1` must be an integer or infinity.";
+SetReplace[set_, rules_, n_] := 0 /; !$StepCountQ[n] &&
+	Message[SetReplace::nonIntegerIterations, SetReplace, n]
+
+
+(* ::Subsubsection:: *)
+(*Implementation*)
+
+
+SetReplace[
+		set_List,
+		rules_ ? $SetReplaceRulesQ,
+		n_ ? $StepCountQ] :=
+	Quiet[
+		ReplaceRepeated[List @@ set, $ToNormalRules @ rules, MaxIterations -> n],
+		ReplaceRepeated::rrlim]
+
+
+SetReplace[set_List, rules_ ? $SetReplaceRulesQ] := SetReplace[set, rules, 1]
+
+
+(* ::Subsection:: *)
+(*SetReplaceList*)
+
+
+(* ::Text:: *)
+(*Same as SetReplace, but returns all intermediate steps in a List.*)
+
+
+(* ::Subsubsection:: *)
+(*Documentation*)
+
+
+SetReplaceList::usage = UsageString[
+	"SetReplaceList[`s`, {\!\(\*SubscriptBox[\(`i`\), \(`1`\)]\) \[Rule] ",
+	"\!\(\*SubscriptBox[\(`o`\), \(`1`\)]\), ",
+	"\!\(\*SubscriptBox[\(`i`\), \(`2`\)]\) \[Rule] ",
+	"\!\(\*SubscriptBox[\(`o`\), \(`2`\)]\), \[Ellipsis]}, `n`] performs SetReplace `n` times ",
+	"and returns the list of all intermediate results."];
+
+
+(* ::Subsubsection:: *)
+(*Syntax*)
 
 
 SyntaxInformation[SetReplaceList] = {"ArgumentsPattern" -> {_, _, _}};
 
 
-SetReplaceList[set_UnorderedSet, rules_, n_] := UnorderedSet @@@ FixedPointList[
-	Replace[#, $ToNormalRules @ rules] &,
-	List @@ set, n]
+SetReplaceList[args___] := 0 /;
+	!Developer`CheckArgumentCount[SetReplaceList[args], 3, 3] && False
+
+
+SetReplaceList[set_, rules_, n_] := 0 /; !ListQ[set] &&
+	Message[SetReplace::setNotList, SetReplaceList]
+
+
+SetReplaceList[set_, rules_, n_] := 0 /;
+	!$SetReplaceRulesQ[rules] && Message[SetReplace::invalidRules, SetReplaceList]
+
+
+SetReplaceList[set_, rules_, n_] := 0 /; !$StepCountQ[n] &&
+	Message[SetReplace::nonIntegerIterations, SetReplaceList, n]
+
+
+(* ::Subsubsection:: *)
+(*Implementation*)
+
+
+SetReplaceList[set_List, rules_ ? $SetReplaceRulesQ, n_ ? $StepCountQ] :=
+	FixedPointList[Replace[#, $ToNormalRules @ rules] &, set, n]
+
+
+(* ::Subsection:: *)
+(*SetReplaceFixedPoint*)
 
 
 (* ::Text:: *)
-(*TODO(maxitg): There is a potential issue that has to do with the order of elements in the set being rearranged*)
-(*at each replacement (even if the set contents are not changing), which will prevent FixedPoint from stopping.*)
-(*Possible solution: use custom comparison for FixedPoint.*)
+(*Same as SetReplace, but automatically stops replacing when the set no longer changes.*)
+
+
+(* ::Subsubsection:: *)
+(*Documentation*)
+
+
+SetReplaceFixedPoint::usage = UsageString[
+	"SetReplaceFixedPoint[`s`, {\!\(\*SubscriptBox[\(`i`\), \(`1`\)]\) \[Rule] ",
+	"\!\(\*SubscriptBox[\(`o`\), \(`1`\)]\), ",
+	"\!\(\*SubscriptBox[\(`i`\), \(`2`\)]\) \[Rule] ",
+	"\!\(\*SubscriptBox[\(`o`\), \(`2`\)]\), \[Ellipsis]}] performs SetReplace repeatedly ",
+	"until the set no longer changes, and returns the final set.",
+	"\n",
+	"Fixed point requires not only the elements, but also the order of elements to be ",
+	"fixed. Will go into infinite loop if fixed point does not exist."];
+
+
+(* ::Subsubsection:: *)
+(*Syntax*)
 
 
 SyntaxInformation[SetReplaceFixedPoint] = {"ArgumentsPattern" -> {_, _}};
 
 
-SetReplaceFixedPoint[set_UnorderedSet, rules_] := UnorderedSet @@
-	SetReplace[set, rules, \[Infinity]]
+SetReplaceFixedPoint[args___] := 0 /;
+	!Developer`CheckArgumentCount[SetReplaceFixedPoint[args], 2, 2] && False
+
+
+SetReplaceFixedPoint[set_, rules_] := 0 /; !ListQ[set] &&
+	Message[SetReplace::setNotList, SetReplaceFixedPoint]
+
+
+SetReplaceFixedPoint[set_, rules_] := 0 /; !$SetReplaceRulesQ[rules] &&
+	Message[SetReplace::invalidRules, SetReplaceFixedPoint]
+
+
+(* ::Subsubsection:: *)
+(*Implementation*)
+
+
+SetReplaceFixedPoint[set_List, rules_ ? $SetReplaceRulesQ] := SetReplace[set, rules, \[Infinity]]
+
+
+(* ::Subsection:: *)
+(*SetReplaceFixedPointList*)
+
+
+(* ::Text:: *)
+(*Same as SetReplaceFixedPoint, but returns all intermediate steps.*)
+
+
+(* ::Subsubsection:: *)
+(*Documentation*)
+
+
+SetReplaceFixedPointList::usage = UsageString[
+	"SetReplaceFixedPointList[`s`, {\!\(\*SubscriptBox[\(`i`\), \(`1`\)]\) \[Rule] ",
+	"\!\(\*SubscriptBox[\(`o`\), \(`1`\)]\), ",
+	"\!\(\*SubscriptBox[\(`i`\), \(`2`\)]\) \[Rule] ",
+	"\!\(\*SubscriptBox[\(`o`\), \(`2`\)]\), \[Ellipsis]}] performs SetReplace repeatedly ",
+	"until the set no longer changes, and returns the list of all intermediate sets."];
+
+
+(* ::Subsubsection:: *)
+(*Syntax*)
 
 
 SyntaxInformation[SetReplaceFixedPointList] = {"ArgumentsPattern" -> {_, _}};
 
 
-SetReplaceFixedPointList[set_UnorderedSet, rules_] := UnorderedSet @@@
+SetReplaceFixedPointList[args___] := 0 /;
+	!Developer`CheckArgumentCount[SetReplaceFixedPointList[args], 2, 2] && False
+
+
+SetReplaceFixedPointList[set_, rules_] := 0 /; !ListQ[set] &&
+	Message[SetReplace::setNotList, SetReplaceFixedPointList]
+
+
+SetReplaceFixedPointList[set_, rules_] := 0 /; !$SetReplaceRulesQ[rules] &&
+	Message[SetReplace::invalidRules, SetReplaceFixedPointList]
+
+
+(* ::Subsubsection:: *)
+(*Implementation*)
+
+
+SetReplaceFixedPointList[set_List, rules_ ? $SetReplaceRulesQ] :=
 	SetReplaceList[set, rules, \[Infinity]]
 
 
-(* ::Text:: *)
-(*We might want to visualize the list-elements of the set as directed hyperedges. We can do that by drawing each*)
-(*hyperedge as a sequence of same-color normal 2-edges.*)
-
-
-Options[UnorderedSetPlot] = Options[Graph];
-
-
-SyntaxInformation[UnorderedSetPlot] = {"ArgumentsPattern" -> {_, OptionsPattern[]}};
+(* ::Subsection:: *)
+(*HypergraphPlot*)
 
 
 (* ::Text:: *)
-(*TODO(maxitg): There is an issue here due to a bug in WL. If there are multiple edges in a Graph with the same*)
-(*endpoints, it is impossible to color them differently due to how edges styles being handled internally in WL.*)
-(*Must be fixed upstream.*)
+(*We might want to visualize the list-elements of the set as directed hyperedges. We can do that by drawing each hyperedge as sequences of same-color normal 2-edges.*)
 
 
-UnorderedSetPlot[UnorderedSet[edges___List], o___] := Module[
-		{normalEdges, styledEdges},
-	normalEdges = Partition[#, 2, 1] & /@ {edges};
-	styledEdges =
-		With[{color = RandomColor[]}, Style[DirectedEdge @@ #, color] & /@ #] & /@
-			normalEdges;
-	Graph[Flatten[styledEdges], o]
+(* ::Text:: *)
+(*We will have to work around the bug in Wolfram Language that prevents multi-edges appear in different colors regardless of their different styles.*)
+
+
+(* ::Subsubsection:: *)
+(*Documentation*)
+
+
+HypergraphPlot::usage = UsageString[
+	"HypergraphPlot[`s`, `opts`] plots a list of vertex lists `s` as a ",
+	"hypergraph with each hyperedge represented as a sequence of same-color arrows. ",
+	"Graph options `opts` can be used."];
+
+
+Options[HypergraphPlot] = Join[Options[Graph], {PlotStyle -> ColorData[97]}];
+
+
+(* ::Subsubsection:: *)
+(*Syntax*)
+
+
+SyntaxInformation[HypergraphPlot] = {"ArgumentsPattern" -> {_, OptionsPattern[]}};
+
+
+HypergraphPlot[args___] := 0 /;
+	!Developer`CheckArgumentCount[HypergraphPlot[args], 1, 1] && False
+
+
+$CorrectOptions[HypergraphPlot][o___] := Module[
+		{plotStyle = OptionValue[HypergraphPlot, {o}, PlotStyle]},
+	Head[plotStyle] === ColorDataFunction &&
+	plotStyle[[2]] === "Indexed"
 ]
+
+
+HypergraphPlot::unsupportedPlotStyle =
+	"Only indexed ColorDataFunction, i.e., ColorData[n] is supported as a plot style.";
+
+
+HypergraphPlot[edges : {___List}, o : OptionsPattern[]] := 0 /;
+	!$CorrectOptions[HypergraphPlot][o] &&
+	Message[HypergraphPlot::unsupportedPlotStyle]
+
+
+(* ::Subsubsection:: *)
+(*Implementation*)
+
+
+(* ::Text:: *)
+(*The idea here is that we are going to draw Graph first while substituting EdgeShapeFunction with a function that collects edge shapes, and produces edge -> hash mapping.*)
+
+
+(* ::Text:: *)
+(*We can then use that to produce hash -> color association, which we use to properly color the edges.*)
+
+
+HypergraphPlot[edges : {___List}, o : OptionsPattern[]] /;
+	$CorrectOptions[HypergraphPlot][o] := Module[
+		{normalEdges, edgeColors, shapeHashes, hashesToColors},
+	normalEdges = Partition[#, 2, 1] & /@ edges;
+	edgeColors = Sort @ Flatten @ MapIndexed[
+		Thread[DirectedEdge @@@ #1 -> OptionValue[PlotStyle][#2[[1]]]] &, normalEdges];
+	shapeHashes = Sort @ First @ Last @ Reap @ Rasterize @ Graph[
+		DirectedEdge @@@ Flatten[normalEdges, 1], Join[{
+			EdgeShapeFunction -> (Sow[#2 -> Hash[#1]] &)},
+			FilterRules[{o}, Options[Graph]]]];
+	hashesToColors =
+		Association @ Thread[shapeHashes[[All, 2]] -> edgeColors[[All, 2]]];
+	Graph[DirectedEdge @@@ Flatten[normalEdges, 1], Join[
+		FilterRules[{o}, Options[Graph]],
+		{EdgeShapeFunction -> ({hashesToColors[Hash[#1]], Line[#1]} &)}]]
+]
+
+
+(* ::Section:: *)
+(*End*)
+
+
+Protect @@ SetReplace`Private`$PublicSymbols;
 
 
 End[];

--- a/SetReplace.wl
+++ b/SetReplace.wl
@@ -60,7 +60,8 @@ Begin["`Private`"];
 
 
 (* ::Text:: *)
-(*We are going to transform set substitution rules into a list of n! normal rules, where elements of the input subset are arranged in every possible order with blank null sequences in between.*)
+(*We are going to transform set substitution rules into a list of n! normal rules, where elements of the input*)
+(*subset are arranged in every possible order with blank null sequences in between.*)
 
 
 (* ::Text:: *)
@@ -83,7 +84,8 @@ $ToNormalRules[input_ :> output_UnorderedSet] := Module[
 
 
 (* ::Text:: *)
-(*Now, if there are new vertices that need to be created, we will disassemble the Module remembering which variables it applies to, and then reassemble it for the output.*)
+(*Now, if there are new vertices that need to be created, we will disassemble the Module remembering which*)
+(*variables it applies to, and then reassemble it for the output.*)
 
 
 $ToNormalRules[input_ :> output_Module] := With[
@@ -132,7 +134,9 @@ SetReplaceList[set_UnorderedSet, rules_, n_] := UnorderedSet @@@ FixedPointList[
 
 
 (* ::Text:: *)
-(*TODO(maxitg): There is a potential issue that has to do with the order of elements in the set being rearranged at each replacement (even if the set contents are not changing), which will prevent FixedPoint from stopping. Possible solution: use custom comparison for FixedPoint.*)
+(*TODO(maxitg): There is a potential issue that has to do with the order of elements in the set being rearranged*)
+(*at each replacement (even if the set contents are not changing), which will prevent FixedPoint from stopping.*)
+(*Possible solution: use custom comparison for FixedPoint.*)
 
 
 SyntaxInformation[SetReplaceFixedPoint] = {"ArgumentsPattern" -> {_, _}};
@@ -150,7 +154,8 @@ SetReplaceFixedPointList[set_UnorderedSet, rules_] := UnorderedSet @@@
 
 
 (* ::Text:: *)
-(*We might want to visualize the list-elements of the set as directed hyperedges. We can do that by drawing each hyperedge as a sequence of same-color normal 2-edges.*)
+(*We might want to visualize the list-elements of the set as directed hyperedges. We can do that by drawing each*)
+(*hyperedge as a sequence of same-color normal 2-edges.*)
 
 
 Options[UnorderedSetPlot] = Options[Graph];
@@ -160,7 +165,9 @@ SyntaxInformation[UnorderedSetPlot] = {"ArgumentsPattern" -> {_, OptionsPattern[
 
 
 (* ::Text:: *)
-(*TODO(maxitg): There is an issue here due to a bug in WL. If there are multiple edges in a Graph with the same endpoints, it is impossible to color them differently due to how edges styles being handled internally in WL. Must be fixed upstream.*)
+(*TODO(maxitg): There is an issue here due to a bug in WL. If there are multiple edges in a Graph with the same*)
+(*endpoints, it is impossible to color them differently due to how edges styles being handled internally in WL.*)
+(*Must be fixed upstream.*)
 
 
 UnorderedSetPlot[UnorderedSet[edges___List], o___] := Module[

--- a/SetReplace.wl
+++ b/SetReplace.wl
@@ -1,0 +1,35 @@
+(* ::Package:: *)
+
+(* ::Title:: *)
+(*Implementation of*)
+(*Set Substitution System*)
+
+
+(* ::Text:: *)
+(*See https://github.com/maxitg/set-replace.*)
+
+
+BeginPackage["SetReplace`"];
+
+
+UnorderedSet::usage =
+	"UnorderedSet[\!\(\*SubscriptBox[\(e\), \(1\)]\), "~~
+	"\!\(\*SubscriptBox[\(e\), \(2\)]\), \[Ellipsis]] is an unordered collection of elements.";
+
+
+SetReplace::usage =
+	"SetReplace[s, {\!\(\*SubscriptBox[\(i\), \(1\)]\) \[Rule] "~~
+	"\!\(\*SubscriptBox[\(o\), \(1\)]\), \!\(\*SubscriptBox[\(i\), \(2\)]\) \[Rule] "~~
+	"\!\(\*SubscriptBox[\(o\), \(2\)]\), \[Ellipsis]}] attempts to replace a subset "~~
+	"\!\(\*SubscriptBox[\(i\), \(1\)]\) of s with \!\(\*SubscriptBox[\(o\), \(1\)]\). "~~
+	"If not found, replaces \!\(\*SubscriptBox[\(i\), \(2\)]\) with "~~
+	"\!\(\*SubscriptBox[\(o\), \(2\)]\), etc.";
+
+
+Begin["`Private`"];
+
+
+End[];
+
+
+EndPackage[];

--- a/SetReplace.wl
+++ b/SetReplace.wl
@@ -86,8 +86,12 @@ $ToNormalRules[rules_List] := Join @@ $ToNormalRules /@ rules
 (*TODO(maxitg): Implement SyntaxInformation*)
 
 
-SetReplace[set_UnorderedSet, rules_] :=
-	UnorderedSet @@ Replace[List @@ set, $ToNormalRules @ rules]
+SetReplace[set_UnorderedSet, rules_, n_] := UnorderedSet @@ Quiet[
+	ReplaceRepeated[List @@ set, $ToNormalRules @ rules, MaxIterations -> n],
+	ReplaceRepeated::rrlim]
+
+
+SetReplace[set_UnorderedSet, rules_] := SetReplace[set, rules, 1]
 
 
 End[];

--- a/SetReplace.wl
+++ b/SetReplace.wl
@@ -94,6 +94,17 @@ SetReplace[set_UnorderedSet, rules_, n_] := UnorderedSet @@ Quiet[
 SetReplace[set_UnorderedSet, rules_] := SetReplace[set, rules, 1]
 
 
+SetReplaceList[set_UnorderedSet, rules_, n_] := FixedPointList[
+	Replace[#, $ToNormalRules @ rules] &,
+	List @@ set, n]
+
+
+SetReplaceFixedPoint[set_UnorderedSet, rules_] := SetReplace[set, rules, \[Infinity]]
+
+
+SetReplaceFixedPointList[set_UnorderedSet, rules_] := SetReplaceList[set, rules, \[Infinity]]
+
+
 End[];
 
 

--- a/SetReplace.wl
+++ b/SetReplace.wl
@@ -371,6 +371,15 @@ HypergraphPlot[args___] := 0 /;
 	!Developer`CheckArgumentCount[HypergraphPlot[args], 1, 1] && False
 
 
+HypergraphPlot::invalidEdges =
+	"First argument of HypergraphPlot must be list of lists, where elements " ~~
+	"represent vertices."; 
+
+
+HypergraphPlot[edges_, o : OptionsPattern[]] := 0 /;
+	!MatchQ[edges, {___List}] && Message[HypergraphPlot::invalidEdges]
+
+
 $CorrectOptions[HypergraphPlot][o___] := Module[
 		{plotStyle = OptionValue[HypergraphPlot, {o}, PlotStyle]},
 	Head[plotStyle] === ColorDataFunction &&

--- a/SetReplace.wl
+++ b/SetReplace.wl
@@ -159,6 +159,10 @@ Options[UnorderedSetPlot] = Options[Graph];
 SyntaxInformation[UnorderedSetPlot] = {"ArgumentsPattern" -> {_, OptionsPattern[]}};
 
 
+(* ::Text:: *)
+(*TODO(maxitg): There is an issue here due to a bug in WL. If there are multiple edges in a Graph with the same endpoints, it is impossible to color them differently due to how edges styles being handled internally in WL. Must be fixed upstream.*)
+
+
 UnorderedSetPlot[UnorderedSet[edges___List], o___] := Module[
 		{normalEdges, styledEdges},
 	normalEdges = Partition[#, 2, 1] & /@ {edges};

--- a/SetReplace.wl
+++ b/SetReplace.wl
@@ -29,6 +29,67 @@ SetReplace::usage =
 Begin["`Private`"];
 
 
+(* ::Text:: *)
+(*We are going to transform set substitution rules into a list of n! normal rules, where elements of the input subset are arranged in every possible order with blank null sequences in between.*)
+
+
+(* ::Text:: *)
+(*This is for the case of no new vertices being created, so there is no need for a Module in the output*)
+
+
+$ToNormalRules[input_ :> output_UnorderedSet] := Module[
+		{inputLength, untouchedElements, untouchedPatterns,
+		 inputPermutations, inputsWithUntouchedElements, outputWithUntouchedElements},
+	inputLength = Length @ input;
+	untouchedElements = Table[Unique[], inputLength + 1];
+	untouchedPatterns = Pattern[#, ___] & /@ untouchedElements;
+
+	inputPermutations = Permutations @ (List @@ input);
+	inputsWithUntouchedElements = Riffle[untouchedPatterns, #] & /@ inputPermutations;
+	outputWithUntouchedElements = Join[untouchedElements, List @@ output];
+
+	# :> Evaluate @ outputWithUntouchedElements & /@ inputsWithUntouchedElements
+] 
+
+
+(* ::Text:: *)
+(*Now, if there are new vertices that need to be created, we will disassemble the Module remembering which variables it applies to, and then reassemble it for the output.*)
+
+
+$ToNormalRules[input_ :> output_Module] := With[
+		{ruleInputOriginal = input,
+		 moduleInputContents = Hold[output][[1, 2]]},
+	With[{ruleInputFinal = #[[1]],
+		  moduleArguments = Hold[output][[1, 1]],
+		  moduleOutputContents = #[[2]]},
+		ruleInputFinal :> Module[moduleArguments, moduleOutputContents]
+	] & /@ $ToNormalRules[ruleInputOriginal :> Evaluate @ moduleInputContents]
+]
+
+
+(* ::Text:: *)
+(*If there are multiple rules, we just join them*)
+
+
+$ToNormalRules[rules_List] := Join @@ $ToNormalRules /@ rules
+
+
+(* ::Text:: *)
+(*Now, we can use that to implement SetReplace*)
+
+
+(* ::Text:: *)
+(*TODO(maxitg): Implement checking of arguments*)
+
+
+(* ::Text:: *)
+(*TODO(maxitg): Implement SyntaxInformation*)
+
+
+SetReplace[set_UnorderedSet, rules_] :=
+	UnorderedSet @@ Replace[List @@ set, $ToNormalRules @ rules]
+
+
 End[];
 
 

--- a/SetReplace.wl
+++ b/SetReplace.wl
@@ -13,17 +13,42 @@ BeginPackage["SetReplace`"];
 
 
 UnorderedSet::usage =
-	"UnorderedSet[\!\(\*SubscriptBox[\(e\), \(1\)]\), "~~
+"UnorderedSet[\!\(\*SubscriptBox[\(e\), \(1\)]\), "~~
 	"\!\(\*SubscriptBox[\(e\), \(2\)]\), \[Ellipsis]] is an unordered collection of elements.";
 
 
 SetReplace::usage =
-	"SetReplace[s, {\!\(\*SubscriptBox[\(i\), \(1\)]\) \[Rule] "~~
+"SetReplace[s, {\!\(\*SubscriptBox[\(i\), \(1\)]\) \[Rule] "~~
 	"\!\(\*SubscriptBox[\(o\), \(1\)]\), \!\(\*SubscriptBox[\(i\), \(2\)]\) \[Rule] "~~
 	"\!\(\*SubscriptBox[\(o\), \(2\)]\), \[Ellipsis]}] attempts to replace a subset "~~
 	"\!\(\*SubscriptBox[\(i\), \(1\)]\) of s with \!\(\*SubscriptBox[\(o\), \(1\)]\). "~~
 	"If not found, replaces \!\(\*SubscriptBox[\(i\), \(2\)]\) with "~~
-	"\!\(\*SubscriptBox[\(o\), \(2\)]\), etc.";
+	"\!\(\*SubscriptBox[\(o\), \(2\)]\), etc.
+SetReplace[s, {\!\(\*SubscriptBox[\(i\), \(1\)]\) \[Rule] "~~
+	"\!\(\*SubscriptBox[\(o\), \(1\)]\), \!\(\*SubscriptBox[\(i\), \(2\)]\) \[Rule] "~~
+	"\!\(\*SubscriptBox[\(o\), \(2\)]\), \[Ellipsis]}, n] performs replacement n times "~~
+	"and returns the result.";
+
+
+SetReplaceList::usage =
+"SetReplaceList[s, {\!\(\*SubscriptBox[\(i\), \(1\)]\) \[Rule] "~~
+	"\!\(\*SubscriptBox[\(o\), \(1\)]\), \!\(\*SubscriptBox[\(i\), \(2\)]\) \[Rule] "~~
+	"\!\(\*SubscriptBox[\(o\), \(2\)]\), \[Ellipsis]}, n] performs SetReplace n times "~~
+	"and returns the list of all intermediate sets.";
+
+
+SetReplaceFixedPoint::usage =
+"SetReplaceList[s, {\!\(\*SubscriptBox[\(i\), \(1\)]\) \[Rule] "~~
+	"\!\(\*SubscriptBox[\(o\), \(1\)]\), \!\(\*SubscriptBox[\(i\), \(2\)]\) \[Rule] "~~
+	"\!\(\*SubscriptBox[\(o\), \(2\)]\), \[Ellipsis]}] performs SetReplace repeatedly until "~~
+	"the set no longer changes, and returns the final set.";
+
+
+SetReplaceFixedPointList::usage =
+"SetReplaceList[s, {\!\(\*SubscriptBox[\(i\), \(1\)]\) \[Rule] "~~
+	"\!\(\*SubscriptBox[\(o\), \(1\)]\), \!\(\*SubscriptBox[\(i\), \(2\)]\) \[Rule] "~~
+	"\!\(\*SubscriptBox[\(o\), \(2\)]\), \[Ellipsis]}] performs SetReplace repeatedly until "~~
+	"the set no longer changes, and returns the list of all intermediate sets.";
 
 
 Begin["`Private`"];
@@ -97,6 +122,10 @@ SetReplace[set_UnorderedSet, rules_] := SetReplace[set, rules, 1]
 SetReplaceList[set_UnorderedSet, rules_, n_] := FixedPointList[
 	Replace[#, $ToNormalRules @ rules] &,
 	List @@ set, n]
+
+
+(* ::Text:: *)
+(*TODO(maxitg): There is a potential issue that has to do with the order of elements in the set being rearranged at each replacement (even if the set contents are not changing), which will prevent FixedPoint from stopping. Possible solution: use custom comparison for FixedPoint.*)
 
 
 SetReplaceFixedPoint[set_UnorderedSet, rules_] := SetReplace[set, rules, \[Infinity]]

--- a/SetReplace.wlt
+++ b/SetReplace.wlt
@@ -1,0 +1,233 @@
+BeginTestSection["SetReplace"]
+
+VerificationTest[
+	SetReplace[{}, {} :> {}],
+	{}
+]
+
+VerificationTest[
+	SetReplace[{1, 2, 3}, 2 -> 5],
+	{1, 3, 5}
+]
+
+VerificationTest[
+	SetReplace[{1, 2, 3}, 2 :> 5],
+	{1, 3, 5}
+]
+
+VerificationTest[
+	SetReplace[{1, 2, 3}, {2 :> 5, 3 :> 6}, 2],
+	{1, 5, 6}
+]
+
+VerificationTest[
+	SetReplace[{1, 2, 3}, {2 -> 5, 3 :> 6}, 2],
+	{1, 5, 6}
+]
+
+VerificationTest[
+	SetReplace[{1, 2, 3}, {2 -> 5, 3 :> 6}, 10],
+	{1, 5, 6}
+]
+
+VerificationTest[
+	SetReplace[{1, 2, 3}, {3, 2} -> 5],
+	{1, 5}
+]
+
+VerificationTest[
+	SetReplace[{1, 2, 3}, 4 -> 5],
+	{1, 2, 3}
+]
+
+VerificationTest[
+	SetReplace[{{1}}, {{1}} :> {}],
+	{}
+]
+
+VerificationTest[
+	SetReplace[{{1}, {2}}, {{1}, {2}} :> {{3}}],
+	{{3}}
+]
+
+VerificationTest[
+	SetReplace[{{2}, {1}}, {{1}, {2}} :> {{3}}],
+	{{3}}
+]
+
+VerificationTest[
+	Module[{extraEdge},
+ 		extraEdge =
+ 			SetReplace[{{0, 1}}, {{a_, b_}} :> Module[{$0}, {{a, $0}, {$0, b}}]];
+ 		SetReplace[extraEdge, {{a_, b_}, {b_, c_}} :> {{a, c}}]
+ 	],
+	{{0, 1}}
+]
+
+VerificationTest[
+	SetReplace[],
+	SetReplace[],
+	{SetReplace::argt}
+]
+
+VerificationTest[
+	SetReplace[1, 1 -> 2],
+	SetReplace[1, 1 -> 2],
+	{SetReplace::setNotList}
+]
+
+VerificationTest[
+	SetReplace[{1}, 1],
+	SetReplace[{1}, 1],
+	{SetReplace::invalidRules}
+]
+
+VerificationTest[
+	SetReplace[{1}, {1}],
+	SetReplace[{1}, {1}],
+	{SetReplace::invalidRules}
+]
+
+VerificationTest[
+	SetReplace[{1}, {1 -> 2}, -1],
+	SetReplace[{1}, {1 -> 2}, -1],
+	{SetReplace::nonIntegerIterations}
+]
+
+VerificationTest[
+	SetReplace[{1}, {1 -> 2}, 1.5],
+	SetReplace[{1}, {1 -> 2}, 1.5],
+	{SetReplace::nonIntegerIterations}
+]
+
+VerificationTest[
+	SetReplaceList[{1, 2, 3}, {2 -> 5, 3 :> 6}, 10],
+	{{1, 2, 3}, {1, 3, 5}, {1, 5, 6}, {1, 5, 6}}
+]
+
+VerificationTest[
+	SetReplaceList[{1, 2, 3}, {2 -> 5, 3 :> 6}, 1],
+	{{1, 2, 3}, {1, 3, 5}}
+]
+
+VerificationTest[
+	SetReplaceList[{1}],
+	SetReplaceList[{1}],
+	{SetReplaceList::argr}
+]
+
+VerificationTest[
+	SetReplaceList[1, 1 -> 2, 2],
+	SetReplaceList[1, 1 -> 2, 2],
+	{SetReplace::setNotList}
+]
+
+VerificationTest[
+	SetReplaceList[{1}, {1}, 1],
+	SetReplaceList[{1}, {1}, 1],
+	{SetReplace::invalidRules}
+]
+
+VerificationTest[
+	SetReplaceList[{1}, {1 -> 2}, -1],
+	SetReplaceList[{1}, {1 -> 2}, -1],
+	{SetReplace::nonIntegerIterations}
+]
+
+VerificationTest[
+	SetReplaceFixedPoint[{1, 1, 1}, {1 -> 2}],
+	{2, 2, 2}
+]
+
+VerificationTest[
+	SetReplaceFixedPoint[{0.5}, {n_ :> 1 - n}],
+	{0.5}
+]
+
+VerificationTest[
+	SetReplaceFixedPoint[{1}],
+	SetReplaceFixedPoint[{1}],
+	{SetReplaceFixedPoint::argr}
+]
+
+VerificationTest[
+	SetReplaceFixedPoint[1, 1 -> 2],
+	SetReplaceFixedPoint[1, 1 -> 2],
+	{SetReplace::setNotList}
+]
+
+VerificationTest[
+	SetReplaceFixedPoint[{1}, {1}],
+	SetReplaceFixedPoint[{1}, {1}],
+	{SetReplace::invalidRules}
+]
+
+VerificationTest[
+	SetReplaceFixedPointList[{1, 1, 1}, {1 -> 2}],
+	{{1, 1, 1}, {1, 1, 2}, {1, 2, 2}, {2, 2, 2}, {2, 2, 2}}
+]
+
+VerificationTest[
+	SetReplaceFixedPointList[{0.5}, {n_ :> 1 - n}],
+	{{0.5}, {0.5}}
+]
+
+VerificationTest[
+	SetReplaceFixedPointList[{1}],
+	SetReplaceFixedPointList[{1}],
+	{SetReplaceFixedPointList::argr}
+]
+
+VerificationTest[
+	SetReplaceFixedPointList[1, 1 -> 2],
+	SetReplaceFixedPointList[1, 1 -> 2],
+	{SetReplace::setNotList}
+]
+
+VerificationTest[
+	SetReplaceFixedPointList[{1}, {1}],
+	SetReplaceFixedPointList[{1}, {1}],
+	{SetReplace::invalidRules}
+]
+
+VerificationTest[
+	HypergraphPlot[],
+	HypergraphPlot[],
+	{HypergraphPlot::argx}
+]
+
+VerificationTest[
+	HypergraphPlot[{{1, 2}}, {{1, 2}}],
+	HypergraphPlot[{{1, 2}}, {{1, 2}}],
+	{HypergraphPlot::argx}
+]
+
+VerificationTest[
+	HypergraphPlot[1],
+	HypergraphPlot[1],
+	{HypergraphPlot::invalidEdges}
+]
+
+VerificationTest[
+	HypergraphPlot[{1, 2}],
+	HypergraphPlot[{1, 2}],
+	{HypergraphPlot::invalidEdges}
+]
+
+VerificationTest[
+	HypergraphPlot[{{1, 3}, 2}],
+	HypergraphPlot[{{1, 3}, 2}],
+	{HypergraphPlot::invalidEdges}
+]
+
+VerificationTest[
+	GraphQ[HypergraphPlot[{{1, 3}, {2, 4}}]]
+]
+
+VerificationTest[
+	GraphQ[HypergraphPlot[{{1, 3}, 6, {2, 4}}]],
+	False,
+	{HypergraphPlot::invalidEdges}
+]
+
+EndTestSection[]


### PR DESCRIPTION
## Changes

* Implements SetReplace and related functions in Wolfram Language.
  * Implementation is slow, but it can be used to test C++ implementation.
* Implements HypergraphPlot, that plots a set of directed hyperedges (lists) as a Graph with each hyperedge represented as a series of arrows.
* Adds argument checks for all functions.
* Implements unit tests for all functions.

## Test

### Split and combine edges
* Evaluate a rule that splits a single edge into two, and plot the results:
`HypergraphPlot[manyEdges = SetReplace[{{0, 1}}, {{a_, b_}} :> Module[{$0}, {{a, $0}, {$0, b}}], 5]]`
![image](https://user-images.githubusercontent.com/1479325/50428198-23b30080-086a-11e9-8b4b-3626ccf04c02.png)
* Reduce it back to a single edge:
`SetReplaceFixedPoint[manyEdges, {{a_, b_}, {b_, c_}} :> {{a, c}}]`
* You should see `{{0, 1}}` as output.

### Point to a triangle
* As a more complicated example, try converting a point with 3 connections into a triangle:
`HypergraphPlot[
 SetReplace[{{0, 1}, {0, 2}, {0, 3}}, {{a_, b_}, {a_, c_}, {a_, d_}} :> Module[{$1, $2, $3}, {{$1, $2}, {$2, $3}, {$3, $1}, {$1, $3}, {$3, $2}, {$2, $1}, {$1, b}, {$2, c}, {$3, d}}], 1 + 3 + 9 + 27], ColoredEdgeShapeFunction -> (Line[#1] &)]`
![image](https://user-images.githubusercontent.com/1479325/50429569-2d416600-0874-11e9-8225-bf6ed1b39c0f.png)

### Unit tests
* Import or evaluate the package: `Get["path to SetReplace.wl"]`.
* Run unit tests: `TestReport["path to SetReplace.wlt"]`