### PR TITLE
Fix HypergraphPlot for large graphs

### DIFF
--- a/SetReplace.wl
+++ b/SetReplace.wl
@@ -680,7 +680,7 @@ HypergraphPlot[edges : {___List}, o : OptionsPattern[]] /;
 	graphEdges = DirectedEdge @@@ Flatten[normalEdges, 1];
 	graphOptions = FilterRules[{o}, Options[Graph]];
 	shapeHashes = Sort @ (If[# == {}, {}, #[[1]]] &) @ Last @ Reap @ Rasterize @
-		Graph[graphEdges, Join[{
+		GraphPlot[graphEdges, Join[{
 			EdgeShapeFunction -> (Sow[#2 -> Hash[#1]] &)},
 			graphOptions]];
 	graphBoxes = ToBoxes[Graph[graphEdges, DirectedEdges -> True]];
@@ -690,7 +690,7 @@ HypergraphPlot[edges : {___List}, o : OptionsPattern[]] /;
 		Cases[graphBoxes, ArrowBox[x_, offset_] :> offset, All];
 	hashesToColors =
 		Association @ Thread[shapeHashes[[All, 2]] -> edgeColors[[All, 2]]];
-	Graph[graphEdges, Join[
+	GraphPlot[graphEdges, Join[
 		graphOptions,
 		{EdgeShapeFunction -> ({
 			arrowheads,

--- a/SetReplace.wlt
+++ b/SetReplace.wlt
@@ -587,14 +587,26 @@ VerificationTest[
 ]
 
 VerificationTest[
-	GraphQ[HypergraphPlot[{{1, 3}, {2, 4}}]]
+	Head[HypergraphPlot[{{1, 3}, {2, 4}}]],
+	Graphics
 ]
 
 VerificationTest[
-	GraphQ[HypergraphPlot[{{1, 3}, 6, {2, 4}}]],
-	False,
+	HypergraphPlot[{{1, 3}, 6, {2, 4}}],
+	HypergraphPlot[{{1, 3}, 6, {2, 4}}],
 	{HypergraphPlot::invalidEdges}
 ]
+
+VerificationTest[
+	Head @ HypergraphPlot @ SetReplace[
+		{{0, 1}, {0, 2}, {0, 3}},
+		FromAnonymousRules[
+			{{0, 1}, {0, 2}, {0, 3}} ->
+			{{4, 5}, {5, 4}, {4, 6}, {6, 4},
+				{5, 6}, {6, 5}, {4, 1}, {5, 2}, {6, 3}}],
+		#],
+	Graphics
+] & /@ {10, 5000}
 
 (* FromAnonymousRules *)
 


### PR DESCRIPTION
## Changes

* Resolves #24.
* Fix a bug that would cause `HypergraphPlot` to fail for large graphs.
* This was happening due to a change in Wolfram Language v12, in which large graphs are no longer plotted by default, and `GraphPlot` must be explicitly called to plot them.
* Add unit tests for large graphs.

## Tests

* Check example from the issue now works:
```
In[.] := HypergraphPlot[
 SetReplace[{{1}}, FromAnonymousRules[{{1}} -> {{2}, {2}, {1, 2}}], 
  10000]]
```
![image](https://user-images.githubusercontent.com/1479325/59816428-ada3c980-92e1-11e9-8e97-622a7c21b429.png)

* Run unit tests:
```
In[.] := TestReport["path_to_SetReplace.wlt"]
```
![image](https://user-images.githubusercontent.com/1479325/59816457-c7dda780-92e1-11e9-9e2a-629de0d2c6e8.png)