### PR TITLE
Install script

### DIFF
--- a/install.wls
+++ b/install.wls
@@ -1,7 +1,7 @@
 #!/usr/bin/env wolframscript
 (* ::Package:: *)
 
-pacletInfo = (Association @@ Import["PacletInfo.m"]);
+pacletInfo = Association @@ Import["PacletInfo.m"];
 
 
 filename = pacletInfo[Name] <> "-" <> pacletInfo[Version] <> ".paclet";

--- a/install.wls
+++ b/install.wls
@@ -1,0 +1,22 @@
+#!/usr/bin/env wolframscript
+(* ::Package:: *)
+
+pacletInfo = (Association @@ Import["PacletInfo.m"]);
+
+
+filename = pacletInfo[Name] <> "-" <> pacletInfo[Version] <> ".paclet";
+
+
+If[!FileExistsQ[filename],
+	Print[
+		"The paclet file ", filename, " was not found. ",
+		"Run ./build.wls."];
+	Quit[];
+]
+
+
+If[PacletInformation["SetReplace"] != {}, PacletUninstall["SetReplace"]];
+
+
+If[Head[PacletInstall[filename]] == Paclet,
+	Print["Done. Restart running kernels to complete installation."]];


### PR DESCRIPTION
## Changes

* Implements script that installs the built paclet.
* Only macOS is supported at the moment.

## Tests

* In Terminal, `cd` to the root repository directory.
* Run `./build.wls` to build the paclet.
* Run `./install.wls` to install the paclet.
* Restart Wolfram Kernel in Mathematica.
* Evaluate ``<<SetReplace` `` to import the package.
* Evaluate `SetReplace[{{0}}, {{x_}} :> {{x}}, Method -> "C++"]`.
* If the paclet is installed correctly, `{{0}}` will be returned and no messages will be produced.