### PR TITLE
Fix Windows runtime exception

### DIFF
--- a/SetReplace/SetReplace/Set.cpp
+++ b/SetReplace/SetReplace/Set.cpp
@@ -28,12 +28,12 @@ namespace SetReplace {
         };
         std::unordered_map<ExpressionID, std::unordered_set<std::set<Match>::const_iterator, IteratorHash>> matchesIndex_;
         
-        const std::function<bool()>& shouldAbort_;
+        const std::function<bool()> shouldAbort_;
 
     public:
         Implementation(const std::vector<Rule>& rules,
                        const std::vector<Expression>& initialExpressions,
-                       const std::function<bool()>& shouldAbort) : rules_(rules), shouldAbort_(shouldAbort) {
+                       const std::function<bool()> shouldAbort) : rules_(rules), shouldAbort_(shouldAbort) {
             for (const auto& expression : initialExpressions) {
                 for (const auto& atom : expression) {
                     nextAtomID = std::max(nextAtomID - 1, atom) + 1;
@@ -354,7 +354,7 @@ namespace SetReplace {
         }
     };
     
-    Set::Set(const std::vector<Rule>& rules, const std::vector<Expression>& initialExpressions, const std::function<bool()>& shouldAbort) {
+    Set::Set(const std::vector<Rule>& rules, const std::vector<Expression>& initialExpressions, const std::function<bool()> shouldAbort) {
         implementation_ = std::make_shared<Implementation>(rules, initialExpressions, shouldAbort);
     }
     

--- a/SetReplace/SetReplace/Set.hpp
+++ b/SetReplace/SetReplace/Set.hpp
@@ -13,7 +13,7 @@ namespace SetReplace {
     public:
         enum Error {Aborted};
 
-        Set(const std::vector<Rule>& rules, const std::vector<Expression>& initialExpressions, const std::function<bool()>& shouldAbort);
+        Set(const std::vector<Rule>& rules, const std::vector<Expression>& initialExpressions, const std::function<bool()> shouldAbort);
         
         int replace();
         int replace(const int stepCount);


### PR DESCRIPTION
## Changes

* Fixes an exception on Windows, which was caused by passing a lambda function that checks for abort in progress by reference.

## Tests

* On Windows, run,
```
SetReplace[{{0}}, FromAnonymousRules[{{0}} -> {{1}}], Method -> "C++"]
```
* Before, C++ code failed with `LibraryFunctionError`, but now, it should evaluate correctly.