### PR TITLE
Least-recent-first updating order

### DIFF
--- a/SetReplace/ToPatternRules.wlt
+++ b/SetReplace/ToPatternRules.wlt
@@ -76,7 +76,7 @@ VerificationTest[
     ToPatternRules[{
       {{1, 2}, {2, 3}} -> {{1, 3}},
       {{1, 2}} -> {{1, 1, 2, 2}}}], 2],
-  {{"v1", "v1", "v3", "v3"}}
+  {{"v1", "v1", "v2", "v2"}, {"v2", "v2", "v3", "v3"}}
 ]
 
 (** Creating vertices **)

--- a/SetReplace/correctness.wlt
+++ b/SetReplace/correctness.wlt
@@ -308,4 +308,59 @@ VerificationTest[
   True
 ]
 
+(** Evaluation order **)
+
+VerificationTest[
+  SetReplace[{{1}, {2}, {3}, {4}, {5}}, {{{2}, {3}, {4}} -> {{X}}, {{3}} -> {{X}}}],
+  {{1}, {2}, {4}, {5}, {X}}
+]
+
+VerificationTest[
+  Table[
+    WolframModel[
+        <|"PatternRules" -> {{{1, 2}, {2, 3}} -> {{R1}}, {{4, 5}, {5, 6}} -> {{R2}}}|>,
+        #,
+        <|"Events" -> 1|>,
+        "FinalState",
+        Method -> method][[-1, 1]] & /@
+      Permutations[{{1, 2}, {2, 3}, {4, 5}, {5, 6}}],
+    {method, {"LowLevel", "Symbolic"}}],
+  ConstantArray[{
+      R1, R1, R1, R2, R1, R2, R1, R1, R1, R2, R1, R2,
+      R1, R2, R1, R2, R2, R2, R1, R2, R1, R2, R2, R2},
+    2]
+]
+
+VerificationTest[
+  Table[
+    WolframModel[
+        <|"PatternRules" -> {{1, 2, x_}, {1, 2, z_}} :> {{x, z}}|>,
+        #,
+        <|"Events" -> 1|>,
+        "FinalState",
+        Method -> method][[-1]] & /@
+      Permutations[{{1, 2, x}, {1, 2, y}, {1, 2, z}}],
+    {method, {"LowLevel", "Symbolic"}}],
+  ConstantArray[
+    {{x, y}, {x, z}, {y, x}, {y, z}, {z, x}, {z, y}},
+    2]
+]
+
+VerificationTest[
+  Table[
+    WolframModel[
+        <|"PatternRules" -> {
+          {{1, 2, x_}, {1, 3, z_}} :> {{1, x, z}},
+          {{1, 2, x_}, {1, 2, z_}} :> {{2, x, z}}}|>,
+        #,
+        <|"Events" -> 1|>,
+        "FinalState",
+        Method -> method][[-1]] & /@
+      Permutations[{{1, 2, x}, {1, 2, y}, {1, 3, z}}],
+    {method, {"LowLevel", "Symbolic"}}],
+  ConstantArray[
+    {{2, x, y}, {1, x, z}, {2, y, x}, {1, y, z}, {1, x, z}, {1, y, z}},
+    2]
+]
+
 EndTestSection[]

--- a/SetReplace/libSetReplace/Match.cpp
+++ b/SetReplace/libSetReplace/Match.cpp
@@ -16,13 +16,17 @@ namespace SetReplace {
             else return 0;
         }
         
-        int compareSortedIDs(const Match& first, const Match& second) {
+        int compareSortedIDs(const Match& first, const Match& second, bool reverseOrder = false) {
             std::vector<ExpressionID> thisExpressions = first.inputExpressions;
             std::sort(thisExpressions.begin(), thisExpressions.end());
             
             std::vector<ExpressionID> otherExpressions = second.inputExpressions;
             std::sort(otherExpressions.begin(), otherExpressions.end());
             
+            if (reverseOrder) {
+                std::reverse(thisExpressions.begin(), thisExpressions.end());
+                std::reverse(otherExpressions.begin(), otherExpressions.end());
+            }
             return compareVectors(thisExpressions, otherExpressions);
         }
         
@@ -32,15 +36,16 @@ namespace SetReplace {
     }
     
     bool Match::operator<(const Match& other) const {
-        // First rule goes first
-        if (rule != other.rule) return rule < other.rule;
-
-        // Then, find which Match has oldest (lowest ID) expressions
-        int sortedComparison = compareSortedIDs(*this, other);
+        // First, find which Match has oldest (lowest ID) expressions
+        int sortedComparison = compareSortedIDs(*this, other, true);
         if (sortedComparison != 0) return sortedComparison < 0;
 
-        // Finally, if sets of expressions are the same, use smaller permutation
-        return compareUnsortedIDs(*this, other) < 0;
+        // Then, if sets of expressions are the same, use smaller permutation
+        int unsortedComparison = compareUnsortedIDs(*this, other);
+        if (unsortedComparison != 0) return unsortedComparison < 0;
+        
+        // Finally, first rule goes first
+        return rule < other.rule;
     }
     
     class Matcher::Implementation {

--- a/SetReplace/setSubstitutionSystem$wl.m
+++ b/SetReplace/setSubstitutionSystem$wl.m
@@ -31,18 +31,14 @@ PackageScope["setSubstitutionSystem$wl"]
 
 
 toNormalRules[input_List :> output_List] := Module[
-		{inputLength, untouchedElements, untouchedPatterns,
-		 inputPermutations, inputsWithUntouchedElements, outputWithUntouchedElements},
+		{inputLength, inputPermutations, heldOutput},
 	inputLength = Length @ input;
-	untouchedElements = Table[Unique[], inputLength + 1];
-	untouchedPatterns = Pattern[#, ___] & /@ untouchedElements;
 
 	inputPermutations = Permutations @ input;
-	inputsWithUntouchedElements = Riffle[untouchedPatterns, #] & /@ inputPermutations;
-	outputWithUntouchedElements = Join[untouchedElements, Thread @ Hold @ output];
+	heldOutput = Thread @ Hold @ output;
 
-	With[{right = outputWithUntouchedElements},
-		# :> right & /@ inputsWithUntouchedElements] /. Hold[expr_] :> expr
+	With[{right = heldOutput},
+		# :> right & /@ inputPermutations] /. Hold[expr_] :> expr
 ] 
 
 
@@ -70,7 +66,40 @@ toNormalRules[input_List :> output_Module] := Module[
 (*If there are multiple rules, we just join them*)
 
 
-toNormalRules[rules_List] := Join @@ toNormalRules /@ rules
+toNormalRules[rules_List] := Module[{
+		ruleNames, separateNormalRules, longestRuleLength, untouchedNames,
+		input, output},
+	ruleNames = Table[Unique[], Length[rules]];
+	separateNormalRules = toNormalRules /@ rules;
+	longestRuleLength = Max[Map[Length, separateNormalRules[[All, All, 1]], {2}]];
+	untouchedNames = Table[Unique[], longestRuleLength + 1];
+	input = List[
+		Shortest[Alternatives @@ Catenate[Transpose @ PadRight[
+			MapIndexed[
+				With[{patternName = ruleNames[[#2[[1]]]]},
+					Function[patternContent,
+						Pattern[patternName, patternContent]] /@ #] &,
+				Map[
+					PatternSequence @@ Riffle[
+						#,
+						Pattern[#, ___] & /@ untouchedNames,
+						{1, 2 Length[#] - 1, 2}] &,
+					separateNormalRules[[All, All, 1]],
+					{2}]],
+			Automatic,
+			nothing] /. nothing -> Nothing]],
+		With[{lastPatternName = Last @ untouchedNames}, Pattern[lastPatternName, ___]]];
+	output = Hold @ Catenate @ # & @ Prepend[
+		With[{ruleName = #[[1]], outputRule = #[[2]]},
+			Hold[Replace[{ruleName}, outputRule]]] & /@
+				Transpose[{
+					ruleNames,
+					With[{outputExpression = (Hold /@ #)[[2]]},
+							Except[{}] :> outputExpression] & /@
+						separateNormalRules[[All, 1]]}],
+		untouchedNames];
+	With[{evaluatedOutput = output}, input :> evaluatedOutput] //. Hold[expr_] :> expr
+]
 
 
 (* ::Subsection:: *)


### PR DESCRIPTION
## Changes

* Closes https://github.com/maxitg/SetReplace/issues/44.
* Changes the evaluation order to, by priority:
  * Least recent expressions are updated first. I.e., the most recent expression in the rule input must be as old as possible.
  * Expressions matched in the same order as the rules are written, or, if not possible, in the smallest permutation of that order (i.e., vector of set expression indices in the order of the rule input should be the smallest element wise).
  * Rule with the smallest index is used.
* Both LowLevel and Symbolic methods now use the new updating order.
* Adds unit tests for the updating order to `correctness.wlt`.

## Tests

* Run unit tests: `./build.wlt && ./install.wlt && ./test.wlt`.
* The oldest expressions are updated first, regardless of the rule index:
```
In[] := WolframModel[{{{1, 2}} -> {}, {{1, 2, 3}} -> {}}, {{1, 2, 3}, {1, 
   2}}, <|"Events" -> 1|>, "FinalState"]
```
```
Out[] = {{1, 2}}
```
* Oldest means more specifically least recent, i.e., the most recent expression updated should be as old as possible:
```
In[] := WolframModel[<|
  "PatternRules" -> {{{1, 2}, {2, 3}} -> {}, {{4, 5}, {5, 
       6}} -> {}}|>, {{1, 2}, {4, 5}, {5, 6}, {2, 3}}, <|
  "Events" -> 1|>, "FinalState"]
```
```
Out[] = {{1, 2}, {2, 3}}
```
* If the sets of matched expressions are the same for multiple rules, they are matched in the order the rules are written, even if the rule with a higher index has to be used:
```
In[] := WolframModel[<|
  "PatternRules" -> {{{1, 2, x_}, {1, 3, z_}} :> {{R1}}, {{1, 3, 
       x_}, {1, 2, z_}} :> {{R2}}}|>, {{1, 3, x}, {1, 2, y}}, <|
  "Events" -> 1|>, "FinalState"]
```
```
Out[] = {{R2}}
```
* Finally, only if the input expressions are exactly the same, the rule with the smaller index is used:
```
In[] := WolframModel[<|
  "PatternRules" -> {{{1, 2, x_}, {1, 2, z_}} :> {{R1}}, {{1, 2, 
       x_}, {1, 2, z_}} :> {{R2}}}|>, {{1, 2, x}, {1, 2, y}}, <|
  "Events" -> 1|>, "FinalState"]
```
```
Out[] = {{R1}}
```