### PR TITLE
Fix min time in Abort test

### DIFF
--- a/SetReplace.wlt
+++ b/SetReplace.wlt
@@ -250,10 +250,10 @@ VerificationTest[
 (* SetReplace: C++ aborting *)
 (* assumes example below runs slow, may need to be replaced in the future *)
 VerificationTest[
-	1.0 < Timing[TimeConstrained[SetReplace[
+	0.8 < Timing[TimeConstrained[SetReplace[
 			{{0}},
   		FromAnonymousRules[{{{0}} -> {{0}, {0}, {0}}, {{0}, {0}, {0}} -> {{0}}}],
-  		30], 1]][[1]] < 1.5
+  		30], 1]][[1]] < 1.2
 ]
 
 (* SetReplace: matching cases *)


### PR DESCRIPTION
## Changes

It turns out it is possible for a `TimeConstrained[...]` evaluation to finish earlier than the specified time, at least this happens on Windows.

So, to avoid a failing test because of this, the min time constraint is changed to be below 1 second.

## Tests

* Evaluate unit tests (especially on Windows):
```
In[.] := TestReport["path_to_SetReplace.wlt"]
```
* Check all tests pass.
* Check if `CPUTimeUsed` in test 49 is smaller than 1 second.