### PR TITLE
Add functional include to fix compilation on Linux.

### DIFF
--- a/SetReplace/SetReplace/Set.hpp
+++ b/SetReplace/SetReplace/Set.hpp
@@ -1,6 +1,7 @@
 #ifndef Set_hpp
 #define Set_hpp
 
+#include <functional>
 #include <memory>
 #include <vector>
 


### PR DESCRIPTION
## Changes

* Adds explicit `#include <functional>` to fix compilation error on Linux.

## Tests

* Run `./build.wls` on Linux, and see compilation is successful.