### PR TITLE
HypergraphPlot: "HyperedgeType" option

### DIFF
--- a/SetReplace/HypergraphPlot.m
+++ b/SetReplace/HypergraphPlot.m
@@ -69,7 +69,8 @@ HypergraphPlot[edges_, o : OptionsPattern[]] := 0 /;
 
 Options[HypergraphPlot] = Join[{
 	"HyperedgeLayout" -> "Ordered",
-	PlotStyle -> (ColorData[97][# + 1] &)},
+	PlotStyle -> (ColorData[97][# + 1] &),
+	DirectedEdges -> True},
 	Options[GraphPlot]];
 
 
@@ -177,7 +178,11 @@ HypergraphPlot[set : {___List}, o : OptionsPattern[]] := Module[{
 		graphForEmbedding = Graph[edgesForEmbedding];
 		coordinateRules = Thread[
 			VertexList[graphForEmbedding] ->
-				GraphEmbedding[graphForEmbedding, OptionValue[GraphLayout]]];
+				GraphEmbedding[
+					graphForEmbedding,
+					Replace[
+						OptionValue[GraphLayout],
+						Automatic -> "SpringElectricalEmbedding"]]];
 		
 		vertices = Union @ Flatten @ set;
 		vertexColors = (# -> ColorData[97, Count[set, {#}] + 1] & /@ vertices);
@@ -187,7 +192,9 @@ HypergraphPlot[set : {___List}, o : OptionsPattern[]] := Module[{
 				DirectedEdge @@@ Partition[#, 2, 1] & /@ hyperedges];
 		graphForPlotting = EdgeTaggedGraph[
 			vertices,
-			Join[Rule @@@ edges, edgesWithColors]];
+			Join[
+				If[OptionValue[DirectedEdges], DirectedEdge, UndirectedEdge] @@@ edges,
+				edgesWithColors]];
 	];
 	graphPlotOptions =
 		FilterRules[FilterRules[{o}, Options[GraphPlot]], Except[PlotStyle]];

--- a/SetReplace/HypergraphPlot.m
+++ b/SetReplace/HypergraphPlot.m
@@ -24,8 +24,7 @@ PackageExport["HypergraphPlot"]
 
 HypergraphPlot::usage = usageString[
 	"HypergraphPlot[`s`, `opts`] plots a list of vertex lists `s` as a ",
-	"hypergraph with each hyperedge represented as a sequence of same-color arrows. ",
-	"Graph options `opts` can be used."];
+	"hypergraph."];
 
 
 (* ::Section:: *)
@@ -60,73 +59,120 @@ HypergraphPlot[edges_, o : OptionsPattern[]] := 0 /;
 	!MatchQ[edges, {___List}] && Message[HypergraphPlot::invalidEdges]
 
 
-(* ::Subsection:: *)
-(*PlotStyle is an indexed ColorDataFunction*)
-
-
-HypergraphPlot::unsupportedPlotStyle =
-	"Only indexed ColorDataFunction, i.e., ColorData[n] is supported as a plot style.";
-
-
-correctOptionsQ[o___] := Module[
-		{plotStyle = OptionValue[HypergraphPlot, {o}, PlotStyle]},
-	Head[plotStyle] === ColorDataFunction &&
-	plotStyle[[2]] === "Indexed"
-]
-
-
-HypergraphPlot[edges : {___List}, o : OptionsPattern[]] := 0 /;
-	!correctOptionsQ[o] &&
-	Message[HypergraphPlot::unsupportedPlotStyle]
-
-
 (* ::Section:: *)
 (*Options*)
 
 
-Options[HypergraphPlot] = Join[Options[Graph], {PlotStyle -> ColorData[97]}];
+(* ::Text:: *)
+(*"HyperedgeLayout" can be set to: "Unordered" (sequence of edges), "Cyclic" (same, but last vertex connected to the first), and "Ordered" (all vertices connected in a complete graph).*)
+
+
+Options[HypergraphPlot] = Join[{
+	"HyperedgeLayout" -> "Ordered",
+	PlotStyle -> (ColorData[97][# + 1] &)},
+	Options[GraphPlot]];
 
 
 (* ::Section:: *)
 (*Implementation*)
 
 
-(* ::Text:: *)
-(*The idea here is that we are going to draw Graph first while substituting EdgeShapeFunction with a function that collects edge shapes, and produces edge -> hash mapping.*)
+(* ::Subsection:: *)
+(*parseHyperedgeLayout*)
 
 
-(* ::Text:: *)
-(*We can then use that to produce hash -> color association, which we use to properly color the edges.*)
+$hyperedgeLayouts = {"Ordered", "Cyclic", "Unordered"};
 
 
-HypergraphPlot[edges : {___List}, o : OptionsPattern[]] /;
-	correctOptionsQ[o] := Module[
-		{normalEdges, vertices, edgeColors, shapeHashes, hashesToColors,
-		 graphEdges, graphOptions, graphBoxes, arrowheads, arrowheadOffset,
-		 vertexColors},
-	normalEdges = Partition[#, 2, 1] & /@ edges;
-	vertices = Union @ Flatten @ edges;
-	vertexColors = (# -> ColorData[97, Count[edges, {#}] + 1] & /@ vertices);
-	edgeColors = Sort @ Flatten @ MapIndexed[
-		Thread[DirectedEdge @@@ #1 -> OptionValue[PlotStyle][#2[[1]]]] &, normalEdges];
-	graphEdges = DirectedEdge @@@ Flatten[normalEdges, 1];
-	graphOptions = FilterRules[{o}, Options[Graph]];
-	shapeHashes = Sort @ (If[# == {}, {}, #[[1]]] &) @ Last @ Reap @ Rasterize @
-		GraphPlot[Graph[vertices, graphEdges, Join[{
-			EdgeShapeFunction -> (Sow[#2 -> Hash[#1]] &)},
-			graphOptions]]];
-	graphBoxes = ToBoxes[Graph[graphEdges, DirectedEdges -> True]];
-	arrowheads =
-		If[Length[#] == 0, {}, #[[1]]] & @ Cases[graphBoxes, _Arrowheads, All];
-	arrowheadOffset = If[Length[#] == 0, 0, #[[1]]] & @
-		Cases[graphBoxes, ArrowBox[x_, offset_] :> offset, All];
-	hashesToColors =
-		Association @ Thread[shapeHashes[[All, 2]] -> edgeColors[[All, 2]]];
-	GraphPlot[Graph[vertices, graphEdges, Join[
-		graphOptions,
-		{EdgeShapeFunction -> ({
-			arrowheads,
-			hashesToColors[Hash[#1]],
-			Arrow[#1, arrowheadOffset]} &),
-		 VertexStyle -> vertexColors}]]]
+HypergraphPlot::unknownHyperedgeLayout = "HyperedgeLayout `1` should be one of `2`.";
+
+
+parseHyperedgeLayout[hyperedges_, opt : _String | _Rule] :=
+	parseHyperedgeLayout[hyperedges, {opt}]
+
+
+parseHyperedgeLayout[hyperedges_, opt : {(_String | _Rule)...}] := Module[{
+		result, incorrectCase},
+	result = Replace[
+		hyperedges,
+		Reverse @ Prepend[
+			Replace[opt, s_String :> _ -> s, {1}],
+			_ -> OptionValue[HypergraphPlot, "HyperedgeLayout"]],
+		{1}];
+	If[!MissingQ[incorrectCase = FirstCase[
+			result, Except[Alternatives @@ $hyperedgeLayouts], Missing[], {1}]],
+		Message[HypergraphPlot::unknownHyperedgeLayout,
+			incorrectCase, $hyperedgeLayouts];
+		$Failed,
+		result
+	]
+]
+
+
+HypergraphPlot::invalidHyperedgeLayout =
+	"HyperedgeLayout `1` should be a string or a list of rules.";
+
+
+parseHyperedgeLayout[hyperedges_, opt_] := (
+	Message[HypergraphPlot::invalidHyperedgeLayout, opt];
+	$Failed)
+
+
+(* ::Subsection:: *)
+(*hyperedgeToEdges*)
+
+
+hyperedgeToEdges[hyperedge_, "Ordered"] := DirectedEdge @@@ Partition[hyperedge, 2, 1]
+
+
+hyperedgeToEdges[hyperedge_, "Cyclic"] :=
+	DirectedEdge @@@ Append[Partition[hyperedge, 2, 1], hyperedge[[{-1, 1}]]]
+
+
+hyperedgeToEdges[hyperedge_, "Unordered"] := UndirectedEdge @@@ Subsets[hyperedge, {2}]
+
+
+(* ::Subsection:: *)
+(*HypergraphPlot*)
+
+
+HypergraphPlot[set : {___List}, o : OptionsPattern[]] := Module[{
+		failedQ = False, hyperedges, edges, hypoedges, emptyEdges, hyperedgeLayouts,
+		result, edgesForEmbedding, graphForEmbedding, coordinateRules,
+		vertices, vertexColors, edgesWithColors, graphPlotOptions, graphForPlotting},
+	hyperedges = Select[Length[#] > 2 &][set];
+	edges = Select[Length[#] == 2 &][set];
+	hypoedges = Select[Length[#] == 1 &][set];
+	emptyEdges = Select[Length[#] == 0 &][set];
+	hyperedgeLayouts = parseHyperedgeLayout[hyperedges, OptionValue["HyperedgeLayout"]];
+	If[hyperedgeLayouts === $Failed, failedQ = True];
+	If[!failedQ,
+		edgesForEmbedding = Join[
+			DirectedEdge @@@ edges,
+			Catenate[hyperedgeToEdges[#1, #2] & @@@
+				Transpose[{hyperedges, hyperedgeLayouts}]]];
+		graphForEmbedding = Graph[edgesForEmbedding];
+		coordinateRules = Thread[
+			VertexList[graphForEmbedding] ->
+				GraphEmbedding[graphForEmbedding, OptionValue[GraphLayout]]];
+		
+		vertices = Union @ Flatten @ set;
+		vertexColors = (# -> ColorData[97, Count[set, {#}] + 1] & /@ vertices);
+		edgesWithColors = Annotation[#[[1]], EdgeStyle -> #[[2]]] & /@
+			Sort @ Flatten @ MapIndexed[
+				Thread[#1 -> OptionValue[PlotStyle][#2[[1]]]] &,
+				DirectedEdge @@@ Partition[#, 2, 1] & /@ hyperedges];
+		graphForPlotting = EdgeTaggedGraph[
+			vertices,
+			Join[Rule @@@ edges, edgesWithColors]];
+	];
+	graphPlotOptions =
+		FilterRules[FilterRules[{o}, Options[GraphPlot]], Except[PlotStyle]];
+	GraphPlot[
+		graphForPlotting,
+		Join[
+			graphPlotOptions, {
+			VertexStyle -> vertexColors,
+			VertexCoordinates ->
+				(VertexList[graphForPlotting] /. coordinateRules)}]] /; !failedQ
 ]

--- a/SetReplace/HypergraphPlot.m
+++ b/SetReplace/HypergraphPlot.m
@@ -64,11 +64,11 @@ HypergraphPlot[edges_, o : OptionsPattern[]] := 0 /;
 
 
 (* ::Text:: *)
-(*"HyperedgeLayout" can be set to: "Unordered" (sequence of edges), "Cyclic" (same, but last vertex connected to the first), and "Ordered" (all vertices connected in a complete graph).*)
+(*"HyperedgeType" can be set to: "Unordered" (sequence of edges), "Cyclic" (same, but last vertex connected to the first), and "Ordered" (all vertices connected in a complete graph).*)
 
 
 Options[HypergraphPlot] = Join[{
-	"HyperedgeLayout" -> "Ordered",
+	"HyperedgeType" -> "Ordered",
 	PlotStyle -> (ColorData[97][# + 1] &),
 	DirectedEdges -> True},
 	Options[GraphPlot]];
@@ -101,43 +101,43 @@ parsePlotStyle[hyperedgeCount_, style_] := Module[{result, failedQ = False},
 
 
 (* ::Subsection:: *)
-(*parseHyperedgeLayout*)
+(*parseHyperedgeType*)
 
 
-$hyperedgeLayouts = {"Ordered", "Cyclic", "Unordered"};
+$hyperedgeTypes = {"Ordered", "Cyclic", "Unordered"};
 
 
-HypergraphPlot::unknownHyperedgeLayout = "HyperedgeLayout `1` should be one of `2`.";
+HypergraphPlot::unknownHyperedgeType = "HyperedgeType `1` should be one of `2`.";
 
 
-parseHyperedgeLayout[hyperedges_, opt : _String | _Rule] :=
-	parseHyperedgeLayout[hyperedges, {opt}]
+parseHyperedgeType[hyperedges_, opt : _String | _Rule] :=
+	parseHyperedgeType[hyperedges, {opt}]
 
 
-parseHyperedgeLayout[hyperedges_, opt : {(_String | _Rule)...}] := Module[{
+parseHyperedgeType[hyperedges_, opt : {(_String | _Rule)...}] := Module[{
 		result, incorrectCase},
 	result = Replace[
 		hyperedges,
 		Reverse @ Prepend[
 			Replace[opt, s_String :> _ -> s, {1}],
-			_ -> OptionValue[HypergraphPlot, "HyperedgeLayout"]],
+			_ -> OptionValue[HypergraphPlot, "HyperedgeType"]],
 		{1}];
 	If[!MissingQ[incorrectCase = FirstCase[
-			result, Except[Alternatives @@ $hyperedgeLayouts], Missing[], {1}]],
-		Message[HypergraphPlot::unknownHyperedgeLayout,
-			incorrectCase, $hyperedgeLayouts];
+			result, Except[Alternatives @@ $hyperedgeTypes], Missing[], {1}]],
+		Message[HypergraphPlot::unknownHyperedgeType,
+			incorrectCase, $hyperedgeTypes];
 		$Failed,
 		result
 	]
 ]
 
 
-HypergraphPlot::invalidHyperedgeLayout =
-	"HyperedgeLayout `1` should be a string or a list of rules.";
+HypergraphPlot::invalidHyperedgeType =
+	"HyperedgeType `1` should be a string or a list of rules.";
 
 
-parseHyperedgeLayout[hyperedges_, opt_] := (
-	Message[HypergraphPlot::invalidHyperedgeLayout, opt];
+parseHyperedgeType[hyperedges_, opt_] := (
+	Message[HypergraphPlot::invalidHyperedgeType, opt];
 	$Failed)
 
 
@@ -161,20 +161,20 @@ hyperedgeToEdges[hyperedge_, "Unordered"] := UndirectedEdge @@@ Subsets[hyperedg
 
 HypergraphPlot[set : {___List}, o : OptionsPattern[]] := Module[{
 		failedQ = False, hyperedges, edges, hypoedges, emptyEdges, hyperedgeColors,
-		hyperedgeLayouts, result, edgesForEmbedding, graphForEmbedding, coordinateRules,
+		hyperedgeTypes, result, edgesForEmbedding, graphForEmbedding, coordinateRules,
 		vertices, vertexColors, edgesWithColors, graphPlotOptions, graphForPlotting},
 	hyperedges = Select[Length[#] > 2 &][set];
 	edges = Select[Length[#] == 2 &][set];
 	hypoedges = Select[Length[#] == 1 &][set];
 	emptyEdges = Select[Length[#] == 0 &][set];
 	hyperedgeColors = parsePlotStyle[Length[hyperedges], OptionValue[PlotStyle]];
-	hyperedgeLayouts = parseHyperedgeLayout[hyperedges, OptionValue["HyperedgeLayout"]];
-	If[hyperedgeLayouts === $Failed || hyperedgeColors === $Failed, failedQ = True];
+	hyperedgeTypes = parseHyperedgeType[hyperedges, OptionValue["HyperedgeType"]];
+	If[hyperedgeTypes === $Failed || hyperedgeColors === $Failed, failedQ = True];
 	If[!failedQ,
 		edgesForEmbedding = Join[
 			DirectedEdge @@@ edges,
 			Catenate[hyperedgeToEdges[#1, #2] & @@@
-				Transpose[{hyperedges, hyperedgeLayouts}]]];
+				Transpose[{hyperedges, hyperedgeTypes}]]];
 		graphForEmbedding = Graph[edgesForEmbedding];
 		coordinateRules = Thread[
 			VertexList[graphForEmbedding] ->

--- a/SetReplace/HypergraphPlot.wlt
+++ b/SetReplace/HypergraphPlot.wlt
@@ -71,100 +71,100 @@ VerificationTest[
   True
 ]
 
-(** Valid HyperedgeLayout **)
+(** Valid HyperedgeType **)
 
 VerificationTest[
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeLayout" -> None],
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeLayout" -> None],
-  {HypergraphPlot::invalidHyperedgeLayout}
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeType" -> None],
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeType" -> None],
+  {HypergraphPlot::invalidHyperedgeType}
 ]
 
 VerificationTest[
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeLayout" -> "$$$Incorrect$$$"],
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeLayout" -> "$$$Incorrect$$$"],
-  {HypergraphPlot::unknownHyperedgeLayout}
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeType" -> "$$$Incorrect$$$"],
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeType" -> "$$$Incorrect$$$"],
+  {HypergraphPlot::unknownHyperedgeType}
 ]
 
 VerificationTest[
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeLayout" -> {"$$$Incorrect$$$"}],
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeLayout" -> {"$$$Incorrect$$$"}],
-  {HypergraphPlot::unknownHyperedgeLayout}
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeType" -> {"$$$Incorrect$$$"}],
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeType" -> {"$$$Incorrect$$$"}],
+  {HypergraphPlot::unknownHyperedgeType}
 ]
 
 VerificationTest[
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeLayout" -> {{1, 2, 3} -> "$$$Incorrect$$$"}],
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeLayout" -> {{1, 2, 3} -> "$$$Incorrect$$$"}],
-  {HypergraphPlot::unknownHyperedgeLayout}
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeType" -> {{1, 2, 3} -> "$$$Incorrect$$$"}],
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeType" -> {{1, 2, 3} -> "$$$Incorrect$$$"}],
+  {HypergraphPlot::unknownHyperedgeType}
 ]
 
 VerificationTest[
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeLayout" -> {None, {1, 2, 3} -> "Ordered"}],
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeLayout" -> {None, {1, 2, 3} -> "Ordered"}],
-  {HypergraphPlot::invalidHyperedgeLayout}
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeType" -> {None, {1, 2, 3} -> "Ordered"}],
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeType" -> {None, {1, 2, 3} -> "Ordered"}],
+  {HypergraphPlot::invalidHyperedgeType}
 ]
 
 VerificationTest[
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeLayout" -> {"$$$Incorrect$$$", {1, 2, 3} -> "Ordered"}],
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeLayout" -> {"$$$Incorrect$$$", {1, 2, 3} -> "Ordered"}],
-  {HypergraphPlot::unknownHyperedgeLayout}
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeType" -> {"$$$Incorrect$$$", {1, 2, 3} -> "Ordered"}],
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeType" -> {"$$$Incorrect$$$", {1, 2, 3} -> "Ordered"}],
+  {HypergraphPlot::unknownHyperedgeType}
 ]
 
 VerificationTest[
   HypergraphPlot[
     {{1, 2, 3}, {3, 4, 5}},
-    "HyperedgeLayout" -> {{3, 4, 5} -> "Ordered", {1, 2, 3} -> "$$$Incorrect$$$"}],
+    "HyperedgeType" -> {{3, 4, 5} -> "Ordered", {1, 2, 3} -> "$$$Incorrect$$$"}],
   HypergraphPlot[
     {{1, 2, 3}, {3, 4, 5}},
-    "HyperedgeLayout" -> {{3, 4, 5} -> "Ordered", {1, 2, 3} -> "$$$Incorrect$$$"}],
-  {HypergraphPlot::unknownHyperedgeLayout}
+    "HyperedgeType" -> {{3, 4, 5} -> "Ordered", {1, 2, 3} -> "$$$Incorrect$$$"}],
+  {HypergraphPlot::unknownHyperedgeType}
 ]
 
 VerificationTest[
-  Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeLayout" -> "Ordered"]],
+  Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeType" -> "Ordered"]],
   Graphics
 ]
 
 VerificationTest[
-  Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeLayout" -> "Cyclic"]],
+  Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeType" -> "Cyclic"]],
   Graphics
 ]
 
 VerificationTest[
-  Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeLayout" -> "Unordered"]],
+  Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeType" -> "Unordered"]],
   Graphics
 ]
 
 VerificationTest[
-  Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeLayout" -> {"Ordered"}]],
+  Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeType" -> {"Ordered"}]],
   Graphics
 ]
 
 VerificationTest[
-  Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeLayout" -> {{1, 2, 3} -> "Cyclic"}]],
+  Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeType" -> {{1, 2, 3} -> "Cyclic"}]],
   Graphics
 ]
 
 VerificationTest[
-  Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeLayout" -> {"Cyclic", {1, 2, 3} -> "Ordered"}]],
+  Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeType" -> {"Cyclic", {1, 2, 3} -> "Ordered"}]],
   Graphics
 ]
 
 VerificationTest[
   Head[HypergraphPlot[
     {{1, 2, 3}, {3, 4, 5}},
-    "HyperedgeLayout" -> {{3, 4, 5} -> "Unordered", {1, 2, 3} -> "Cyclic"}]],
+    "HyperedgeType" -> {{3, 4, 5} -> "Unordered", {1, 2, 3} -> "Cyclic"}]],
   Graphics
 ]
 
 VerificationTest[
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeLayout" -> {"Cyclic", {1, 2, 3} -> 123}],
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeLayout" -> {"Cyclic", {1, 2, 3} -> 123}],
-  {HypergraphPlot::unknownHyperedgeLayout}
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeType" -> {"Cyclic", {1, 2, 3} -> 123}],
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeType" -> {"Cyclic", {1, 2, 3} -> 123}],
+  {HypergraphPlot::unknownHyperedgeType}
 ]
 
 (*** {1, 2, 4} never appears in the hypergraph, so is never used. ***)
 VerificationTest[
-  Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeLayout" -> {"Cyclic", {1, 2, 4} -> 123}]],
+  Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeType" -> {"Cyclic", {1, 2, 4} -> 123}]],
   Graphics
 ]
 
@@ -204,7 +204,7 @@ VerificationTest[
   FreeQ[HypergraphPlot[{{1}, {1}}], ColorData[97, #]] & /@ {1, 2, 3},
   {True, True, False}]
 
-(* HyperedgeLayout *)
+(* HyperedgeType *)
 
 diskCoordinates[graphics_] := Sort[
   #[[1, 1, Cases[#, Disk[i_, ___] :> i, All]]] & @
@@ -219,7 +219,7 @@ $layoutTestHypergraphs = {
 };
 
 VerificationTest[
-  diskCoordinates[HypergraphPlot[#, "HyperedgeLayout" -> "Ordered"]],
+  diskCoordinates[HypergraphPlot[#, "HyperedgeType" -> "Ordered"]],
   Sort @ GraphEmbedding[
     Rule @@@ Catenate[Partition[#, 2, 1] & /@ #],
     "SpringElectricalEmbedding"],
@@ -227,7 +227,7 @@ VerificationTest[
 ] & /@ $layoutTestHypergraphs
 
 VerificationTest[
-  diskCoordinates[HypergraphPlot[#, "HyperedgeLayout" -> "Cyclic"]],
+  diskCoordinates[HypergraphPlot[#, "HyperedgeType" -> "Cyclic"]],
   Sort @ GraphEmbedding[
     Rule @@@ Catenate[Append[Partition[#, 2, 1], #[[{-1, 1}]]] & /@ #],
     "SpringElectricalEmbedding"],
@@ -235,7 +235,7 @@ VerificationTest[
 ] & /@ $layoutTestHypergraphs
 
 VerificationTest[
-  diskCoordinates[HypergraphPlot[#, "HyperedgeLayout" -> "Unordered"]],
+  diskCoordinates[HypergraphPlot[#, "HyperedgeType" -> "Unordered"]],
   Sort @ GraphEmbedding[
     Rule @@@ Catenate[Subsets[#, {2}] & /@ #],
     "SpringElectricalEmbedding"],
@@ -243,27 +243,27 @@ VerificationTest[
 ] & /@ $layoutTestHypergraphs
 
 VerificationTest[
-  diskCoordinates[HypergraphPlot[#, "HyperedgeLayout" -> "Ordered"]],
-  diskCoordinates[HypergraphPlot[#, "HyperedgeLayout" -> "Cyclic"]],
+  diskCoordinates[HypergraphPlot[#, "HyperedgeType" -> "Ordered"]],
+  diskCoordinates[HypergraphPlot[#, "HyperedgeType" -> "Cyclic"]],
   SameTest -> (Not @* Equal)
 ] & /@ $layoutTestHypergraphs
 
 VerificationTest[
-  diskCoordinates[HypergraphPlot[#, "HyperedgeLayout" -> "Ordered"]],
-  diskCoordinates[HypergraphPlot[#, "HyperedgeLayout" -> "Unordered"]],
+  diskCoordinates[HypergraphPlot[#, "HyperedgeType" -> "Ordered"]],
+  diskCoordinates[HypergraphPlot[#, "HyperedgeType" -> "Unordered"]],
   SameTest -> (Not @* Equal)
 ] & /@ $layoutTestHypergraphs
 
 VerificationTest[
-  diskCoordinates[HypergraphPlot[#, "HyperedgeLayout" -> "Unordered"]],
-  diskCoordinates[HypergraphPlot[#, "HyperedgeLayout" -> "Cyclic"]],
+  diskCoordinates[HypergraphPlot[#, "HyperedgeType" -> "Unordered"]],
+  diskCoordinates[HypergraphPlot[#, "HyperedgeType" -> "Cyclic"]],
   SameTest -> (Not @* Equal)
 ] & /@ $layoutTestHypergraphs
 
 VerificationTest[
   diskCoordinates[HypergraphPlot[
     {{1, 2, 3, 4, 5, 6}, {1, 2, 3, 4}},
-    "HyperedgeLayout" -> {"Ordered", {_, _, _, _} -> "Cyclic"}]],
+    "HyperedgeType" -> {"Ordered", {_, _, _, _} -> "Cyclic"}]],
   Sort @ GraphEmbedding[
     {1 -> 2, 2 -> 3, 3 -> 4, 4 -> 5, 5 -> 6, 1 -> 2, 2 -> 3, 3 -> 4, 4 -> 1},
     "SpringElectricalEmbedding"],
@@ -273,10 +273,10 @@ VerificationTest[
 VerificationTest[
   diskCoordinates[HypergraphPlot[
     {{1, 2, 3, 4, 5, 6}, {1, 2, 3, 4}},
-    "HyperedgeLayout" -> {"Ordered", {_, _, _, _} -> "Cyclic"}]],
+    "HyperedgeType" -> {"Ordered", {_, _, _, _} -> "Cyclic"}]],
   diskCoordinates[HypergraphPlot[
     {{1, 2, 3, 4, 5, 6}, {1, 2, 3, 4}},
-    "HyperedgeLayout" -> {"Ordered"}]],
+    "HyperedgeType" -> {"Ordered"}]],
   SameTest -> (Not @* Equal)
 ]
 

--- a/SetReplace/HypergraphPlot.wlt
+++ b/SetReplace/HypergraphPlot.wlt
@@ -204,4 +204,80 @@ VerificationTest[
   FreeQ[HypergraphPlot[{{1}, {1}}], ColorData[97, #]] & /@ {1, 2, 3},
   {True, True, False}]
 
+(* HyperedgeLayout *)
+
+diskCoordinates[graphics_] := Sort[
+  #[[1, 1, Cases[#, Disk[i_, ___] :> i, All]]] & @
+    Cases[graphics, GraphicsComplex[___], All]]
+
+$layoutTestHypergraphs = {
+  {{1, 2, 3}, {3, 4, 5}},
+  {{1, 2, 3, 4, 5}, {5, 6, 7, 8, 9}},
+  {{1, 2, 3, 4, 5, 6, 7, 8, 9}, {1, 4, 7}},
+  {{1, 2, 3, 4, 5, 6}, {1, 2, 3, 4}},
+  {{1, 2, 3}, {3, 4, 5}, {1, 2, 3, 4}}
+};
+
+VerificationTest[
+  diskCoordinates[HypergraphPlot[#, "HyperedgeLayout" -> "Ordered"]],
+  Sort @ GraphEmbedding[
+    Rule @@@ Catenate[Partition[#, 2, 1] & /@ #],
+    "SpringElectricalEmbedding"],
+  SameTest -> Equal
+] & /@ $layoutTestHypergraphs
+
+VerificationTest[
+  diskCoordinates[HypergraphPlot[#, "HyperedgeLayout" -> "Cyclic"]],
+  Sort @ GraphEmbedding[
+    Rule @@@ Catenate[Append[Partition[#, 2, 1], #[[{-1, 1}]]] & /@ #],
+    "SpringElectricalEmbedding"],
+  SameTest -> Equal
+] & /@ $layoutTestHypergraphs
+
+VerificationTest[
+  diskCoordinates[HypergraphPlot[#, "HyperedgeLayout" -> "Unordered"]],
+  Sort @ GraphEmbedding[
+    Rule @@@ Catenate[Subsets[#, {2}] & /@ #],
+    "SpringElectricalEmbedding"],
+  SameTest -> Equal
+] & /@ $layoutTestHypergraphs
+
+VerificationTest[
+  diskCoordinates[HypergraphPlot[#, "HyperedgeLayout" -> "Ordered"]],
+  diskCoordinates[HypergraphPlot[#, "HyperedgeLayout" -> "Cyclic"]],
+  SameTest -> (Not @* Equal)
+] & /@ $layoutTestHypergraphs
+
+VerificationTest[
+  diskCoordinates[HypergraphPlot[#, "HyperedgeLayout" -> "Ordered"]],
+  diskCoordinates[HypergraphPlot[#, "HyperedgeLayout" -> "Unordered"]],
+  SameTest -> (Not @* Equal)
+] & /@ $layoutTestHypergraphs
+
+VerificationTest[
+  diskCoordinates[HypergraphPlot[#, "HyperedgeLayout" -> "Unordered"]],
+  diskCoordinates[HypergraphPlot[#, "HyperedgeLayout" -> "Cyclic"]],
+  SameTest -> (Not @* Equal)
+] & /@ $layoutTestHypergraphs
+
+VerificationTest[
+  diskCoordinates[HypergraphPlot[
+    {{1, 2, 3, 4, 5, 6}, {1, 2, 3, 4}},
+    "HyperedgeLayout" -> {"Ordered", {_, _, _, _} -> "Cyclic"}]],
+  Sort @ GraphEmbedding[
+    {1 -> 2, 2 -> 3, 3 -> 4, 4 -> 5, 5 -> 6, 1 -> 2, 2 -> 3, 3 -> 4, 4 -> 1},
+    "SpringElectricalEmbedding"],
+  SameTest -> Equal
+]
+
+VerificationTest[
+  diskCoordinates[HypergraphPlot[
+    {{1, 2, 3, 4, 5, 6}, {1, 2, 3, 4}},
+    "HyperedgeLayout" -> {"Ordered", {_, _, _, _} -> "Cyclic"}]],
+  diskCoordinates[HypergraphPlot[
+    {{1, 2, 3, 4, 5, 6}, {1, 2, 3, 4}},
+    "HyperedgeLayout" -> {"Ordered"}]],
+  SameTest -> (Not @* Equal)
+]
+
 EndTestSection[]

--- a/SetReplace/HypergraphPlot.wlt
+++ b/SetReplace/HypergraphPlot.wlt
@@ -42,7 +42,7 @@ VerificationTest[
   {HypergraphPlot::invalidEdges}
 ]
 
-(** PlotStyle is an indexed ColorDataFunction **)
+(** Valid PlotStyle **)
 
 VerificationTest[
   HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, PlotStyle -> Red],
@@ -69,6 +69,103 @@ VerificationTest[
 VerificationTest[
   FreeQ[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, PlotStyle -> ColorData[1]], ColorData[1, 3]],
   True
+]
+
+(** Valid HyperedgeLayout **)
+
+VerificationTest[
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeLayout" -> None],
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeLayout" -> None],
+  {HypergraphPlot::invalidHyperedgeLayout}
+]
+
+VerificationTest[
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeLayout" -> "$$$Incorrect$$$"],
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeLayout" -> "$$$Incorrect$$$"],
+  {HypergraphPlot::unknownHyperedgeLayout}
+]
+
+VerificationTest[
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeLayout" -> {"$$$Incorrect$$$"}],
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeLayout" -> {"$$$Incorrect$$$"}],
+  {HypergraphPlot::unknownHyperedgeLayout}
+]
+
+VerificationTest[
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeLayout" -> {{1, 2, 3} -> "$$$Incorrect$$$"}],
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeLayout" -> {{1, 2, 3} -> "$$$Incorrect$$$"}],
+  {HypergraphPlot::unknownHyperedgeLayout}
+]
+
+VerificationTest[
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeLayout" -> {None, {1, 2, 3} -> "Ordered"}],
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeLayout" -> {None, {1, 2, 3} -> "Ordered"}],
+  {HypergraphPlot::invalidHyperedgeLayout}
+]
+
+VerificationTest[
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeLayout" -> {"$$$Incorrect$$$", {1, 2, 3} -> "Ordered"}],
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeLayout" -> {"$$$Incorrect$$$", {1, 2, 3} -> "Ordered"}],
+  {HypergraphPlot::unknownHyperedgeLayout}
+]
+
+VerificationTest[
+  HypergraphPlot[
+    {{1, 2, 3}, {3, 4, 5}},
+    "HyperedgeLayout" -> {{3, 4, 5} -> "Ordered", {1, 2, 3} -> "$$$Incorrect$$$"}],
+  HypergraphPlot[
+    {{1, 2, 3}, {3, 4, 5}},
+    "HyperedgeLayout" -> {{3, 4, 5} -> "Ordered", {1, 2, 3} -> "$$$Incorrect$$$"}],
+  {HypergraphPlot::unknownHyperedgeLayout}
+]
+
+VerificationTest[
+  Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeLayout" -> "Ordered"]],
+  Graphics
+]
+
+VerificationTest[
+  Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeLayout" -> "Cyclic"]],
+  Graphics
+]
+
+VerificationTest[
+  Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeLayout" -> "Unordered"]],
+  Graphics
+]
+
+VerificationTest[
+  Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeLayout" -> {"Ordered"}]],
+  Graphics
+]
+
+VerificationTest[
+  Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeLayout" -> {{1, 2, 3} -> "Cyclic"}]],
+  Graphics
+]
+
+VerificationTest[
+  Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeLayout" -> {"Cyclic", {1, 2, 3} -> "Ordered"}]],
+  Graphics
+]
+
+VerificationTest[
+  Head[HypergraphPlot[
+    {{1, 2, 3}, {3, 4, 5}},
+    "HyperedgeLayout" -> {{3, 4, 5} -> "Unordered", {1, 2, 3} -> "Cyclic"}]],
+  Graphics
+]
+
+VerificationTest[
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeLayout" -> {"Cyclic", {1, 2, 3} -> 123}],
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeLayout" -> {"Cyclic", {1, 2, 3} -> 123}],
+  {HypergraphPlot::unknownHyperedgeLayout}
+]
+
+(*** {1, 2, 4} never appears in the hypergraph, so is never used. ***)
+VerificationTest[
+  Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeLayout" -> {"Cyclic", {1, 2, 4} -> 123}]],
+  Graphics
 ]
 
 (* Implementation *)

--- a/SetReplace/HypergraphPlot.wlt
+++ b/SetReplace/HypergraphPlot.wlt
@@ -45,26 +45,30 @@ VerificationTest[
 (** PlotStyle is an indexed ColorDataFunction **)
 
 VerificationTest[
-  HypergraphPlot[{{1, 2}, {2, 3}, {3, 1}}, PlotStyle -> Red],
-  HypergraphPlot[{{1, 2}, {2, 3}, {3, 1}}, PlotStyle -> Red],
-  {HypergraphPlot::unsupportedPlotStyle}
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, PlotStyle -> Red],
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, PlotStyle -> Red],
+  {HypergraphPlot::notColor}
 ]
 
 VerificationTest[
-  HypergraphPlot[{{1, 2}, {2, 3}, {3, 1}}, PlotStyle -> 23],
-  HypergraphPlot[{{1, 2}, {2, 3}, {3, 1}}, PlotStyle -> 23],
-  {HypergraphPlot::unsupportedPlotStyle}
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, PlotStyle -> 23],
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, PlotStyle -> 23],
+  {HypergraphPlot::notColor}
 ]
 
 VerificationTest[
-  HypergraphPlot[{{1, 2}, {2, 3}, {3, 1}}, PlotStyle -> ColorData["DarkRainbow"]],
-  HypergraphPlot[{{1, 2}, {2, 3}, {3, 1}}, PlotStyle -> ColorData["DarkRainbow"]],
-  {HypergraphPlot::unsupportedPlotStyle}
+  FreeQ[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, PlotStyle -> ColorData[1]], ColorData[1, 1]],
+  False
 ]
 
 VerificationTest[
-  Head[HypergraphPlot[{{1, 2}, {2, 3}, {3, 1}}, PlotStyle -> ColorData[1]]],
-  Graphics
+  FreeQ[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, PlotStyle -> ColorData[1]], ColorData[1, 2]],
+  False
+]
+
+VerificationTest[
+  FreeQ[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, PlotStyle -> ColorData[1]], ColorData[1, 3]],
+  True
 ]
 
 (* Implementation *)

--- a/SetReplace/performance.wlt
+++ b/SetReplace/performance.wlt
@@ -65,4 +65,33 @@ VerificationTest[
   TimeConstraint -> 3
 ]
 
+(** HypergraphPlot **)
+
+$largeSet = WolframModel[
+  {{1, 2, 3}} -> {{5, 6, 1}, {6, 4, 2}, {4, 5, 3}},
+  {{0, 0, 0}},
+  7,
+  "FinalState"];
+
+{$normalPlotTiming, $normalPlotMemory} =
+  AbsoluteTiming[MaxMemoryUsed[GraphPlot[Rule @@@ Catenate[Partition[#, 2, 1] & /@ $largeSet]]]];
+
+VerificationTest[
+  Head[HypergraphPlot[$largeSet, "HyperedgeLayout" -> "Ordered"]],
+  Graphics,
+  TimeConstraint -> (2 $normalPlotTiming),
+  MemoryConstraint -> (5 $normalPlotMemory)]
+
+VerificationTest[
+  Head[HypergraphPlot[$largeSet, "HyperedgeLayout" -> "Cyclic"]],
+  Graphics,
+  TimeConstraint -> (2 $normalPlotTiming),
+  MemoryConstraint -> (5 $normalPlotMemory)]
+
+VerificationTest[
+  Head[HypergraphPlot[$largeSet, "HyperedgeLayout" -> "Unordered"]],
+  Graphics,
+  TimeConstraint -> (2 $normalPlotTiming),
+  MemoryConstraint -> (5 $normalPlotMemory)]
+
 EndTestSection[]

--- a/SetReplace/performance.wlt
+++ b/SetReplace/performance.wlt
@@ -77,19 +77,19 @@ $largeSet = WolframModel[
   AbsoluteTiming[MaxMemoryUsed[GraphPlot[Rule @@@ Catenate[Partition[#, 2, 1] & /@ $largeSet]]]];
 
 VerificationTest[
-  Head[HypergraphPlot[$largeSet, "HyperedgeLayout" -> "Ordered"]],
+  Head[HypergraphPlot[$largeSet, "HyperedgeType" -> "Ordered"]],
   Graphics,
   TimeConstraint -> (2 $normalPlotTiming),
   MemoryConstraint -> (5 $normalPlotMemory)]
 
 VerificationTest[
-  Head[HypergraphPlot[$largeSet, "HyperedgeLayout" -> "Cyclic"]],
+  Head[HypergraphPlot[$largeSet, "HyperedgeType" -> "Cyclic"]],
   Graphics,
   TimeConstraint -> (2 $normalPlotTiming),
   MemoryConstraint -> (5 $normalPlotMemory)]
 
 VerificationTest[
-  Head[HypergraphPlot[$largeSet, "HyperedgeLayout" -> "Unordered"]],
+  Head[HypergraphPlot[$largeSet, "HyperedgeType" -> "Unordered"]],
   Graphics,
   TimeConstraint -> (2 $normalPlotTiming),
   MemoryConstraint -> (5 $normalPlotMemory)]


### PR DESCRIPTION
## Changes

* Implements "HyperedgeType" option of HypergraphPlot.
* Possible values are "Ordered" (sequence), "Cyclic" (last vertex connect to first), and "Unordered" (all vertices in a hyperedge form a complete graph).
* Specification is per-pattern, i.e., {"Ordered", {_, _, _} -> "Cyclic"} will make hyperedges "Ordered", except for 3-edges, which will be "Cyclic".

## Context

The idea is to have three options: "HyperedgeType", GraphLayout (both vertex- and edge-layout parts), and "HyperedgeShapeFunction" (responsible for drawing).

"HyperedgeType" will have an effect on all other options, and possible can be specified with `Hyperedge` head in the future.

`"VertexLayout"` will take for the most part the same layouts as `GraphPlot`, with possible an addition of `"BraneElectricalEmbedding"`.

`"EdgeLayout"` will return a list of curves for hyperedge components (possibly a polygon, but might not necessarily).

`"HyperedgeShapeFunction"` will take these curves, and just do the drawing, no layout.

## Tests

* Run unit tests: `./build.wls && ./install.wls && ./test.wls`.
* Try different layouts:
```
In[] := HypergraphPlot[{{1, 2, 3, 4, 5}, {5, 6, 7, 8, 9}}, 
   VertexLabels -> Automatic, "HyperedgeType" -> #] & /@ {"Ordered",
   "Cyclic", "Unordered"}
```
![image](https://user-images.githubusercontent.com/1479325/67526720-3a80da00-f66a-11e9-898c-a8e0f6bfa0c8.png)

```
In[] := HypergraphPlot[{{1, 2, 3, 4, 5, 6, 7, 8, 9}, {1, 4, 7}}, 
   VertexLabels -> Automatic, "HyperedgeType" -> #] & /@ {"Ordered",
   "Cyclic", "Unordered"}
```
![image](https://user-images.githubusercontent.com/1479325/67526751-479dc900-f66a-11e9-8e24-7f41b12d66d3.png)

* Use different layouts for different hyperedges:
```
In[] := HypergraphPlot[{{1, 2, 3, 4, 5, 6}, {1, 2, 3, 4}}, 
 VertexLabels -> Automatic, 
 "HyperedgeType" -> {"Ordered", {_, _, _, _} -> "Cyclic"}]
```
![image](https://user-images.githubusercontent.com/1479325/67526805-6603c480-f66a-11e9-8ad9-810cdec7c432.png)
