### PR TITLE
SetReplaceAll

### DIFF
--- a/SetReplace.wl
+++ b/SetReplace.wl
@@ -17,7 +17,7 @@ BeginPackage["SetReplace`"];
 
 SetReplace`Private`$PublicSymbols = {
 	SetReplace, SetReplaceList, SetReplaceFixedPoint, SetReplaceFixedPointList,
-	HypergraphPlot, FromAnonymousRules};
+	SetReplaceAll, FromAnonymousRules, HypergraphPlot};
 
 
 Unprotect @@ SetReplace`Private`$PublicSymbols;
@@ -52,6 +52,9 @@ Begin["`Private`"];
 
 (* ::Text:: *)
 (*This is for the case of no new vertices being created, so there is no need for a Module in the output*)
+
+
+ClearAll[$ToNormalRules];
 
 
 $ToNormalRules[(input_List :> output_List) | (input_List -> output_List)] := Module[
@@ -154,23 +157,21 @@ SetReplace[args___] := 0 /;
 
 
 SetReplace::setNotList = "The first argument of `` must be a List.";
-SetReplace[set_, rules_, n_] := 0 /; !ListQ[set] &&
-	Message[SetReplace::setNotList, SetReplace]
-SetReplace[set_, rules_] := 0 /; !ListQ[set] &&
+SetReplace[set_, rules_, n_: 0] := 0 /; !ListQ[set] &&
 	Message[SetReplace::setNotList, SetReplace]
 
 
+ClearAll[$SetReplaceRulesQ];
 $SetReplaceRulesQ[rules_] :=
 	MatchQ[rules, {(_Rule | _RuleDelayed)..} | _Rule | _RuleDelayed]
 SetReplace::invalidRules =
 	"The second argument of `` must be either a Rule, RuleDelayed, or " ~~
 	"a List of them.";
-SetReplace[set_, rules_, n_] := 0 /;
-	!$SetReplaceRulesQ[rules] && Message[SetReplace::invalidRules, SetReplace]
-SetReplace[set_, rules_] := 0 /;
+SetReplace[set_, rules_, n_: 0] := 0 /;
 	!$SetReplaceRulesQ[rules] && Message[SetReplace::invalidRules, SetReplace]
 
 
+ClearAll[$StepCountQ];
 $StepCountQ[n_] := IntegerQ[n] && n >= 0 || n == \[Infinity]
 SetReplace::nonIntegerIterations =
 	"The third argument `2` of `1` must be an integer or infinity.";
@@ -182,10 +183,7 @@ SetReplace[set_, rules_, n_] := 0 /; !$StepCountQ[n] &&
 (*Implementation*)
 
 
-SetReplace[
-		set_List,
-		rules_ ? $SetReplaceRulesQ,
-		n_ ? $StepCountQ] :=
+SetReplace[set_List, rules_ ? $SetReplaceRulesQ, n_ ? $StepCountQ] :=
 	Quiet[
 		ReplaceRepeated[List @@ set, $ToNormalRules @ rules, MaxIterations -> n],
 		ReplaceRepeated::rrlim]
@@ -386,6 +384,7 @@ HypergraphPlot[edges_, o : OptionsPattern[]] := 0 /;
 	!MatchQ[edges, {___List}] && Message[HypergraphPlot::invalidEdges]
 
 
+ClearAll[$CorrectOptions];
 $CorrectOptions[HypergraphPlot][o___] := Module[
 		{plotStyle = OptionValue[HypergraphPlot, {o}, PlotStyle]},
 	Head[plotStyle] === ColorDataFunction &&
@@ -521,6 +520,114 @@ FromAnonymousRules[rule : _Rule] := Module[
 
 
 FromAnonymousRules[rules : {___Rule}] := FromAnonymousRules /@ rules
+
+
+(* ::Subsection:: *)
+(*$ToCanonicalRules*)
+
+
+(* ::Text:: *)
+(*There are multiple ways SetReplace rules can be expressed, which is mostly manifested by missing lists in various places. Specifically, we could have either a single rule, or a list of rules. Then, inputs / outputs of every rules might either have a single element or a subset. The idea of this function is to ensure two things: (1) we have a list (even if a single-element) of rules, and (2) each rule goes from a list to another list.*)
+
+
+ClearAll[$ToCanonicalRules];
+SetAttributes[$ToCanonicalRules, HoldAll];
+
+
+$ToCanonicalRules[r : (_Rule | _RuleDelayed)] := $ToCanonicalRules[{r}]
+
+
+$ToCanonicalRules[rules : {(_Rule | _RuleDelayed)..}] := $ToCanonicalRule /@ rules
+
+
+ClearAll[$ToCanonicalRule];
+SetAttributes[$ToCanonicalRule, HoldAll];
+
+
+$ToCanonicalRule[(left_ -> right_) | (left_ :> right_)] := With[
+		{newLeft = $ToCanonicalRuleSide[left], newRight = $ToCanonicalRuleSide[right]},
+	newLeft :> newRight
+] //. Hold[expr_] :> expr
+
+
+ClearAll[$ToCanonicalRuleSide];
+SetAttributes[$ToCanonicalRuleSide, HoldAll];
+
+
+$ToCanonicalRuleSide[expr_ : Except[_List | _Module]] := {expr}
+
+
+$ToCanonicalRuleSide[expr_List] := expr
+
+
+$ToCanonicalRuleSide[Module[args_, set_ ? (Not @* ListQ)]] := Hold @ Module[args, {set}]
+
+
+$ToCanonicalRuleSide[Module[args_, set_List]] := Hold @ Module[args, set]
+
+
+(* ::Subsection:: *)
+(*SetReplaceAll*)
+
+
+(* ::Text:: *)
+(*The idea for SetReplaceAll is to keep performing SetReplace on the graph until no replacement can be done without touching the same edge twice.*)
+
+
+(* ::Text:: *)
+(*Note, it's not doing replacement until all edges are touched at least once. That may not always be possible. We just don't want to touch edges twice in a single step.*)
+
+
+(* ::Subsubsection:: *)
+(*Documentation*)
+
+
+SetReplaceAll::usage = UsageString[
+	"SetReplaceAll[`s`, `r`] performs SetReplace[`s`, `r`] as many times as it takes ",
+	"until no replacement can be done without touching the same edge twice.",
+	"\n",
+	"SetReplaceAll[`s`, `r`, `n`] performes the same operation `n` times, i.e., any ",
+	"edge will at most be replaced `n` times."];
+
+
+(* ::Subsubsection:: *)
+(*Syntax*)
+
+
+SyntaxInformation[SetReplaceAll] = {"ArgumentsPattern" -> {_, _, _.}};
+
+
+SetReplaceAll[args___] := 0 /;
+	!Developer`CheckArgumentCount[SetReplaceAll[args], 2, 3] && False
+
+
+SetReplaceAll[set_, rules_, n_: 0] := 0 /; !ListQ[set] &&
+	Message[SetReplace::setNotList, SetReplaceAll]
+
+
+SetReplaceAll[set_, rules_, n_: 0] := 0 /;
+	!$SetReplaceRulesQ[rules] && Message[SetReplace::invalidRules, SetReplaceAll]
+
+
+SetReplaceAll[set_, rules_, n_] := 0 /; !$StepCountQ[n] &&
+	Message[SetReplace::nonIntegerIterations, SetReplaceAll, n]
+
+
+(* ::Subsubsection:: *)
+(*Implementation*)
+
+
+(* ::Text:: *)
+(*The idea here is to replace each element of the set, and each element of rules input with something like touched[original, False], and replace every element of the rules output with touched[original, True]. This way, rules can no longer be applied on the previous output. Then, we can call SetReplaceFixedPoint on that, which will take care of evaluating until everything is fixed.*)
+
+
+SetReplaceAll[set_List, rules_ ? $SetReplaceRulesQ, n_ ? $StepCountQ] := Module[
+		{canonicalRules},
+	canonicalRules = $ToCanonicalRules[rules]
+]
+
+
+SetReplaceAll[set_List, rules_ ? $SetReplaceRulesQ] := SetReplaceAll[set, rules, 1]
 
 
 (* ::Section:: *)

--- a/SetReplace.wlt
+++ b/SetReplace.wlt
@@ -327,4 +327,107 @@ VerificationTest[
 	{{2, 1, 2}}
 ]
 
+(* SetReplaceAll *)
+
+VerificationTest[
+	SetReplaceAll[],
+	SetReplaceAll[],
+	{SetReplaceAll::argt}
+]
+
+VerificationTest[
+	SetReplaceAll[1, 1 -> 2],
+	SetReplaceAll[1, 1 -> 2],
+	{SetReplace::setNotList}
+]
+
+VerificationTest[
+	SetReplaceAll[{1}, 1],
+	SetReplaceAll[{1}, 1],
+	{SetReplace::invalidRules}
+]
+
+VerificationTest[
+	SetReplaceAll[{1}, {1}],
+	SetReplaceAll[{1}, {1}],
+	{SetReplace::invalidRules}
+]
+
+VerificationTest[
+	SetReplaceAll[{1}, {1 -> 2}, -1],
+	SetReplaceAll[{1}, {1 -> 2}, -1],
+	{SetReplace::nonIntegerIterations}
+]
+
+VerificationTest[
+	SetReplaceAll[{1}, {1 -> 2}, 1.5],
+	SetReplaceAll[{1}, {1 -> 2}, 1.5],
+	{SetReplace::nonIntegerIterations}
+]
+
+VerificationTest[	
+	SetReplaceAll[{1, 2, 3}, n_ :> -n],
+	{-1, -2, -3}
+]
+
+VerificationTest[
+	SetReplaceAll[{1, 2, 3}, n_ :> -n, 2],
+	{1, 2, 3}
+]
+
+VerificationTest[
+	SetReplaceAll[{1, 2, 3}, {n_, m_} :> {-m, -n}],
+	{3, -2, -1}
+]
+
+VerificationTest[
+	SetReplaceAll[{1, 2, 3}, {n_, m_} :> {-m, -n}, 2],
+	{-1, 2, -3}
+]
+
+VerificationTest[
+	Most @ SetReplaceAll[
+			{1, 2, 3, 4}, {2 -> {3, 4}, {v1_, v2_} :> Module[{x}, {v1, v2, x}]}],
+	{4, 3, 4, 1, 3}
+]
+
+VerificationTest[
+	MatchQ[SetReplaceAll[
+			{1, 2, 3, 4},
+			{2 -> {3, 4}, {v1_, v2_} :> Module[{x}, {v1, v2, x}]},
+			2], {4, 3, _, 4, 1, _, 3, _, _}],
+	True
+]
+
+VerificationTest[
+	Length @ SetReplaceAll[
+		{{0, 1}, {0, 2}, {0, 3}}, 
+		FromAnonymousRules[
+			{{0, 1}, {0, 2}, {0, 3}} ->
+			{{4, 5}, {5, 4}, {4, 6}, {6, 4}, {5, 6}, {6, 5}, {4, 1}, {5, 2}, {6, 3}}],
+		4],
+	3^5
+]
+
+VerificationTest[
+	Length @ SetReplaceAll[
+		{{0, 0}, {0, 0}, {0, 0}}, 
+		FromAnonymousRules[
+			{{0, 1}, {0, 2}, {0, 3}} ->
+			{{4, 5}, {5, 4}, {4, 6}, {6, 4}, {5, 6}, {6, 5}, {4, 1}, {5, 2}, {6, 3}}],
+		4],
+	3^5
+]
+
+VerificationTest[
+	Length @ SetReplaceAll[
+		{{0, 1}, {0, 2}, {0, 3}}, 
+		FromAnonymousRules[
+			{{0, 1}, {0, 2}, {0, 3}} ->
+			{{4, 5}, {5, 4}, {4, 6}, {6, 4}, {5, 6}, {6, 5},
+			 {4, 1}, {5, 2}, {6, 3}, {1, 6}, {3, 4}}],
+		3],
+	107
+]
+
 EndTestSection[]


### PR DESCRIPTION
## Changes

* Closes https://github.com/maxitg/SetReplace/issues/9.
* Implements `SetReplaceAll`, which performs the replacement on all set elements at once.
* More specifically, `SetReplaceAll` does `SetReplace` repeatedly, until touching previous output is necessary to do another replacement.

* For example, `SetReplaceAll[{1, 2, 3}, n_ :> -n]` performs replacement 3 times.

## Tests

* Turn every graph point into a fully-connected triangle 5 times:
`HypergraphPlot[SetReplaceAll[{{0, 0}, {0, 0}, {0, 0}}, FromAnonymousRules[{{0, 1}, {0, 2}, {0, 3}} -> {{4, 5}, {5, 4}, {4, 6}, {6, 4}, {5, 6}, {6, 5}, {4, 1}, {5, 2}, {6, 3}}], 5]]`
![image](https://user-images.githubusercontent.com/1479325/50575385-6c5f4200-0db3-11e9-8cab-84e66ebdb470.png)

* Notebook with more examples:
[setReplaceAllExamples.nb.zip](https://github.com/maxitg/SetReplace/files/2719555/setReplaceAllExamples.nb.zip)

* Run tests:
`TestReport["path to SetReplace.wlt"]`