### PR TITLE
SetCases

### DIFF
--- a/SetReplace.wlt
+++ b/SetReplace.wlt
@@ -875,4 +875,66 @@ VerificationTest[
 	{}
 ]
 
+(* SetCases: Argument Checking *)
+
+VerificationTest[
+	SetCases[],
+	SetCases[],
+	{SetCases::argrx}
+]
+
+VerificationTest[
+	SetCases[1, {{1}}],
+	SetCases[1, {{1}}],
+	{SetReplace::setNotList}
+]
+
+VerificationTest[
+	SetCases[{{1}}, 1],
+	SetCases[{{1}}, 1],
+	{SetReplace::cppNotImplemented}
+]
+
+VerificationTest[
+	SetCases[{{1}}, {{1}, {2}}],
+	SetCases[{{1}}, {{1}, {2}}],
+	{SetReplace::cppNotImplemented}
+]
+
+VerificationTest[
+	SetCases[{{1}}, {1, {2}}],
+	SetCases[{{1}}, {1, {2}}],
+	{SetReplace::cppNotImplemented}
+]
+
+VerificationTest[
+	SetCases[{{1}}, {}],
+	SetCases[{{1}}, {}],
+	{SetReplace::cppNotImplemented}
+]
+
+(* SetCases: Performance *)
+
+VerificationTest[
+	SetCases[SetReplace[
+		{{0, 0}, {0, 0}, {0, 0}},
+		{{{a_, b_}, {a_, c_}, {a_, d_}} :>
+			Module[{$0, $1, $2}, {
+				{$0, $1}, {$1, $2}, {$2, $0}, {$0, $2}, {$2, $1}, {$1, $0},
+				{$0, b}, {$1, c}, {$2, d}, {b, $2}, {d, $0}}]},
+		100], {{a_, b_}, {a_, c_}, {a_, d_}}],
+	{0},
+	SameTest -> (ListQ[#1] && ListQ[#2] &),
+	TimeConstraint -> 5,
+	MemoryConstraint -> 5*^6
+]
+
+(* SetCases: Aborting *)
+
+VerificationTest[
+	0.8 < Timing[TimeConstrained[SetCases[
+			Table[{0}, 60],
+			{{0}, {0}, {0}}], 1]][[1]] < 1.2
+]
+
 EndTestSection[]

--- a/SetReplace.wlt
+++ b/SetReplace.wlt
@@ -823,4 +823,56 @@ VerificationTest[
 	107
 ]
 
+(* SetCases: Simple Cases *)
+
+VerificationTest[
+	SetCases[{}, {{x_}}],
+	{}
+]
+
+VerificationTest[
+	SetCases[{{1}}, {{1}}],
+	{{{1}}}
+]
+
+VerificationTest[
+	SetCases[{{0}}, {{x_}}],
+	{{{0}}}
+]
+
+VerificationTest[
+	SetCases[{{0}, {0}}, {{x_}}],
+	{{{0}}}
+]
+
+VerificationTest[
+	SetCases[{{0}, {1}}, {{x_}}],
+	{{{0}}, {{1}}}
+]
+
+VerificationTest[
+	SetCases[{{0, 1}, {0, 2}}, {{x_, y_}}],
+	{{{0, 1}}, {{0, 2}}}
+]
+
+VerificationTest[
+	SetCases[{{0, 1}, {0, 2}}, {{x_, y_}, {x_, z_}}],
+	{{{0, 1}, {0, 2}}, {{0, 2}, {0, 1}}}
+]
+
+VerificationTest[
+	SetCases[{{0, 1}, {0, 2}, {0, 3}}, {{x_, y_}, {x_, z_}}],
+	{{{0, 1}, {0, 2}}, {{0, 2}, {0, 1}}, {{0, 1}, {0, 3}}, {{0, 3}, {0, 1}}, {{0, 2}, {0, 3}}, {{0, 3}, {0, 2}}}
+]
+
+VerificationTest[
+	SetCases[{{0, 1}, {1, 2}, {2, 3}}, {{x_, y_}, {y_, z_}}],
+	{{{0, 1}, {1, 2}}, {{1, 2}, {2, 3}}}
+]
+
+VerificationTest[
+	SetCases[{{0, 1}, {1, 2}, {2, 3}}, {{x_, y_}, {x_, z_}}],
+	{}
+]
+
 EndTestSection[]

--- a/SetReplace/SetReplace/Match.hpp
+++ b/SetReplace/SetReplace/Match.hpp
@@ -4,10 +4,11 @@
 #include <vector>
 
 #include "Expression.hpp"
+#include "Rule.hpp"
 
 namespace SetReplace {
     struct Match {
-        int ruleID;
+        RuleID ruleID;
         std::vector<ExpressionID> expressionIDs;
         
         bool operator<(const Match& other) const;

--- a/SetReplace/SetReplace/Rule.hpp
+++ b/SetReplace/SetReplace/Rule.hpp
@@ -6,6 +6,8 @@
 #include "Expression.hpp"
 
 namespace SetReplace {
+    using RuleID = int;
+    
     struct Rule {
         std::vector<Expression> inputs;
         std::vector<Expression> outputs;

--- a/SetReplace/SetReplace/Set.cpp
+++ b/SetReplace/SetReplace/Set.cpp
@@ -162,6 +162,22 @@ namespace SetReplace {
           return result;
         }
         
+        std::vector<std::pair<RuleID, std::vector<Expression>>> matches() const {
+            std::vector<std::pair<RuleID, std::vector<Expression>>> result;
+            result.reserve(matches_.size());
+            for (const auto& match : matches_) {
+                const auto& ruleID = match.ruleID;
+                const auto& expressionIDs = match.expressionIDs;
+                std::vector<Expression> expressions;
+                expressions.reserve(match.expressionIDs.size());
+                for (const auto& id : expressionIDs) {
+                    expressions.push_back(expressions_.at(id));
+                }
+                result.push_back({ruleID, expressions});
+            }
+            return result;
+        }
+        
     private:
         std::vector<Expression> nameAnonymousAtoms(const std::vector<Expression>& expressions) {
             std::unordered_map<AtomID, AtomID> names;
@@ -208,7 +224,7 @@ namespace SetReplace {
             }
         }
         
-        void addMatches(const std::vector<ExpressionID>& expressionIDs, const int ruleID) {
+        void addMatches(const std::vector<ExpressionID>& expressionIDs, const RuleID ruleID) {
             for (int i = 0; i < rules_[ruleID].inputs.size(); ++i) {
                 Match emptyMatch{ruleID, std::vector<ExpressionID>(rules_[ruleID].inputs.size(), -1)};
                 addMatches(emptyMatch, rules_[ruleID].inputs, i, expressionIDs);
@@ -368,5 +384,9 @@ namespace SetReplace {
     
     std::vector<Expression> Set::expressions() const {
         return implementation_->expressions();
+    }
+    
+    std::vector<std::pair<RuleID, std::vector<Expression>>> Set::matches() const {
+        return implementation_->matches();
     }
 }

--- a/SetReplace/SetReplace/Set.hpp
+++ b/SetReplace/SetReplace/Set.hpp
@@ -19,6 +19,7 @@ namespace SetReplace {
         int replace(const int stepCount);
         
         std::vector<Expression> expressions() const;
+        std::vector<std::pair<RuleID, std::vector<Expression>>> matches() const;
         
     private:
         class Implementation;

--- a/SetReplace/SetReplace/SetReplace.cpp
+++ b/SetReplace/SetReplace/SetReplace.cpp
@@ -88,6 +88,45 @@ namespace SetReplace {
         return output;
     }
     
+    MTensor putSets(const std::vector<std::vector<Expression>>& sets, WolframLibraryData libData) {
+        int tensorLength = 1 + (int)sets.size();
+        for (const auto& set : sets) {
+            tensorLength += (int)set.size();
+            for (const auto& expression : set) {
+                tensorLength += (int)expression.size();
+            }
+        }
+        
+        mint dimensions[1] = {tensorLength};
+        MTensor output;
+        libData->MTensor_new(MType_Integer, 1, dimensions, &output);
+        
+        int writeIndex = 0;
+        mint position[1];
+        position[0] = ++writeIndex;
+        libData->MTensor_setInteger(output, position, sets.size());
+        for (int setIndex = 0; setIndex < sets.size(); ++setIndex) {
+            position[0] = ++writeIndex;
+            libData->MTensor_setInteger(output, position, sets[setIndex].size());
+            for (int expressionIndex = 0; expressionIndex < sets[setIndex].size(); expressionIndex++) {
+                position[0] = ++writeIndex;
+                libData->MTensor_setInteger(output, position, sets[setIndex][expressionIndex].size());
+                for (int atomIndex = 0; atomIndex < sets[setIndex][expressionIndex].size(); atomIndex++) {
+                    position[0] = ++writeIndex;
+                    libData->MTensor_setInteger(output, position, sets[setIndex][expressionIndex][atomIndex]);
+                }
+            }
+        }
+        
+        return output;
+    }
+    
+    const auto abortCheckFunction(WolframLibraryData libData) {
+        return [libData]() {
+            return static_cast<bool>(libData->AbortQ());
+        };
+    }
+    
     int setReplace(WolframLibraryData libData, mint argc, MArgument *argv, MArgument result) {
         if (argc != 3) {
             return LIBRARY_FUNCTION_ERROR;
@@ -104,14 +143,41 @@ namespace SetReplace {
             return LIBRARY_FUNCTION_ERROR;
         }
         
-        const auto shouldAbort = [&libData]() {
-            return static_cast<bool>(libData->AbortQ());
-        };
         try {
-            Set set(rules, initialExpressions, shouldAbort);
+            Set set(rules, initialExpressions, abortCheckFunction(libData));
             set.replace(steps);
             const auto expressions = set.expressions();
             MArgument_setMTensor(result, putSet(expressions, libData));
+        } catch (...) {
+            return LIBRARY_FUNCTION_ERROR;
+        }
+        
+        return LIBRARY_NO_ERROR;
+    }
+    
+    int setCases(WolframLibraryData libData, mint argc, MArgument *argv, MArgument result) {
+        if (argc != 2) {
+            return LIBRARY_FUNCTION_ERROR;
+        }
+        
+        std::vector<Expression> pattern;
+        std::vector<Expression> initialExpressions;
+        try {
+            pattern = getSet(libData, MArgument_getMTensor(argv[0]));
+            initialExpressions = getSet(libData, MArgument_getMTensor(argv[1]));
+        } catch (...) {
+            return LIBRARY_FUNCTION_ERROR;
+        }
+        
+        try {
+            const Set set({{pattern, {}}}, initialExpressions, abortCheckFunction(libData));
+            const auto matches = set.matches();
+            std::vector<std::vector<Expression>> matchedSets;
+            matchedSets.reserve(matches.size());
+            for (const auto& match : matches) {
+                matchedSets.push_back(match.second);
+            }
+            MArgument_setMTensor(result, putSets(matchedSets, libData));
         } catch (...) {
             return LIBRARY_FUNCTION_ERROR;
         }
@@ -134,4 +200,8 @@ EXTERN_C void WolframLibrary_uninitialize(WolframLibraryData libData) {
 
 EXTERN_C int setReplace(WolframLibraryData libData, mint argc, MArgument *argv, MArgument result) {
     return SetReplace::setReplace(libData, argc, argv, result);
+}
+
+EXTERN_C int setCases(WolframLibraryData libData, mint argc, MArgument *argv, MArgument result) {
+    return SetReplace::setCases(libData, argc, argv, result);
 }

--- a/SetReplace/SetReplace/SetReplace.hpp
+++ b/SetReplace/SetReplace/SetReplace.hpp
@@ -13,4 +13,6 @@ EXTERN_C DLLEXPORT void WolframLibrary_uninitialize(WolframLibraryData libData);
 
 EXTERN_C DLLEXPORT int setReplace(WolframLibraryData libData, mint argc, MArgument *argv, MArgument result);
 
+EXTERN_C DLLEXPORT int setCases(WolframLibraryData libData, mint argc, MArgument *argv, MArgument result);
+
 #endif /* SetReplace_hpp */


### PR DESCRIPTION
## Changes

* Adds `SetCases` function that yields the list of matching subsets to a pattern.

## Tests

* Build and install the paclet: `./build.wls && ./install.wls`, then import ``<< SetReplace` ``
* Take a graph:
```
In[] := Graph[DirectedEdge @@@ (g = {{0, 1}, {1, 2}, {0, 5}, {5, 2}, {2, 
      3}, {2, 4}})]
```
![image](https://user-images.githubusercontent.com/1479325/60370683-3d720380-99c5-11e9-9648-ca77c3004eac.png)
* Find all matching paths of 3 vertices:
```
In[] := cases = SetCases[g, {{x_, y_}, {y_, z_}}]
```
```
Out[] = {{{0, 1}, {1, 2}}, {{1, 2}, {2, 3}}, {{1, 2}, {2, 4}}, {{0, 5}, {5, 
   2}}, {{5, 2}, {2, 3}}, {{5, 2}, {2, 4}}}
```

```
In[] := HighlightGraph[DirectedEdge @@@ g, DirectedEdge @@@ #] & /@ cases
```
![image](https://user-images.githubusercontent.com/1479325/60370890-b709f180-99c5-11e9-9531-03ace396fcb1.png)
* Run unit tests:
```
In[] := TestReport["path_to_SetReplace.wlt"]
```
![image](https://user-images.githubusercontent.com/1479325/60371436-42d04d80-99c7-11e9-8ad3-c285a60d0ee5.png)