### PR TITLE
Abort C++ evaluation

### DIFF
--- a/SetReplace.wlt
+++ b/SetReplace.wlt
@@ -247,6 +247,15 @@ VerificationTest[
 	MemoryConstraint -> 5*^6
 ]
 
+(* SetReplace: C++ aborting *)
+(* assumes example below runs slow, may need to be replaced in the future *)
+VerificationTest[
+	1.0 < Timing[TimeConstrained[SetReplace[
+			{{0}},
+  		FromAnonymousRules[{{{0}} -> {{0}, {0}, {0}}, {{0}, {0}, {0}} -> {{0}}}],
+  		30], 1]][[1]] < 1.5
+]
+
 (* SetReplace: matching cases *)
 graphsForMatching = {
 	{{1, 2}, {2, 3}, {3, 4}, {4, 5}},

--- a/SetReplace/SetReplace/Set.cpp
+++ b/SetReplace/SetReplace/Set.cpp
@@ -27,8 +27,12 @@ namespace SetReplace {
         };
         std::unordered_map<ExpressionID, std::unordered_set<std::set<Match>::const_iterator, IteratorHash>> matchesIndex_;
         
+        const std::function<bool()>& shouldAbort_;
+
     public:
-        Implementation(const std::vector<Rule>& rules, const std::vector<Expression>& initialExpressions) : rules_(rules) {
+        Implementation(const std::vector<Rule>& rules,
+                       const std::vector<Expression>& initialExpressions,
+                       const std::function<bool()>& shouldAbort) : rules_(rules), shouldAbort_(shouldAbort) {
             for (const auto& expression : initialExpressions) {
                 for (const auto& atom : expression) {
                     nextAtomID = std::max(nextAtomID - 1, atom) + 1;
@@ -282,6 +286,9 @@ namespace SetReplace {
         }
         
         void addMatches(const Match& currentMatch, const std::vector<Expression>& inputs) {
+            if (shouldAbort_()) {
+                throw Error::Aborted;
+            }
             if (matchComplete(currentMatch)) {
                 const auto iterator = matches_.insert(currentMatch).first;
                 for (const auto& expressionID : currentMatch.expressionIDs) {
@@ -346,8 +353,8 @@ namespace SetReplace {
         }
     };
     
-    Set::Set(const std::vector<Rule>& rules, const std::vector<Expression>& initialExpressions) {
-        implementation_ = std::make_shared<Implementation>(rules, initialExpressions);
+    Set::Set(const std::vector<Rule>& rules, const std::vector<Expression>& initialExpressions, const std::function<bool()>& shouldAbort) {
+        implementation_ = std::make_shared<Implementation>(rules, initialExpressions, shouldAbort);
     }
     
     int Set::replace() {

--- a/SetReplace/SetReplace/Set.hpp
+++ b/SetReplace/SetReplace/Set.hpp
@@ -10,7 +10,9 @@
 namespace SetReplace {
     class Set {
     public:
-        Set(const std::vector<Rule>& rules, const std::vector<Expression>& initialExpressions);
+        enum Error {Aborted};
+
+        Set(const std::vector<Rule>& rules, const std::vector<Expression>& initialExpressions, const std::function<bool()>& shouldAbort);
         
         int replace();
         int replace(const int stepCount);

--- a/SetReplace/SetReplace/SetReplace.cpp
+++ b/SetReplace/SetReplace/SetReplace.cpp
@@ -116,11 +116,17 @@ namespace SetReplace {
             return LIBRARY_FUNCTION_ERROR;
         }
         
-        Set set(rules, initialExpressions);
-        set.replace(steps);
-        const auto expressions = set.expressions();
-        
-        MArgument_setMTensor(result, putSet(expressions, libData));
+        const auto shouldAbort = [&libData]() {
+            return static_cast<bool>(libData->AbortQ());
+        };
+        try {
+            Set set(rules, initialExpressions, shouldAbort);
+            set.replace(steps);
+            const auto expressions = set.expressions();
+            MArgument_setMTensor(result, putSet(expressions, libData));
+        } catch (...) {
+            return LIBRARY_FUNCTION_ERROR;
+        }
         
         return LIBRARY_NO_ERROR;
     }


### PR DESCRIPTION
## Changes

* Closes #23.
* Allows aborting evaluation of C++ code.
* Abort check is inserted inside the low-level matching code, so it should happen fast in every case.
* Add a unit test.

## Tests

* The following should finish with `$Aborted` in about 1 second (otherwise it would take 3):
```
In[.] := TimeConstrained[
 SetReplace[{{0}}, 
  FromAnonymousRules[{{{0}} -> {{0}, {0}, {0}}, {{0}, {0}, {0}} -> \
{{0}}}], 30], 1]
```
```
Out[.] = $Aborted
```
* Try aborting the following interactively:
```
In[.] := SetReplace[{{0}}, 
 FromAnonymousRules[{{{0}} -> {{0}, {0}, {0}}, {{0}, {0}, {0}} -> \
{{0}}}], 30]
```
```
Out[.] = $Aborted
```
* Run unit tests
```
In[.] := TestReport["path_to_SetReplace.wlt"]
```
![image](https://user-images.githubusercontent.com/1479325/59866020-2477ab80-9350-11e9-96b9-85928cf7ed32.png)