### PR TITLE
HypergraphPlot: SpringElectricalPolygons

### DIFF
--- a/SetReplace/HypergraphPlot.m
+++ b/SetReplace/HypergraphPlot.m
@@ -107,15 +107,18 @@ toNormalEdges["Ordered"][hyperedge_] :=
 toNormalEdges["CyclicOpen" | "CyclicClosed"][hyperedge_] :=
 	DirectedEdge @@@ Append[Partition[hyperedge, 2, 1], hyperedge[[{-1, 1}]]]
 
-graphEmbedding[vertices_, edges_, edges_, layout_, coordinates_ : Automatic] := Reap[
-	GraphPlot[
-		Graph[vertices, edges],
-		GraphLayout -> layout,
-		VertexCoordinates -> coordinates,
-		VertexShapeFunction -> (Sow[#2 -> #, "v"] &),
-		EdgeShapeFunction -> (Sow[#2 -> #, "e"] &)],
-	{"v", "e"}
-][[2, All, 1]]
+graphEmbedding[vertices_, edges_, edges_, layout_, coordinates_ : Automatic] := Replace[
+	Reap[
+		GraphPlot[
+			Graph[vertices, edges],
+			GraphLayout -> layout,
+			VertexCoordinates -> coordinates,
+			VertexShapeFunction -> (Sow[#2 -> #, "v"] &),
+			EdgeShapeFunction -> (Sow[#2 -> #, "e"] &)],
+		{"v", "e"}][[2]],
+	el : Except[{}] :> el[[1]],
+	{1}
+]
 
 graphEmbedding[vertices_, vertexEmbeddingEdges_, edgeEmbeddingEdges_, layout_] := Module[{embedding},
 	embedding = GraphEmbedding[Graph[vertices, vertexEmbeddingEdges], layout];

--- a/SetReplace/HypergraphPlot.m
+++ b/SetReplace/HypergraphPlot.m
@@ -154,7 +154,23 @@ normalToHypergraphEmbedding[edges_, normalEdges_, normalEmbedding_] := Module[{
 	{vertexEmbedding, edgeEmbedding}
 ]
 
-drawEmbedding[embedding_] := Graphics[embedding[[{2, 1}, All, 2]] /. {
-	Point[p_] :> {Opacity[.7], Disk[p, 0.03]},
-	Polygon[pts_] :> {Opacity[.3], Polygon[pts]}
-}]
+drawEmbedding[embedding_] := Module[{embeddingShapes, points, lines, polygons},
+	embeddingShapes = embedding[[{2, 1}, All, 2]];
+	{points, lines, polygons, polygonBoundaries} = Cases[embeddingShapes, #, All] & /@ {
+		Point[p_] :> {
+			Directive[Hue[0.6, 0.2, 0.8], EdgeForm[Directive[GrayLevel[0], Opacity[0.7]]]],
+			Disk[p, 0.03]},
+		Line[pts_] :> {
+			Directive[Opacity[0.7], Hue[0.6, 0.7, 0.5]],
+			Line[pts]},
+		Polygon[pts_] :> {
+			Opacity[0.3],
+			Lighter[Hue[0.6, 0.7, 0.5], 0.7],
+			Polygon[pts]},
+		Polygon[pts_] :> {
+			EdgeForm[White],
+			Transparent,
+			Polygon[pts]}
+	};
+	Graphics[{polygons, polygonBoundaries, lines, points}]
+]

--- a/SetReplace/HypergraphPlot.m
+++ b/SetReplace/HypergraphPlot.m
@@ -162,15 +162,21 @@ hypergraphEmbedding[edgeType_, layout : "SpringElectricalPolygons"][edges_] := M
 
 (** Drawing **)
 
-drawEmbedding[vertexLabels_][embedding_] := Module[{embeddingShapes, points, lines, polygons, labels},
+drawEmbedding[vertexLabels_][embedding_] := Module[{
+		plotRange, vertexSize, arrowheadsSize, embeddingShapes, points, lines, polygons, labels},
+	plotRange = #2 - #1 & @@ MinMax[embedding[[1, All, 2, 1, 1, 1]]];
+	vertexSize = computeVertexSize[plotRange];
+	arrowheadsSize = computeArrowheadsSize[Length[embedding[[1]]], plotRange, vertexSize];
+
 	embeddingShapes = embedding[[{2, 1}, All, 2]];
 	{points, lines, polygons, polygonBoundaries} = Cases[embeddingShapes, #, All] & /@ {
 		Point[p_] :> {
 			Directive[Hue[0.6, 0.2, 0.8], EdgeForm[Directive[GrayLevel[0], Opacity[0.7]]]],
-			Disk[p, 0.03]},
+			Disk[p, vertexSize]},
 		Line[pts_] :> {
 			Directive[Opacity[0.7], Hue[0.6, 0.7, 0.5]],
-			Line[pts]},
+			Arrowheads[arrowheadsSize],
+			Arrow[pts]},
 		Polygon[pts_] :> {
 			Opacity[0.3],
 			Lighter[Hue[0.6, 0.7, 0.5], 0.7],
@@ -192,3 +198,9 @@ drawEmbedding[vertexLabels_][embedding_] := Module[{embeddingShapes, points, lin
 			EdgeShapeFunction -> None]];
 	Show[Graphics[{polygons, polygonBoundaries, lines, points}], labels]
 ]
+
+(*** Arrowhead and vertex sizes are approximately the same as GraphPlot ***)
+computeArrowheadsSize[vertexCount_ ? (# <= 20 &), plotRange_, vertexSize_] := Medium
+computeArrowheadsSize[vertexCount_ ? (# > 20 &), plotRange_, vertexSize_] := 1.25 * 2 * vertexSize / plotRange
+
+computeVertexSize[plotRange_] := 0.15 - 2. * 1 / (plotRange + 13.7)

--- a/SetReplace/HypergraphPlot.m
+++ b/SetReplace/HypergraphPlot.m
@@ -1,314 +1,44 @@
-(* ::Package:: *)
-
-(* ::Title:: *)
-(*HypergraphPlot*)
-
-
-(* ::Text:: *)
-(*We might want to visualize the list-elements of the set as directed hyperedges. We can do that by drawing each hyperedge as sequences of same-color normal 2-edges.*)
-
-
-(* ::Text:: *)
-(*We will have to work around the bug in Wolfram Language that prevents multi-edges appear in different colors regardless of their different styles.*)
-
-
 Package["SetReplace`"]
-
 
 PackageExport["HypergraphPlot"]
 
-
-(* ::Section:: *)
-(*Documentation*)
-
+(* Documentation *)
 
 HypergraphPlot::usage = usageString[
-	"HypergraphPlot[`s`, `opts`] plots a list of vertex lists `s` as a ",
-	"hypergraph."];
-
-
-(* ::Section:: *)
-(*Syntax Information*)
-
+	"HypergraphPlot[`s`, `opts`] plots a list of vertex lists `s` as a hypergraph."]
 
 SyntaxInformation[HypergraphPlot] = {"ArgumentsPattern" -> {_, OptionsPattern[]}};
 
-
-(* ::Section:: *)
-(*Argument Checks*)
-
-
-(* ::Subsection:: *)
-(*Argument count*)
-
-
-HypergraphPlot[args___] := 0 /;
-	!Developer`CheckArgumentCount[HypergraphPlot[args], 1, 1] && False
-
-
-(* ::Subsection:: *)
-(*Valid edges*)
-
-
-HypergraphPlot::invalidEdges =
-	"First argument of HypergraphPlot must be list of lists, where elements " ~~
-	"represent vertices."; 
-
-
-HypergraphPlot[edges_, o : OptionsPattern[]] := 0 /;
-	!MatchQ[edges, {___List}] && Message[HypergraphPlot::invalidEdges]
-
-
-(* ::Section:: *)
-(*Options*)
-
-
-(* ::Text:: *)
-(*"HyperedgeType" can be set to: "Unordered" (sequence of edges), "Cyclic" (same, but last vertex connected to the first), and "Ordered" (all vertices connected in a complete graph).*)
-
-
 Options[HypergraphPlot] = Join[{
-	"HyperedgeType" -> "Ordered",
-	PlotStyle -> ColorData[97],
-	DataRange -> Automatic,
-	GraphLayout -> Automatic,
-	VertexCoordinates -> Automatic,
-	VertexLabels -> Automatic,
-	VertexShapeFunction -> Automatic,
-	VertexSize -> Automatic,
-	VertexStyle -> Automatic},
+	},
 	Options[Graphics]];
 
+(* Evaluation *)
 
-(* ::Section:: *)
-(*Implementation*)
-
-
-(* ::Subsection:: *)
-(*parsePlotStyle*)
-
-
-HypergraphPlot::notColor =
-	"PlotStyle `1` at index `2` should return a color instead of `3`.";
-
-
-parsePlotStyle[hyperedgeCount_, style_] := Module[{result, failedQ = False},
-	result = If[!failedQ,
-		Module[{color},
-			color = style[#];
-			If[!ColorQ[color],
-				Message[HypergraphPlot::notColor, style, #, color];
-				failedQ = True];
-				color
-		]
-	] & /@ Range[hyperedgeCount];
-	If[failedQ, $Failed, result]
+HypergraphPlot[args___] := With[{result = hypergraphPlot$dispatch[args]},
+	result /; result =!= $Failed
 ]
 
+(* Messages *)
 
-(* ::Subsection:: *)
-(*parseHyperedgeType*)
+HypergraphPlot::invalidEdges =
+	"First argument of HypergraphPlot must be list of lists, where elements represent vertices.";
 
+HypergraphPlot::optx =
+	"Unknown option `1` in `2`.";
 
-$hyperedgeTypes = {"Ordered", "Cyclic", "Unordered"};
+(* Arguments parsing *)
 
-
-HypergraphPlot::unknownHyperedgeType = "HyperedgeType `1` should be one of `2`.";
-
-
-parseHyperedgeType[hyperedges_, opt : _String | _Rule] :=
-	parseHyperedgeType[hyperedges, {opt}]
-
-
-parseHyperedgeType[hyperedges_, opt : {(_String | _Rule)...}] := Module[{
-		result, incorrectCase},
-	result = Replace[
-		hyperedges,
-		Reverse @ Prepend[
-			Replace[opt, s_String :> _ -> s, {1}],
-			_ -> OptionValue[HypergraphPlot, "HyperedgeType"]],
-		{1}];
-	If[!MissingQ[incorrectCase = FirstCase[
-			result, Except[Alternatives @@ $hyperedgeTypes], Missing[], {1}]],
-		Message[HypergraphPlot::unknownHyperedgeType,
-			incorrectCase, $hyperedgeTypes];
+hypergraphPlot$dispatch[args___] := Switch[{args},
+	{a___} /; !Developer`CheckArgumentCount[HypergraphPlot[a], 1, 1],
 		$Failed,
-		result
-	]
-]
+	{edges : Except[{___List}], ___},
+		Message[HypergraphPlot::invalidEdges];
+		$Failed,
+	{edges_, o : OptionsPattern[HypergraphPlot]} /;
+			Quiet[Check[OptionValue[HypergraphPlot, {o}, ImageSize]]; False, True],
 
-
-HypergraphPlot::invalidHyperedgeType =
-	"HyperedgeType `1` should be a string or a list of rules.";
-
-
-parseHyperedgeType[hyperedges_, opt_] := (
-	Message[HypergraphPlot::invalidHyperedgeType, opt];
-	$Failed)
-
-
-(* ::Subsection:: *)
-(*hyperedgeToEdges*)
-
-
-hyperedgeToEdges[hyperedge_, "Ordered"] := DirectedEdge @@@ Partition[hyperedge, 2, 1]
-
-
-hyperedgeToEdges[hyperedge_, "Cyclic"] :=
-	DirectedEdge @@@ Append[Partition[hyperedge, 2, 1], hyperedge[[{-1, 1}]]]
-
-
-hyperedgeToEdges[hyperedge_, "Unordered"] := UndirectedEdge @@@ Subsets[hyperedge, {2}]
-
-
-(* ::Subsection:: *)
-(*parseGraphLayout*)
-
-
-$graphLayoutStages = {"VertexLayout", "EdgeLayout", "PackingLayout"};
-
-
-parseGraphLayout[Automatic] := {Automatic, Automatic, Automatic}
-
-
-parseGraphLayout[vertexLayout_String] := {vertexLayout, Automatic, Automatic}
-
-
-parseGraphLayout[rules_List] /;
-		SubsetQ[$graphLayoutStages, Keys[Association[rules]]] :=
-	Lookup[Association[rules], #, Automatic] & /@ $graphLayoutStages
-
-
-HypergraphPlot::invalidGraphLayout =
-	"GraphLayout `1` should be Automatic, a string, or a list of rules with keys `2`.";
-
-
-parseGraphLayout[opt_] := (
-	Message[HypergraphPlot::invalidGraphLayout, opt, $graphLayoutStages];
-	ConstantArray[$Failed, 3])
-
-
-(* ::Subsection:: *)
-(*embedEdges*)
-
-
-edgeSort[UndirectedEdge[a_, b_]] := Sort[UndirectedEdge[a, b]]
-
-
-edgeSort[DirectedEdge[a_, b_]] := DirectedEdge[a, b]
-
-
-embedEdges[
-			edgeLayout :
-				"Normal" | "DividedEdgeBundling" |
-				"HierarchicalEdgeBundling" | "StraightLine",
-			set_,
-			hyperedgeTypes_,
-			vertexCoordinateRules_] := Module[{
-		vertices, normalEdges, normalEdgeCoordinateRules, normalEdgeIndices,
-		indexedSegments},
-	vertices = vertexCoordinateRules[[All, 1]];
-	normalEdges =
-		hyperedgeToEdges[#1, #2] & @@@ Transpose[{set, hyperedgeTypes}];
-	
-	normalEdgeCoordinateRules = Reap[GraphPlot[
-		Graph[vertices, Catenate @ normalEdges],
-		GraphLayout -> {"EdgeLayout" -> Replace[edgeLayout, "Normal" -> Automatic]},
-		EdgeShapeFunction -> (Sow[edgeSort[#2] -> #] &),
-		VertexCoordinates -> vertexCoordinateRules[[All, 2]]]][[2, 1]];
-	normalEdgeIndices = Catenate @ MapIndexed[edgeSort[#] -> #2 &, normalEdges, {2}];
-	indexedSegments = Association[Rule @@@ Transpose[{
-		Sort[normalEdgeIndices][[All, 2]],
-		Sort[normalEdgeCoordinateRules][[All, 2]]}]];
-	Thread[{
-		MapIndexed[indexedSegments[#2] &, Range /@ Length /@ normalEdges, {2}],
-		set}]
-]
-
-
-(* ::Subsection:: *)
-(*drawEdges*)
-
-
-drawEdges[edgeEmbedding_, colors_, types_] := Module[{meanArrowLength, graphicsSize},
-	meanArrowLength = Median[
-		Total[EuclideanDistance @@@ Partition[#, 2, 1]] & /@
-			Catenate @ edgeEmbedding[[All, 1]]];
-	graphicsSize =
-		#2 - #1 & @@ CoordinateBounds[Flatten[edgeEmbedding[[All, 1]], 2]][[1]];
-	{Arrowheads[0.07 meanArrowLength / graphicsSize],
-		Function[edgePart, {#2, If[#3 == "Unordered", Line, Arrow][edgePart]}] /@
-					# & @@@
-				Transpose[{#[[1, All, 1]], #[[2]], #[[3]]}] & @
-			{edgeEmbedding, colors, types}}
-]
-
-
-(* ::Subsection:: *)
-(*HypergraphPlot*)
-
-
-HypergraphPlot[set : {___List}, o : OptionsPattern[]] := Module[{
-		failedQ = False, hyperedgeColors, vertexLayout, edgeLayout, packingLayout,
-		hyperedgeTypes, graphForEmbedding, embedding, vertexCoordinateRules,
-		vertices, vertexColors, graphPlotOptions, graphForPlotting,
-		edgeEmbedding, edgeGraphics, result},
-	hyperedgeTypes = parseHyperedgeType[set, OptionValue["HyperedgeType"]];
-	hyperedgeColors = parsePlotStyle[Length[set], OptionValue[PlotStyle]];
-	{vertexLayout, edgeLayout, packingLayout} =
-		parseGraphLayout[OptionValue[GraphLayout]];
-	If[hyperedgeTypes === $Failed ||
-			hyperedgeColors === $Failed ||
-			vertexLayout === $Failed,
-		failedQ = True];
-	
-	If[!failedQ,
-		graphForEmbedding = Graph[
-			Catenate[hyperedgeToEdges[#1, #2] & @@@
-				Transpose[{set, hyperedgeTypes}]]];
-		embedding = If[OptionValue[VertexCoordinates] === Automatic,
-			GraphEmbedding[
-				graphForEmbedding,
-				Replace[vertexLayout, Automatic -> "SpringElectricalEmbedding"]],
-			OptionValue[VertexCoordinates]];
-		If[MatchQ[
-				embedding,
-				{Repeated[
-					{Repeated[_ ? NumericQ, {2}]},
-					{VertexCount[graphForEmbedding]}]}],
-			vertexCoordinateRules = Thread[VertexList[graphForEmbedding] -> embedding];
-			edgeEmbedding = embedEdges[
-				Replace[edgeLayout, Automatic -> "Normal"],
-				set,
-				hyperedgeTypes,
-				vertexCoordinateRules];
-			If[Head[edgeEmbedding] === embedEdges, failedQ = True];,
-			
-			failedQ = True
-		];
-		If[!failedQ,
-			edgeGraphics =
-				drawEdges[edgeEmbedding, hyperedgeColors, hyperedgeTypes];
-			
-			vertices = Union @ Flatten @ set;
-			vertexColors = (# -> ColorData[97, Count[set, {#}] + 1] & /@ vertices);
-			
-			graphForPlotting = Graph[vertices, {}];
-			graphPlotOptions = FilterRules[
-				FilterRules[{o}, Options[GraphPlot]],
-				Except[GraphLayout | VertexCoordinates]];
-			result = Show[
-				Graphics[edgeGraphics],
-				GraphPlot[
-					graphForPlotting,
-					Join[
-						graphPlotOptions, {
-						VertexStyle -> vertexColors,
-						GraphLayout -> {"PackingLayout" -> packingLayout},
-						VertexCoordinates ->
-							(VertexList[graphForPlotting] /.
-								vertexCoordinateRules)}]]];
-		];
-	];
-	result /; !failedQ && Head[result] =!= GraphPlot
+		$Failed,
+	_,
+		"evaluated"
 ]

--- a/SetReplace/HypergraphPlot.m
+++ b/SetReplace/HypergraphPlot.m
@@ -9,36 +9,60 @@ HypergraphPlot::usage = usageString[
 
 SyntaxInformation[HypergraphPlot] = {"ArgumentsPattern" -> {_, OptionsPattern[]}};
 
-Options[HypergraphPlot] = Join[{
-	},
-	Options[Graphics]];
-
-(* Evaluation *)
-
-HypergraphPlot[args___] := With[{result = hypergraphPlot$dispatch[args]},
-	result /; result =!= $Failed
-]
+Options[HypergraphPlot] = Options[Graphics];
 
 (* Messages *)
+
+HypergraphPlot::notImplemented = "Not implemented: `1`.";
 
 HypergraphPlot::invalidEdges =
 	"First argument of HypergraphPlot must be list of lists, where elements represent vertices.";
 
-HypergraphPlot::optx =
-	"Unknown option `1` in `2`.";
+(* Evaluation *)
+
+func : HypergraphPlot[args___] := Module[{result = hypergraphPlot$parse[args]},
+	If[Head[result] === hypergraphPlot$failing,
+		Message[HypergraphPlot::notImplemented, Defer[func]];
+		result = $Failed];
+	result /; Head[result] =!= $Failed
+]
 
 (* Arguments parsing *)
 
-hypergraphPlot$dispatch[args___] := Switch[{args},
-	{a___} /; !Developer`CheckArgumentCount[HypergraphPlot[a], 1, 1],
-		$Failed,
-	{edges : Except[{___List}], ___},
-		Message[HypergraphPlot::invalidEdges];
-		$Failed,
-	{edges_, o : OptionsPattern[HypergraphPlot]} /;
-			Quiet[Check[OptionValue[HypergraphPlot, {o}, ImageSize]]; False, True],
+hypergraphPlot$parse[args___] /; !Developer`CheckArgumentCount[HypergraphPlot[args], 1, 1] := $Failed
 
-		$Failed,
-	_,
-		"evaluated"
+hypergraphPlot$parse[edges : Except[{___List}], o : OptionsPattern[]] := (
+	Message[HypergraphPlot::invalidEdges];
+	$Failed
+)
+
+hypergraphPlot$parse[args : PatternSequence[edges_, o : OptionsPattern[]]] := With[{
+		unknownOptions = Complement @@ {{o}, Options[HypergraphPlot]}[[All, All, 1]]},
+	If[Length[unknownOptions] > 0,
+		Message[HypergraphPlot::optx, unknownOptions[[1]], Defer[HypergraphPlot[args]]]
+	];
+	$Failed /; Length[unknownOptions] > 0
 ]
+
+hypergraphPlot$parse[edges : {___List}, o : OptionsPattern[]] := hypergraphPlot[edges, {o}]
+
+(* Implementation *)
+
+hypergraphPlot[edges_, graphicsOptions_] :=
+	Graphics[(styleShapes @ embeddingShapes @ hypergraphEmbedding @ edges)[[All, All, 2]], graphicsOptions]
+
+(** hypergraphEmbedding produces an embedding of vertices and edges. The format is {vertices, edges},
+			where both vertices and edges are associations of the form <|vertex -> {graphicsPrimitive, ...}, ...|>,
+			where graphicsPrimitive is either a Point, a Line, or a Polygon. **)
+
+hypergraphEmbedding[edges_] := Module[{vertices},
+	vertices = Union[Flatten[edges]];
+	{
+		# -> {Point[RandomReal[1, 2]]} & /@ vertices,
+		# -> {Line[RandomReal[1, {2, 2}]], Polygon[RandomReal[1, {3, 2}]]} & /@ edges
+	}
+]
+
+embeddingShapes[embedding_] := embedding
+
+styleShapes[shapes_] := shapes

--- a/SetReplace/HypergraphPlot.m
+++ b/SetReplace/HypergraphPlot.m
@@ -94,7 +94,7 @@ hypergraphEmbedding[edgeType_, layout : "SpringElectricalEmbedding"][edges_] := 
 		If[# === {}, Identity[#], Most[#]] & /@ # &,
 		Identity][
 			vertexEmbeddingNormalEdges];
-	Echo @ normalToHypergraphEmbedding[
+	normalToHypergraphEmbedding[
 		edges,
 		edgeEmbeddingNormalEdges,
 		graphEmbedding[

--- a/SetReplace/HypergraphPlot.m
+++ b/SetReplace/HypergraphPlot.m
@@ -161,12 +161,13 @@ hypergraphEmbedding[edgeType_, layout : "SpringElectricalPolygons"][edges_] := M
 	vertexEmbedding = embeddingWithNoRegions[[1]];
 	edgePoints =
 		Flatten[#, 2] & /@ (embeddingWithNoRegions[[2, All, 2]] /. {Line[pts_] :> {pts}, Point[pts_] :> {{pts}}});
-	edgeRegions = ConvexHullMesh /@ edgePoints;
 	edgePolygons = Map[
 		Polygon,
-		MapThread[
-			Table[#[[polygon]], {polygon, #2}] &,
-			{MeshCoordinates /@ edgeRegions, MeshCells[#, 2][[All, 1]] & /@ edgeRegions}],
+		Map[
+			With[{region = ConvexHullMesh[#]},
+				Table[MeshCoordinates[region][[polygon]], {polygon, MeshCells[region, 2][[All, 1]]}]
+			] &,
+			edgePoints],
 		{2}];
 	edgeEmbedding = MapThread[#1[[1]] -> Join[#1[[2]], #2] &, {embeddingWithNoRegions[[2]], edgePolygons}];
 	{vertexEmbedding, edgeEmbedding}

--- a/SetReplace/HypergraphPlot.wlt
+++ b/SetReplace/HypergraphPlot.wlt
@@ -117,50 +117,24 @@ VerificationTest[
 
 (** Simple examples **)
 
-VerificationTest[
-  Head[HypergraphPlot[{{1, 3}, {2, 4}}]],
-  Graphics
-]
+$edgeTypes = {"Ordered", "CyclicOpen", "CyclicClosed"};
 
-VerificationTest[
-  Head[HypergraphPlot[{}]],
-  Graphics
-]
+$simpleHypergraphs = {
+  {{1, 3}, {2, 4}},
+  {},
+  {{}},
+  {{1}},
+  {{1}, {1}},
+  {{1}, {2}},
+  {{1}, {1}, {2}},
+  {{1, 2}, {1}},
+  {{1, 2}, {1}, {}}
+};
 
-VerificationTest[
-  Head[HypergraphPlot[{{}}]],
+Table[VerificationTest[
+  Head[HypergraphPlot[hypergraph, "EdgeType" -> #]],
   Graphics
-]
-
-VerificationTest[
-  Head[HypergraphPlot[{{1}}]],
-  Graphics
-]
-
-VerificationTest[
-  Head[HypergraphPlot[{{1}, {1}}]],
-  Graphics
-]
-
-VerificationTest[
-  Head[HypergraphPlot[{{1}, {2}}]],
-  Graphics
-]
-
-VerificationTest[
-  Head[HypergraphPlot[{{1}, {1}, {2}}]],
-  Graphics
-]
-
-VerificationTest[
-  Head[HypergraphPlot[{{1, 2}, {1}}]],
-  Graphics
-]
-
-VerificationTest[
-  Head[HypergraphPlot[{{1, 2}, {1}, {}}]],
-  Graphics
-]
+] & /@ $edgeTypes, {hypergraph, $simpleHypergraphs}]
 
 (** Large graphs **)
 

--- a/SetReplace/HypergraphPlot.wlt
+++ b/SetReplace/HypergraphPlot.wlt
@@ -128,6 +128,11 @@ VerificationTest[
 ]
 
 VerificationTest[
+  Head[HypergraphPlot[{{}}]],
+  Graphics
+]
+
+VerificationTest[
   Head[HypergraphPlot[{{1}}]],
   Graphics
 ]
@@ -149,6 +154,11 @@ VerificationTest[
 
 VerificationTest[
   Head[HypergraphPlot[{{1, 2}, {1}}]],
+  Graphics
+]
+
+VerificationTest[
+  Head[HypergraphPlot[{{1, 2}, {1}, {}}]],
   Graphics
 ]
 

--- a/SetReplace/HypergraphPlot.wlt
+++ b/SetReplace/HypergraphPlot.wlt
@@ -231,4 +231,28 @@ VerificationTest[
     All]]
 ] & /@ $layoutTestHypergraphs
 
+(* Single-vertex edges *)
+
+VerificationTest[
+  HypergraphPlot[{{1}, {1, 2}}],
+  HypergraphPlot[{{1, 2}}],
+  SameTest -> (Not @* SameQ)
+]
+
+VerificationTest[
+  MissingQ[FirstCase[
+    HypergraphPlot[{{1, 2}}, VertexLabels -> None],
+    Circle[___],
+    Missing[],
+    All]]
+]
+
+VerificationTest[
+  !MissingQ[FirstCase[
+    HypergraphPlot[{{1}, {1, 2}}, VertexLabels -> Automatic],
+    Circle[___],
+    Missing[],
+    All]]
+]
+
 EndTestSection[]

--- a/SetReplace/HypergraphPlot.wlt
+++ b/SetReplace/HypergraphPlot.wlt
@@ -42,130 +42,75 @@ VerificationTest[
   {HypergraphPlot::invalidEdges}
 ]
 
-(** Valid PlotStyle **)
+(** Valid EdgeType **)
 
 VerificationTest[
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, PlotStyle -> Red],
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, PlotStyle -> Red],
-  {HypergraphPlot::notColor}
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "EdgeType" -> None],
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "EdgeType" -> None],
+  {HypergraphPlot::invalidFiniteOption}
 ]
 
 VerificationTest[
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, PlotStyle -> 23],
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, PlotStyle -> 23],
-  {HypergraphPlot::notColor}
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "EdgeType" -> "$$$Incorrect$$$"],
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "EdgeType" -> "$$$Incorrect$$$"],
+  {HypergraphPlot::invalidFiniteOption}
 ]
 
 VerificationTest[
-  FreeQ[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, PlotStyle -> ColorData[1]], ColorData[1, 1]],
-  False
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "EdgeType" -> {"$$$Incorrect$$$"}],
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "EdgeType" -> {"$$$Incorrect$$$"}],
+  {HypergraphPlot::invalidFiniteOption}
 ]
 
 VerificationTest[
-  FreeQ[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, PlotStyle -> ColorData[1]], ColorData[1, 2]],
-  False
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "EdgeType" -> {{1, 2, 3} -> "$$$Incorrect$$$"}],
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "EdgeType" -> {{1, 2, 3} -> "$$$Incorrect$$$"}],
+  {HypergraphPlot::invalidFiniteOption}
 ]
 
 VerificationTest[
-  FreeQ[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, PlotStyle -> ColorData[1]], ColorData[1, 3]],
-  True
-]
-
-(** Valid HyperedgeType **)
-
-VerificationTest[
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeType" -> None],
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeType" -> None],
-  {HypergraphPlot::invalidHyperedgeType}
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "EdgeType" -> {None, {1, 2, 3} -> "Ordered"}],
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "EdgeType" -> {None, {1, 2, 3} -> "Ordered"}],
+  {HypergraphPlot::invalidFiniteOption}
 ]
 
 VerificationTest[
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeType" -> "$$$Incorrect$$$"],
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeType" -> "$$$Incorrect$$$"],
-  {HypergraphPlot::unknownHyperedgeType}
-]
-
-VerificationTest[
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeType" -> {"$$$Incorrect$$$"}],
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeType" -> {"$$$Incorrect$$$"}],
-  {HypergraphPlot::unknownHyperedgeType}
-]
-
-VerificationTest[
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeType" -> {{1, 2, 3} -> "$$$Incorrect$$$"}],
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeType" -> {{1, 2, 3} -> "$$$Incorrect$$$"}],
-  {HypergraphPlot::unknownHyperedgeType}
-]
-
-VerificationTest[
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeType" -> {None, {1, 2, 3} -> "Ordered"}],
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeType" -> {None, {1, 2, 3} -> "Ordered"}],
-  {HypergraphPlot::invalidHyperedgeType}
-]
-
-VerificationTest[
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeType" -> {"$$$Incorrect$$$", {1, 2, 3} -> "Ordered"}],
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeType" -> {"$$$Incorrect$$$", {1, 2, 3} -> "Ordered"}],
-  {HypergraphPlot::unknownHyperedgeType}
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "EdgeType" -> {"$$$Incorrect$$$", {1, 2, 3} -> "Ordered"}],
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "EdgeType" -> {"$$$Incorrect$$$", {1, 2, 3} -> "Ordered"}],
+  {HypergraphPlot::invalidFiniteOption}
 ]
 
 VerificationTest[
   HypergraphPlot[
     {{1, 2, 3}, {3, 4, 5}},
-    "HyperedgeType" -> {{3, 4, 5} -> "Ordered", {1, 2, 3} -> "$$$Incorrect$$$"}],
+    "EdgeType" -> {{3, 4, 5} -> "Ordered", {1, 2, 3} -> "$$$Incorrect$$$"}],
   HypergraphPlot[
     {{1, 2, 3}, {3, 4, 5}},
-    "HyperedgeType" -> {{3, 4, 5} -> "Ordered", {1, 2, 3} -> "$$$Incorrect$$$"}],
-  {HypergraphPlot::unknownHyperedgeType}
+    "EdgeType" -> {{3, 4, 5} -> "Ordered", {1, 2, 3} -> "$$$Incorrect$$$"}],
+  {HypergraphPlot::invalidFiniteOption}
 ]
 
 VerificationTest[
-  Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeType" -> "Ordered"]],
+  Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "EdgeType" -> "Ordered"]],
   Graphics
 ]
 
 VerificationTest[
-  Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeType" -> "Cyclic"]],
+  Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "EdgeType" -> "CyclicOpen"]],
   Graphics
 ]
 
 VerificationTest[
-  Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeType" -> "Unordered"]],
+  Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "EdgeType" -> "CyclicClosed"]],
   Graphics
 ]
 
-VerificationTest[
-  Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeType" -> {"Ordered"}]],
-  Graphics
-]
+(* Valid options *)
 
 VerificationTest[
-  Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeType" -> {{1, 2, 3} -> "Cyclic"}]],
-  Graphics
-]
-
-VerificationTest[
-  Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeType" -> {"Cyclic", {1, 2, 3} -> "Ordered"}]],
-  Graphics
-]
-
-VerificationTest[
-  Head[HypergraphPlot[
-    {{1, 2, 3}, {3, 4, 5}},
-    "HyperedgeType" -> {{3, 4, 5} -> "Unordered", {1, 2, 3} -> "Cyclic"}]],
-  Graphics
-]
-
-VerificationTest[
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeType" -> {"Cyclic", {1, 2, 3} -> 123}],
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeType" -> {"Cyclic", {1, 2, 3} -> 123}],
-  {HypergraphPlot::unknownHyperedgeType}
-]
-
-(*** {1, 2, 4} never appears in the hypergraph, so is never used. ***)
-VerificationTest[
-  Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeType" -> {"Cyclic", {1, 2, 4} -> 123}]],
-  Graphics
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "$$$InvalidOption###" -> True],
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "$$$InvalidOption###" -> True],
+  {HypergraphPlot::optx}
 ]
 
 (* Implementation *)
@@ -174,6 +119,36 @@ VerificationTest[
 
 VerificationTest[
   Head[HypergraphPlot[{{1, 3}, {2, 4}}]],
+  Graphics
+]
+
+VerificationTest[
+  Head[HypergraphPlot[{}]],
+  Graphics
+]
+
+VerificationTest[
+  Head[HypergraphPlot[{{1}}]],
+  Graphics
+]
+
+VerificationTest[
+  Head[HypergraphPlot[{{1}, {1}}]],
+  Graphics
+]
+
+VerificationTest[
+  Head[HypergraphPlot[{{1}, {2}}]],
+  Graphics
+]
+
+VerificationTest[
+  Head[HypergraphPlot[{{1}, {1}, {2}}]],
+  Graphics
+]
+
+VerificationTest[
+  Head[HypergraphPlot[{{1, 2}, {1}}]],
   Graphics
 ]
 
@@ -190,25 +165,9 @@ VerificationTest[
   Graphics
 ] & /@ {10, 5000}
 
-(* Vertices with single-vertex edges colored differently *)
+(* EdgeType *)
 
-VerificationTest[
-  FreeQ[HypergraphPlot[{{1, 2}}], ColorData[97, #]] & /@ {1, 2, 3},
-  {False, True, True}]
-
-VerificationTest[
-  FreeQ[HypergraphPlot[{{1}}], ColorData[97, #]] & /@ {1, 2, 3},
-  {True, False, True}]
-
-VerificationTest[
-  FreeQ[HypergraphPlot[{{1}, {1}}], ColorData[97, #]] & /@ {1, 2, 3},
-  {True, True, False}]
-
-(* HyperedgeType *)
-
-diskCoordinates[graphics_] := Sort[
-  #[[1, 1, Cases[#, Disk[i_, ___] :> i, All]]] & @
-    Cases[graphics, GraphicsComplex[___], All]]
+diskCoordinates[graphics_] := Sort[Cases[graphics, Disk[i_, ___] :> i, All]]
 
 $layoutTestHypergraphs = {
   {{1, 2, 3}, {3, 4, 5}},
@@ -219,7 +178,7 @@ $layoutTestHypergraphs = {
 };
 
 VerificationTest[
-  diskCoordinates[HypergraphPlot[#, "HyperedgeType" -> "Ordered"]],
+  diskCoordinates[HypergraphPlot[#, "EdgeType" -> "Ordered"]],
   Sort @ GraphEmbedding[
     Rule @@@ Catenate[Partition[#, 2, 1] & /@ #],
     "SpringElectricalEmbedding"],
@@ -227,7 +186,7 @@ VerificationTest[
 ] & /@ $layoutTestHypergraphs
 
 VerificationTest[
-  diskCoordinates[HypergraphPlot[#, "HyperedgeType" -> "Cyclic"]],
+  diskCoordinates[HypergraphPlot[#, "EdgeType" -> "CyclicOpen"]],
   Sort @ GraphEmbedding[
     Rule @@@ Catenate[Append[Partition[#, 2, 1], #[[{-1, 1}]]] & /@ #],
     "SpringElectricalEmbedding"],
@@ -235,49 +194,57 @@ VerificationTest[
 ] & /@ $layoutTestHypergraphs
 
 VerificationTest[
-  diskCoordinates[HypergraphPlot[#, "HyperedgeType" -> "Unordered"]],
+  diskCoordinates[HypergraphPlot[#, "EdgeType" -> "CyclicClosed"]],
   Sort @ GraphEmbedding[
-    Rule @@@ Catenate[Subsets[#, {2}] & /@ #],
+    Rule @@@ Catenate[Append[Partition[#, 2, 1], #[[{-1, 1}]]] & /@ #],
     "SpringElectricalEmbedding"],
   SameTest -> Equal
 ] & /@ $layoutTestHypergraphs
 
 VerificationTest[
-  diskCoordinates[HypergraphPlot[#, "HyperedgeType" -> "Ordered"]],
-  diskCoordinates[HypergraphPlot[#, "HyperedgeType" -> "Cyclic"]],
+  diskCoordinates[HypergraphPlot[#, "EdgeType" -> "Ordered"]],
+  diskCoordinates[HypergraphPlot[#, "EdgeType" -> "CyclicOpen"]],
   SameTest -> (Not @* Equal)
 ] & /@ $layoutTestHypergraphs
 
 VerificationTest[
-  diskCoordinates[HypergraphPlot[#, "HyperedgeType" -> "Ordered"]],
-  diskCoordinates[HypergraphPlot[#, "HyperedgeType" -> "Unordered"]],
-  SameTest -> (Not @* Equal)
-] & /@ $layoutTestHypergraphs
-
-VerificationTest[
-  diskCoordinates[HypergraphPlot[#, "HyperedgeType" -> "Unordered"]],
-  diskCoordinates[HypergraphPlot[#, "HyperedgeType" -> "Cyclic"]],
-  SameTest -> (Not @* Equal)
-] & /@ $layoutTestHypergraphs
-
-VerificationTest[
-  diskCoordinates[HypergraphPlot[
-    {{1, 2, 3, 4, 5, 6}, {1, 2, 3, 4}},
-    "HyperedgeType" -> {"Ordered", {_, _, _, _} -> "Cyclic"}]],
-  Sort @ GraphEmbedding[
-    {1 -> 2, 2 -> 3, 3 -> 4, 4 -> 5, 5 -> 6, 1 -> 2, 2 -> 3, 3 -> 4, 4 -> 1},
-    "SpringElectricalEmbedding"],
+  diskCoordinates[HypergraphPlot[#, "EdgeType" -> "CyclicOpen"]],
+  diskCoordinates[HypergraphPlot[#, "EdgeType" -> "CyclicClosed"]],
   SameTest -> Equal
-]
+] & /@ $layoutTestHypergraphs
 
 VerificationTest[
-  diskCoordinates[HypergraphPlot[
-    {{1, 2, 3, 4, 5, 6}, {1, 2, 3, 4}},
-    "HyperedgeType" -> {"Ordered", {_, _, _, _} -> "Cyclic"}]],
-  diskCoordinates[HypergraphPlot[
-    {{1, 2, 3, 4, 5, 6}, {1, 2, 3, 4}},
-    "HyperedgeType" -> {"Ordered"}]],
-  SameTest -> (Not @* Equal)
-]
+  MissingQ[FirstCase[
+    HypergraphPlot[#, GraphLayout -> "SpringElectricalEmbedding"],
+    Polygon[___],
+    Missing[],
+    All]]
+] & /@ $layoutTestHypergraphs
+
+VerificationTest[
+  !MissingQ[FirstCase[
+    HypergraphPlot[#, GraphLayout -> "SpringElectricalPolygons"],
+    Polygon[___],
+    Missing[],
+    All]]
+] & /@ $layoutTestHypergraphs
+
+(* VertexLabels *)
+
+VerificationTest[
+  MissingQ[FirstCase[
+    HypergraphPlot[#, VertexLabels -> None],
+    Text[___],
+    Missing[],
+    All]]
+] & /@ $layoutTestHypergraphs
+
+VerificationTest[
+  !MissingQ[FirstCase[
+    HypergraphPlot[#, VertexLabels -> Automatic],
+    Text[___],
+    Missing[],
+    All]]
+] & /@ $layoutTestHypergraphs
 
 EndTestSection[]

--- a/SetReplace/performance.wlt
+++ b/SetReplace/performance.wlt
@@ -76,22 +76,16 @@ $largeSet = WolframModel[
 {$normalPlotTiming, $normalPlotMemory} =
   AbsoluteTiming[MaxMemoryUsed[GraphPlot[Rule @@@ Catenate[Partition[#, 2, 1] & /@ $largeSet]]]];
 
-VerificationTest[
-  Head[HypergraphPlot[$largeSet, "HyperedgeType" -> "Ordered"]],
-  Graphics,
-  TimeConstraint -> (2 $normalPlotTiming),
-  MemoryConstraint -> (5 $normalPlotMemory)]
+$edgeTypes = {"Ordered", "CyclicOpen", "CyclicClosed"};
+$layouts = {"SpringElectricalEmbedding", "SpringElectricalPolygons"};
 
-VerificationTest[
-  Head[HypergraphPlot[$largeSet, "HyperedgeType" -> "Cyclic"]],
-  Graphics,
-  TimeConstraint -> (2 $normalPlotTiming),
-  MemoryConstraint -> (5 $normalPlotMemory)]
-
-VerificationTest[
-  Head[HypergraphPlot[$largeSet, "HyperedgeType" -> "Unordered"]],
-  Graphics,
-  TimeConstraint -> (2 $normalPlotTiming),
-  MemoryConstraint -> (5 $normalPlotMemory)]
+Table[
+  VerificationTest[
+    Head[HypergraphPlot[$largeSet, "EdgeType" -> edgeType, GraphLayout -> layout]],
+    Graphics,
+    TimeConstraint -> (3 $normalPlotTiming),
+    MemoryConstraint -> (5 $normalPlotMemory)],
+  {edgeType, $edgeTypes},
+  {layout, $layouts}]
 
 EndTestSection[]


### PR DESCRIPTION
## Changes

* `HypergraphPlot` is reimplemented from scratch.
* Different graph layouts can now be supported, initially `"SpringElectricalEmbedding"` and `"SpringElectricalPolygons"`.
* `"HypergraphPlot"` now checks that option names passed to it are correct.
* Single-vertex edges are now shown as circles around the vertex.
* `"SpringElectricalPolygons"` draws a hyperedge as a convex polygon around all its vertices and normal edges.
* Closes #30 .
* Closes #82 .

## Removed features

* `PlotStyle` is temporarily removed. Will be added in a future PR.
* Consequently, all hyperedges now have to be the same color.
* `"EdgeType" -> "Unordered"` is removed, will be added in a future PR.
* Performance is about 3 times worse than `GraphPlot`, worse than 2 times worse it was previously.

## Notes

* `RulePlot` will be added in a separate PR.
* `"BraneElectricalEmbedding"`, `"SpringElectricalCurves"`, and `"CommunityRegions"` will be added in future PRs.

## Tests

* Run tests: `./build.wls && ./install.wls && ./test.wls`.
* Plot a simple hypergraph:
```
In[] := HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}]
```
![image](https://user-images.githubusercontent.com/1479325/68100025-b01f4e00-fe93-11e9-9865-687b62daa8b9.png)
* Plot a hypergraph with a self-loop:
```
In[] := HypergraphPlot[{{1, 2, 3}, {3, 4, 5}, {1, 1, 1}}]
```
![image](https://user-images.githubusercontent.com/1479325/68100039-c5947800-fe93-11e9-9ebd-e14960bb6776.png)
* Or single-vertex edges:
```
In[] := HypergraphPlot[{{1, 2, 3}, {3, 4, 5}, {1}, {1}, {2}}]
```
![image](https://user-images.githubusercontent.com/1479325/68100067-efe63580-fe93-11e9-9161-5d4ea497f958.png)
* Label vertices:
```
In[] := HypergraphPlot[{{1, 2, 3}, {3, 4, 5}, {1}, {1}, {2}}, 
 VertexLabels -> Automatic]
```
![image](https://user-images.githubusercontent.com/1479325/68100081-fffe1500-fe93-11e9-8e89-287bfb766649.png)
* Use `"SpringElectricalEmbedding"` without regions:
```
In[] := HypergraphPlot[{{1, 2, 3}, {3, 4, 5}, {1}, {1}, {2}}, 
 GraphLayout -> "SpringElectricalEmbedding"]
```
![image](https://user-images.githubusercontent.com/1479325/68100129-4784a100-fe94-11e9-934c-74e44cc7b366.png)
* `"EdgeType" -> "Ordered"`:
```
In[] := HypergraphPlot[{{1, 2, 3}, {3, 4, 5}, {1}, {1}, {2}}, 
 "EdgeType" -> "Ordered"]
```
![image](https://user-images.githubusercontent.com/1479325/68100144-62571580-fe94-11e9-93f5-f1198517019f.png)
* `"EdgeType" -> "CyclicClosed"`:
```
In[] := HypergraphPlot[{{1, 2, 3}, {3, 4, 5}, {1}, {1}, {2}}, 
 "EdgeType" -> "CyclicClosed"]
```
![image](https://user-images.githubusercontent.com/1479325/68100155-7a2e9980-fe94-11e9-92e8-ebae86bb6cd1.png)
