### PR TITLE
Build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,11 @@ xcuserdata/
 # macOS
 
 .DS_Store
+
+# Build directory
+
+Build/
+
+# Built paclets
+
+*.paclet

--- a/PacletInfo.m
+++ b/PacletInfo.m
@@ -1,0 +1,8 @@
+Paclet[
+	Name -> "SetReplace",
+	Version -> "0.1",
+	MathematicaVersion -> "12.0+",
+	Description -> "Implementation of a set substitution system, which in particular, has graph rewrites as a special case.",
+	Creator -> "Maksim Piskunov",
+	Extensions -> {{"Application", Context -> "SetReplace`"}}
+]

--- a/SetReplace.wl
+++ b/SetReplace.wl
@@ -12,7 +12,7 @@
 (*See on GitHub: https://github.com/maxitg/SetReplace.*)
 
 
-BeginPackage["SetReplace`"];
+BeginPackage["SetReplace`", {"UsageString`"}];
 
 
 SetReplace`Private`$PublicSymbols = {
@@ -22,17 +22,6 @@ SetReplace`Private`$PublicSymbols = {
 
 Unprotect @@ SetReplace`Private`$PublicSymbols;
 ClearAll @@ SetReplace`Private`$PublicSymbols;
-
-
-(* ::Section:: *)
-(*Dependencies*)
-
-
-(* ::Subsection:: *)
-(*UsageString*)
-
-
-Get["https://raw.githubusercontent.com/maxitg/WLUsageString/master/UsageString.wl"]
 
 
 (* ::Section:: *)

--- a/build.wls
+++ b/build.wls
@@ -1,0 +1,25 @@
+#!/usr/bin/env wolframscript
+(* ::Package:: *)
+
+(* ::Text:: *)
+(*Create build directory*)
+
+
+buildDirectory = FileNameJoin[{".", "Build"}];
+If[FileExistsQ[buildDirectory], DeleteDirectory[buildDirectory, DeleteContents -> True]];
+CreateDirectory[buildDirectory];
+
+
+(* ::Text:: *)
+(*Copy packages files inside*)
+
+
+files = {"SetReplace.wl", "PacletInfo.m"};
+CopyFile[FileNameJoin[{".", #}], FileNameJoin[{buildDirectory, #}]] & /@ files;
+
+
+(* ::Text:: *)
+(*Pack paclet*)
+
+
+PacletManager`PackPaclet[buildDirectory];


### PR DESCRIPTION
## Changes

* Adds a build script that packs a paclet file.

## Tests

* WolframScript is a required to run the build script.
* `WLUsageString` is a prerequisite, install it from [releases page](https://github.com/maxitg/UsageString/releases).
* Run `wolframscript build.wls` from terminal. This will create `SetReplace-0.1.paclet` file in the same directory as `build.wls` is located.
* Open Mathematica and evaluate ```PacletManager`PacletInstall["path_to_paclet"]```, where `path_to_paclet` is the path to the newly created `SetReplace-0.1.paclet`.
* Evaluate ```PacletManager`PacletInformation["SetReplace"]```, and make sure the output is not an empty list.
* Import the package with ```<<SetReplace` ```
* Try evaluating, for example, `HypergraphPlot @ SetReplace[{{0, 0}}, FromAnonymousRules[{{{1, 2}} -> {{1, 3}, {3, 2}}}], 10]` to check if the paclet is installed correctly.