### PR TITLE
HypergraphPlot: VertexCoordinates

### DIFF
--- a/SetReplace/HypergraphPlot.m
+++ b/SetReplace/HypergraphPlot.m
@@ -12,7 +12,7 @@ SyntaxInformation[HypergraphPlot] = {"ArgumentsPattern" -> {_, OptionsPattern[]}
 Options[HypergraphPlot] = Join[{
 	"EdgeType" -> "CyclicOpen",
 	GraphLayout -> "SpringElectricalPolygons",
-	VertexCoordinates -> Automatic,
+	VertexCoordinates -> {},
 	VertexLabels -> None},
 	Options[Graphics]];
 
@@ -31,7 +31,7 @@ HypergraphPlot::invalidFiniteOption =
 	"Value `2` of option `1` should be one of `3`.";
 
 HypergraphPlot::invalidCoordinates =
-	"Coordinates `1` should be either Automatic, or a list of rules from vertices to pairs of numbers.";
+	"Coordinates `1` should be a list of rules from vertices to pairs of numbers.";
 
 (* Evaluation *)
 
@@ -87,12 +87,12 @@ hypergraphPlot$parse[edges_, o : OptionsPattern[]] := Module[{
 
 hypergraphPlot$parse[edges : {___List}, o : OptionsPattern[]] :=
 	hypergraphPlot[edges, ##, FilterRules[{o}, Options[Graphics]]] & @@
-		(OptionValue[HypergraphPlot, {o}, #] & /@ {"EdgeType", GraphLayout, VertexLabels})
+		(OptionValue[HypergraphPlot, {o}, #] & /@ {"EdgeType", GraphLayout, VertexCoordinates, VertexLabels})
 
 (* Implementation *)
 
-hypergraphPlot[edges_, edgeType_, layout_, vertexLabels_, graphicsOptions_] :=
-	Show[drawEmbedding[vertexLabels] @ hypergraphEmbedding[edgeType, layout] @ edges, graphicsOptions]
+hypergraphPlot[edges_, edgeType_, layout_, vertexCoordinates_, vertexLabels_, graphicsOptions_] :=
+	Show[drawEmbedding[vertexLabels] @ hypergraphEmbedding[edgeType, layout, vertexCoordinates] @ edges, graphicsOptions]
 
 (** Embedding **)
 (** hypergraphEmbedding produces an embedding of vertices and edges. The format is {vertices, edges},
@@ -101,7 +101,7 @@ hypergraphPlot[edges_, edgeType_, layout_, vertexLabels_, graphicsOptions_] :=
 
 (*** SpringElectricalEmbedding ***)
 
-hypergraphEmbedding[edgeType_, layout : "SpringElectricalEmbedding"][edges_] := Module[{
+hypergraphEmbedding[edgeType_, layout : "SpringElectricalEmbedding", vertexCoordinates_][edges_] := Module[{
 		vertices, vertexEmbeddingNormalEdges, edgeEmbeddingNormalEdges},
 	vertices = Union[Flatten[edges]];
 	vertexEmbeddingNormalEdges = toNormalEdges[edgeType] /@ edges;
@@ -170,9 +170,9 @@ normalToHypergraphEmbedding[edges_, normalEdges_, normalEmbedding_] := Module[{
 
 (*** SpringElectricalPolygons ***)
 
-hypergraphEmbedding[edgeType_, layout : "SpringElectricalPolygons"][edges_] := Module[{
-		embeddingWithNoRegions, vertexEmbedding, edgePoints, edgeRegions, edgePolygons, edgeEmbedding},
-	embeddingWithNoRegions = hypergraphEmbedding[edgeType, "SpringElectricalEmbedding"][edges];
+hypergraphEmbedding[edgeType_, layout : "SpringElectricalPolygons", vertexCoordinates_][edges_] := Module[{
+		embeddingWithNoRegions, vertexEmbedding, edgePoints, edgePolygons, edgeEmbedding},
+	embeddingWithNoRegions = hypergraphEmbedding[edgeType, "SpringElectricalEmbedding", vertexCoordinates][edges];
 	vertexEmbedding = embeddingWithNoRegions[[1]];
 	edgePoints =
 		Flatten[#, 2] & /@ (embeddingWithNoRegions[[2, All, 2]] /. {Line[pts_] :> {pts}, Point[pts_] :> {{pts}}});

--- a/SetReplace/HypergraphPlot.m
+++ b/SetReplace/HypergraphPlot.m
@@ -134,21 +134,28 @@ graphEmbedding[vertices_, vertexEmbeddingEdges_, edgeEmbeddingEdges_, layout_, c
 ]
 
 constrainedGraphEmbedding[graph_, layout_, coordinateRules_] := Module[{
-		indexGraph, vertexToIndex, relevantCoordinateRules, graphPlot},
+		indexGraph, vertexToIndex, relevantCoordinateRules, graphPlot, graphPlotCoordinateRules, displacement},
 	indexGraph = IndexGraph[graph];
 	vertexToIndex = Thread[VertexList[graph] -> VertexList[indexGraph]];
 	relevantCoordinateRules =
-		Select[MemberQ[vertexToIndex[[All, 1]], #[[1]]] &][coordinateRules];
+		Normal[Merge[Select[MemberQ[vertexToIndex[[All, 1]], #[[1]]] &][coordinateRules], Last]];
 	graphPlot = GraphPlot[
 		indexGraph, {
 		Method -> layout,
 		PlotTheme -> "Classic",
-		If[relevantCoordinateRules =!= {},
+		If[Length[relevantCoordinateRules] > 1,
 			VertexCoordinateRules ->
 				Thread[(relevantCoordinateRules[[All, 1]] /. vertexToIndex) ->
 					relevantCoordinateRules[[All, 2]]],
 			Nothing]}];
-	VertexCoordinateRules /. Cases[graphPlot, _Rule, Infinity]
+	graphPlotCoordinateRules = VertexCoordinateRules /. Cases[graphPlot, _Rule, Infinity];
+	If[Length[relevantCoordinateRules] != 1,
+		graphPlotCoordinateRules,
+		displacement =
+			relevantCoordinateRules[[1, 2]] -
+			(relevantCoordinateRules[[1, 1]] /. Thread[VertexList[graph] -> graphPlotCoordinateRules]);
+		# + displacement & /@ graphPlotCoordinateRules
+	]
 ]
 
 graphEmbedding[vertices_, edges_, layout_, coordinates_] := Replace[

--- a/SetReplace/HypergraphPlot.m
+++ b/SetReplace/HypergraphPlot.m
@@ -198,7 +198,7 @@ hypergraphEmbedding[edgeType_, layout : "SpringElectricalPolygons", vertexCoordi
 	edgePolygons = Map[
 		Polygon,
 		Map[
-			With[{region = ConvexHullMesh[#]},
+			With[{region = ConvexHullMesh[Map[# + RandomReal[1.*^-10] &, #, {2}]]},
 				Table[MeshCoordinates[region][[polygon]], {polygon, MeshCells[region, 2][[All, 1]]}]
 			] &,
 			edgePoints],

--- a/SetReplace/HypergraphPlot.wlt
+++ b/SetReplace/HypergraphPlot.wlt
@@ -267,4 +267,20 @@ VerificationTest[
     {{0., 0.}, {1., 0.}})
 ]
 
+VerificationTest[
+  Chop @ diskCoordinates[HypergraphPlot[
+    {{1, 2, 3}, {3, 4, 5}},
+    VertexCoordinates -> {3 -> {0, 0}}]],
+  Table[{0, 0}, 5],
+  SameTest -> (Not @* Equal)
+]
+
+VerificationTest[
+  Chop @ diskCoordinates[HypergraphPlot[
+    {{1, 2, 3}, {3, 4, 5}},
+    VertexCoordinates -> {3 -> {1, 0}, 3 -> {0, 0}}]],
+  Table[{0, 0}, 5],
+  SameTest -> (Not @* Equal)
+]
+
 EndTestSection[]

--- a/SetReplace/HypergraphPlot.wlt
+++ b/SetReplace/HypergraphPlot.wlt
@@ -255,4 +255,15 @@ VerificationTest[
     All]]
 ]
 
+(* VertexCoordinates *)
+
+VerificationTest[
+  And @@ (MemberQ[
+      diskCoordinates[HypergraphPlot[
+        {{1, 2, 3}, {3, 4, 5}, {3, 3}},
+        VertexCoordinates -> {1 -> {0, 0}, 2 -> {1, 0}}]],
+      #] & /@
+    {{0., 0.}, {1., 0.}})
+]
+
 EndTestSection[]

--- a/SetReplace/HypergraphPlot.wlt
+++ b/SetReplace/HypergraphPlot.wlt
@@ -113,6 +113,31 @@ VerificationTest[
   {HypergraphPlot::optx}
 ]
 
+(* Valid coordinates *)
+
+VerificationTest[
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, VertexCoordinates -> $$$invalid$$$],
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, VertexCoordinates -> $$$invalid$$$],
+  {HypergraphPlot::invalidCoordinates}
+]
+
+VerificationTest[
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, VertexCoordinates -> {{0, 0}}],
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, VertexCoordinates -> {{0, 0}}],
+  {HypergraphPlot::invalidCoordinates}
+]
+
+VerificationTest[
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, VertexCoordinates -> {1 -> {0}}],
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, VertexCoordinates -> {1 -> {0}}],
+  {HypergraphPlot::invalidCoordinates}
+]
+
+VerificationTest[
+  Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, VertexCoordinates -> {1 -> {0, 0}}]],
+  Graphics
+]
+
 (* Implementation *)
 
 (** Simple examples **)

--- a/SetReplace/HypergraphPlot.wlt
+++ b/SetReplace/HypergraphPlot.wlt
@@ -188,30 +188,6 @@ $layoutTestHypergraphs = {
 
 VerificationTest[
   diskCoordinates[HypergraphPlot[#, "EdgeType" -> "Ordered"]],
-  Sort @ GraphEmbedding[
-    Rule @@@ Catenate[Partition[#, 2, 1] & /@ #],
-    "SpringElectricalEmbedding"],
-  SameTest -> Equal
-] & /@ $layoutTestHypergraphs
-
-VerificationTest[
-  diskCoordinates[HypergraphPlot[#, "EdgeType" -> "CyclicOpen"]],
-  Sort @ GraphEmbedding[
-    Rule @@@ Catenate[Append[Partition[#, 2, 1], #[[{-1, 1}]]] & /@ #],
-    "SpringElectricalEmbedding"],
-  SameTest -> Equal
-] & /@ $layoutTestHypergraphs
-
-VerificationTest[
-  diskCoordinates[HypergraphPlot[#, "EdgeType" -> "CyclicClosed"]],
-  Sort @ GraphEmbedding[
-    Rule @@@ Catenate[Append[Partition[#, 2, 1], #[[{-1, 1}]]] & /@ #],
-    "SpringElectricalEmbedding"],
-  SameTest -> Equal
-] & /@ $layoutTestHypergraphs
-
-VerificationTest[
-  diskCoordinates[HypergraphPlot[#, "EdgeType" -> "Ordered"]],
   diskCoordinates[HypergraphPlot[#, "EdgeType" -> "CyclicOpen"]],
   SameTest -> (Not @* Equal)
 ] & /@ $layoutTestHypergraphs


### PR DESCRIPTION
## Changes

* Adds the ability to constrain coordinates in HypergraphPlot.

## Tests

* Run unit tests: `./build.wls && ./install.wls && ./test.wls`.
* By default, `VertexCoordinates` for all vertices are chosen automatically:
```
In[] := HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, VertexCoordinates -> {}]
```
![image](https://user-images.githubusercontent.com/1479325/68101880-f24d8d00-fe9d-11e9-8449-36ae9c5a3596.png)
* One of the coordinates can be constrained:
```
In[] := HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, 
 VertexCoordinates -> {3 -> {0, 0}}, Axes -> True, 
 VertexLabels -> Automatic]
```
![image](https://user-images.githubusercontent.com/1479325/68103205-d9e07100-fea3-11e9-9887-794e88ec965d.png)
* Or more than one:
```
In[] := HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, 
 VertexCoordinates -> {1 -> {0, 0}, 2 -> {1, 0}}, Axes -> True, 
 VertexLabels -> Automatic]
```
![image](https://user-images.githubusercontent.com/1479325/68103221-e95fba00-fea3-11e9-91e2-bffad84ff56c.png)

## Known Issues

* Sometimes layout is not optimal due to bugs in the classic `"SpringElectricalEmbedding"` code:
```
In[] := HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, 
 VertexCoordinates -> {3 -> {0, 0}, 4 -> {1, 0}}, Axes -> True, 
 VertexLabels -> Automatic]
```
![image](https://user-images.githubusercontent.com/1479325/68103265-0dbb9680-fea4-11e9-8157-4851e9dcd009.png)
