### PR TITLE
Fix C++ matching of rules with radius over 2

### DIFF
--- a/SetReplace.wlt
+++ b/SetReplace.wlt
@@ -247,6 +247,217 @@ VerificationTest[
 	MemoryConstraint -> 5*^6
 ]
 
+(* SetReplace: matching cases *)
+graphsForMatching = {
+	{{1, 2}, {2, 3}, {3, 4}, {4, 5}},
+	{{1, 2}, {2, 3}, {3, 4}, {4, 1}},
+	{{1, 2}, {2, 3}, {3, 4}, {1, 5}},
+	{{2, 3}, {3, 1}, {4, 2}, {4, 5}},
+	{{1, 5}, {2, 1}, {2, 3}, {2, 4}, {2, 5}, {3, 1}, {4, 2}, {4, 5}}
+};
+methods = {"C++", "WolframLanguage"};
+
+Table[VerificationTest[
+	SetReplace[
+		graph,
+		FromAnonymousRules[graph -> {}],
+		1,
+		Method -> method],
+	{}
+], {graph, graphsForMatching}, {method, methods}]
+
+VerificationTest[
+	SetReplace[
+		{{1, 2}, {2, 3, 4}},
+		FromAnonymousRules[{{2, 3, 4}, {1, 2}} -> {}],
+		1,
+		Method -> #],
+	{}
+] & /@ methods
+
+VerificationTest[
+	SetReplace[
+		{{1, 2}, {2, 2, 3}},
+		FromAnonymousRules[{{2, 3, 4}, {1, 2}} -> {}],
+		1,
+		Method -> #],
+	{}
+] & /@ methods
+
+VerificationTest[
+	SetReplace[
+		{{1, 2}, {2, 1, 3}},
+		FromAnonymousRules[{{2, 3, 4}, {1, 2}} -> {}],
+		1,
+		Method -> #],
+	{}
+] & /@ methods
+
+VerificationTest[
+	SetReplace[
+		{{1, 2}, {1, 1, 3}},
+		FromAnonymousRules[{{2, 3, 4}, {1, 2}} -> {}],
+		1,
+		Method -> #],
+	{{1, 2}, {1, 1, 3}}
+] & /@ methods
+
+VerificationTest[
+	SetReplace[
+		{{1, 2}, {2, 1}},
+		FromAnonymousRules[{{1, 2}, {2, 3}} -> {{1, 3}}],
+		1,
+		Method -> #],
+	{{1, 1}}
+] & /@ methods
+
+(* SetReplace: random tests *)
+graphFromHyperedges[edges_] := Graph[
+	UndirectedEdge @@@ Flatten[Partition[#, 2, 1] & /@ edges, 1]];
+
+randomConnectedGraphs[edgeCount_, edgeLength_, graphCount_] := (
+	Select[ConnectedGraphQ @* graphFromHyperedges]
+		@ Table[
+			With[{k = edgeCount}, Table[RandomInteger[edgeLength k], k, edgeLength]],
+			graphCount]
+)
+
+DistributeDefinitions["SetReplace`"];
+
+(* Here we generate random graphs and try replacing them to nothing *)
+randomSameGraphMatchTest[edgeCount_, edgeLength_, graphCount_, method_] := BlockRandom[Module[{
+		tests},
+	tests = randomConnectedGraphs[edgeCount, edgeLength, graphCount];
+	Union[
+		ParallelMap[
+				SetReplace[#, FromAnonymousRules[RandomSample[#] -> {}], Method -> method] &,
+				tests]]
+			=== {{}}
+]]
+
+VerificationTest[
+	randomSameGraphMatchTest[10, 2, 10000, "C++"],
+	True
+]
+
+VerificationTest[
+	randomSameGraphMatchTest[10, 3, 5000, "C++"],
+	True
+]
+
+VerificationTest[
+	randomSameGraphMatchTest[10, 6, 1000, "C++"],
+	True
+]
+
+VerificationTest[
+	randomSameGraphMatchTest[6, 2, 5000, "WolframLanguage"],
+	True
+]
+
+VerificationTest[
+	randomSameGraphMatchTest[6, 3, 500, "WolframLanguage"],
+	True
+]
+
+VerificationTest[
+	randomSameGraphMatchTest[6, 10, 100, "WolframLanguage"],
+	True
+]
+
+(* Here we generate pairs of different graphs, and check they are not being matched *)
+randomDistinctGraphMatchTest[
+			edgeCount_, edgeLength_, graphCount_, method_] := BlockRandom[Module[{
+		tests},
+	tests = Select[!IsomorphicGraphQ @@ (graphFromHyperedges /@ #) &]
+		@ Partition[
+			Select[SimpleGraphQ @* graphFromHyperedges]
+				@ randomConnectedGraphs[edgeCount, edgeLength, graphCount],
+			2];
+	Not[Or @@ ParallelMap[
+		(* degenerate graphs can still match if not isomorphic, i.e., {{0, 0}} will match {{0, 1}},
+			 that's why we need to try replacing both ways *)
+		SetReplace[#[[1]], FromAnonymousRules[#[[2]] -> {}], Method -> method] == {}
+			&& SetReplace[#[[2]], FromAnonymousRules[#[[1]] -> {}], Method -> method] == {} &,
+		tests]]
+]]
+
+VerificationTest[
+	randomDistinctGraphMatchTest[10, 2, 10000, "C++"],
+	True
+]
+
+VerificationTest[
+	randomDistinctGraphMatchTest[10, 3, 10000, "C++"],
+	True
+]
+
+VerificationTest[
+	randomDistinctGraphMatchTest[10, 6, 10000, "C++"],
+	True
+]
+
+VerificationTest[
+	randomDistinctGraphMatchTest[6, 2, 5000, "WolframLanguage"],
+	True
+]
+
+VerificationTest[
+	randomDistinctGraphMatchTest[6, 3, 5000, "WolframLanguage"],
+	True
+]
+
+VerificationTest[
+	randomDistinctGraphMatchTest[6, 6, 5000, "WolframLanguage"],
+	True
+]
+
+(* Here we make initial condition degenerate, and check it still matches, i.e.,
+	 {{0, 0}} should still match {{0, 1}} *)
+randomDegenerateGraphMatchTest[
+			edgeCount_, edgeLength_, graphCount_, method_] := BlockRandom[Module[{
+		tests},
+	tests = randomConnectedGraphs[edgeCount, edgeLength, graphCount];
+Union[
+	ParallelMap[
+			SetReplace[
+				# /. RandomChoice[Flatten[#]] -> RandomChoice[Flatten[#]],
+				FromAnonymousRules[RandomSample[#] -> {}],
+				Method -> method] &,
+			tests]]
+		=== {{}}
+]]
+
+VerificationTest[
+	randomDegenerateGraphMatchTest[10, 2, 10000, "C++"],
+	True
+]
+
+VerificationTest[
+	randomDegenerateGraphMatchTest[10, 3, 5000, "C++"],
+	True
+]
+
+VerificationTest[
+	randomDegenerateGraphMatchTest[10, 6, 1000, "C++"],
+	True
+]
+
+VerificationTest[
+	randomDegenerateGraphMatchTest[6, 2, 5000, "WolframLanguage"],
+	True
+]
+
+VerificationTest[
+	randomDegenerateGraphMatchTest[6, 3, 500, "WolframLanguage"],
+	True
+]
+
+VerificationTest[
+	randomDegenerateGraphMatchTest[6, 10, 100, "WolframLanguage"],
+	True
+]
+
 (* SetReplaceList *)
 
 VerificationTest[

--- a/SetReplace/SetReplace/Set.cpp
+++ b/SetReplace/SetReplace/Set.cpp
@@ -298,13 +298,16 @@ namespace SetReplace {
                 if (currentMatch.expressionIDs[i] != -1) continue;
                 
                 std::unordered_set<AtomID> requiredAtoms;
+                bool allAnonymous = true;
                 for (const auto atom : inputs[i]) {
                     if (atom >= 0) {
                         requiredAtoms.insert(atom);
+                        allAnonymous = false;
                     } else if (atom < 0) {
                         anonymousAtomsPresent = true;
                     }
                 }
+                if (allAnonymous) continue;
                 
                 std::unordered_map<ExpressionID, int> requiredAtomsCounts;
                 for (const auto atom : requiredAtoms) {


### PR DESCRIPTION
## Changes

* Resolves #28.
* Implements numerous unit tests, including 3 suits of random tests for matching isomorphic, distinct and degenerate graphs.

## Explanation

The bug was in the heuristic that decided which rule input try to match next. Specifically, if the input radius was larger than 2, the heuristic would always choose an expression for which no atoms are matched yet, and would that abort the matching attempt because there are now no candidate atoms for matching.

## Tests

* Verify the bug from #28 is fixed, the following now yields `{}`:
```
SetReplace[{{1, 5}, {2, 1}, {2, 3}, {2, 4}, {2, 5}, {3, 1}, {4, 
   2}, {4, 5}}, 
 FromAnonymousRules[{{1, 5}, {2, 1}, {2, 3}, {2, 4}, {2, 5}, {3, 
     1}, {4, 2}, {4, 5}} -> {}], 1, Method -> "C++"]
```
* Run unit tests, this now uses parallel kernels, and takes awhile, because there are a lot of tests:
```
<< SetReplace`
TestReport["path_to_SetReplace.wlt"]
```