### PR TITLE
HypergraphPlot lone vertices

### DIFF
--- a/SetReplace.wl
+++ b/SetReplace.wl
@@ -690,9 +690,11 @@ HypergraphPlot[edges : {___List}, o : OptionsPattern[]] := 0 /;
 HypergraphPlot[edges : {___List}, o : OptionsPattern[]] /;
 	$CorrectOptions[HypergraphPlot][o] := Module[
 		{normalEdges, vertices, edgeColors, shapeHashes, hashesToColors,
-		 graphEdges, graphOptions, graphBoxes, arrowheads, arrowheadOffset},
+		 graphEdges, graphOptions, graphBoxes, arrowheads, arrowheadOffset,
+		 vertexColors},
 	normalEdges = Partition[#, 2, 1] & /@ edges;
 	vertices = Union @ Flatten @ edges;
+	vertexColors = (# -> ColorData[97, Count[edges, {#}] + 1] & /@ vertices);
 	edgeColors = Sort @ Flatten @ MapIndexed[
 		Thread[DirectedEdge @@@ #1 -> OptionValue[PlotStyle][#2[[1]]]] &, normalEdges];
 	graphEdges = DirectedEdge @@@ Flatten[normalEdges, 1];
@@ -713,7 +715,8 @@ HypergraphPlot[edges : {___List}, o : OptionsPattern[]] /;
 		{EdgeShapeFunction -> ({
 			arrowheads,
 			hashesToColors[Hash[#1]],
-			Arrow[#1, arrowheadOffset]} &)}]]
+			Arrow[#1, arrowheadOffset]} &),
+		 VertexStyle -> vertexColors}]]
 ]
 
 

--- a/SetReplace.wl
+++ b/SetReplace.wl
@@ -700,9 +700,9 @@ HypergraphPlot[edges : {___List}, o : OptionsPattern[]] /;
 	graphEdges = DirectedEdge @@@ Flatten[normalEdges, 1];
 	graphOptions = FilterRules[{o}, Options[Graph]];
 	shapeHashes = Sort @ (If[# == {}, {}, #[[1]]] &) @ Last @ Reap @ Rasterize @
-		GraphPlot[vertices, graphEdges, Join[{
+		GraphPlot[Graph[vertices, graphEdges, Join[{
 			EdgeShapeFunction -> (Sow[#2 -> Hash[#1]] &)},
-			graphOptions]];
+			graphOptions]]];
 	graphBoxes = ToBoxes[Graph[graphEdges, DirectedEdges -> True]];
 	arrowheads =
 		If[Length[#] == 0, {}, #[[1]]] & @ Cases[graphBoxes, _Arrowheads, All];
@@ -710,13 +710,13 @@ HypergraphPlot[edges : {___List}, o : OptionsPattern[]] /;
 		Cases[graphBoxes, ArrowBox[x_, offset_] :> offset, All];
 	hashesToColors =
 		Association @ Thread[shapeHashes[[All, 2]] -> edgeColors[[All, 2]]];
-	GraphPlot[vertices, graphEdges, Join[
+	GraphPlot[Graph[vertices, graphEdges, Join[
 		graphOptions,
 		{EdgeShapeFunction -> ({
 			arrowheads,
 			hashesToColors[Hash[#1]],
 			Arrow[#1, arrowheadOffset]} &),
-		 VertexStyle -> vertexColors}]]
+		 VertexStyle -> vertexColors}]]]
 ]
 
 

--- a/SetReplace.wl
+++ b/SetReplace.wl
@@ -713,8 +713,7 @@ HypergraphPlot[edges : {___List}, o : OptionsPattern[]] /;
 		{EdgeShapeFunction -> ({
 			arrowheads,
 			hashesToColors[Hash[#1]],
-			Arrow[#1, arrowheadOffset]} &),
-		 If[arrowheadOffset > 0, Nothing, VertexShapeFunction -> Point]}]]
+			Arrow[#1, arrowheadOffset]} &)}]]
 ]
 
 

--- a/SetReplace.wl
+++ b/SetReplace.wl
@@ -689,15 +689,16 @@ HypergraphPlot[edges : {___List}, o : OptionsPattern[]] := 0 /;
 
 HypergraphPlot[edges : {___List}, o : OptionsPattern[]] /;
 	$CorrectOptions[HypergraphPlot][o] := Module[
-		{normalEdges, edgeColors, shapeHashes, hashesToColors,
+		{normalEdges, vertices, edgeColors, shapeHashes, hashesToColors,
 		 graphEdges, graphOptions, graphBoxes, arrowheads, arrowheadOffset},
 	normalEdges = Partition[#, 2, 1] & /@ edges;
+	vertices = Union @ Flatten @ edges;
 	edgeColors = Sort @ Flatten @ MapIndexed[
 		Thread[DirectedEdge @@@ #1 -> OptionValue[PlotStyle][#2[[1]]]] &, normalEdges];
 	graphEdges = DirectedEdge @@@ Flatten[normalEdges, 1];
 	graphOptions = FilterRules[{o}, Options[Graph]];
 	shapeHashes = Sort @ (If[# == {}, {}, #[[1]]] &) @ Last @ Reap @ Rasterize @
-		GraphPlot[graphEdges, Join[{
+		GraphPlot[vertices, graphEdges, Join[{
 			EdgeShapeFunction -> (Sow[#2 -> Hash[#1]] &)},
 			graphOptions]];
 	graphBoxes = ToBoxes[Graph[graphEdges, DirectedEdges -> True]];
@@ -707,7 +708,7 @@ HypergraphPlot[edges : {___List}, o : OptionsPattern[]] /;
 		Cases[graphBoxes, ArrowBox[x_, offset_] :> offset, All];
 	hashesToColors =
 		Association @ Thread[shapeHashes[[All, 2]] -> edgeColors[[All, 2]]];
-	GraphPlot[graphEdges, Join[
+	GraphPlot[vertices, graphEdges, Join[
 		graphOptions,
 		{EdgeShapeFunction -> ({
 			arrowheads,

--- a/SetReplace.wlt
+++ b/SetReplace.wlt
@@ -608,6 +608,20 @@ VerificationTest[
 	Graphics
 ] & /@ {10, 5000}
 
+(* HypergraphPlot: Vertices with single-vertex edges colored differently *)
+
+VerificationTest[
+	FreeQ[HypergraphPlot[{{1, 2}}], ColorData[97, #]] & /@ {1, 2, 3},
+	{False, True, True}]
+
+VerificationTest[
+	FreeQ[HypergraphPlot[{{1}}], ColorData[97, #]] & /@ {1, 2, 3},
+	{True, False, True}]
+
+VerificationTest[
+	FreeQ[HypergraphPlot[{{1}, {1}}], ColorData[97, #]] & /@ {1, 2, 3},
+	{True, True, False}]
+
 (* FromAnonymousRules *)
 
 VerificationTest[


### PR DESCRIPTION
## Changes

* Resolves #16.
* `HypergraphPlot` now plots lone vertices as well as edges. Lone vertices may appear if single-vertex edges are present in a graph, i.e., `{{0}}`.
* Vertices that have single-vertex edges are colored differently, note drawing loops would not work because that would be ambiguous with, say, `{{0, 0}}`.
* Add unit tests for these colors.

## Tests

* Check example from the issue is now evaluated correctly:
```
In[.] := HypergraphPlot[{{0}}]
```
![image](https://user-images.githubusercontent.com/1479325/59818652-5b1adb00-92ea-11e9-9f3d-622e6b2d7268.png)

* Compare vertices with different numbers of single-vertex edges:
```
In[.] := HypergraphPlot[{{0, 1, 2, 3}, {1}, {2}, {2}, {3}, {3}, {3}}]
```
![image](https://user-images.githubusercontent.com/1479325/59818685-81d91180-92ea-11e9-898a-73d6e0d8e23e.png)

* Run unit tests:
```
In[.] := TestReport["path_to_SetReplace.wlt"]
```
![image](https://user-images.githubusercontent.com/1479325/59872784-221d4d80-9360-11e9-9d48-22c4419856c3.png)