### PR TITLE
Graph highlight

### DIFF
--- a/SetReplace/HypergraphPlot.m
+++ b/SetReplace/HypergraphPlot.m
@@ -90,7 +90,7 @@ hypergraphPlot$parse[edges_, o : OptionsPattern[]] := Module[{
 ]
 
 hypergraphPlot$parse[edges_, o : OptionsPattern[]] := Module[{
-		highlight, validQ},
+		highlight, vertices, validQ},
 	highlight = OptionValue[HypergraphPlot, {o}, GraphHighlight];
 	vertices = Union[Catenate[edges]];
 	validQ = ListQ[highlight] && (And @@ (MemberQ[Join[vertices, edges], #] & /@ highlight));

--- a/SetReplace/HypergraphPlot.wlt
+++ b/SetReplace/HypergraphPlot.wlt
@@ -138,6 +138,41 @@ VerificationTest[
   Graphics
 ]
 
+(* Valid GraphHighlight *)
+
+VerificationTest[
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> $$$invalid$$$],
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> $$$invalid$$$],
+  {HypergraphPlot::invalidHighlight}
+]
+
+VerificationTest[
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {6}],
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {6}],
+  {HypergraphPlot::invalidHighlight}
+]
+
+VerificationTest[
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {{1, 2}}],
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {{1, 2}}],
+  {HypergraphPlot::invalidHighlight}
+]
+
+VerificationTest[
+  Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {1}]],
+  Graphics
+]
+
+VerificationTest[
+  Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {{1, 2, 3}}]],
+  Graphics
+]
+
+VerificationTest[
+  Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {4, {1, 2, 3}}]],
+  Graphics
+]
+
 (* Implementation *)
 
 (** Simple examples **)
@@ -282,5 +317,12 @@ VerificationTest[
   Table[{0, 0}, 5],
   SameTest -> (Not @* Equal)
 ]
+
+(* GraphHighlight *)
+
+VerificationTest[
+  Length[Union @ Cases[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {#}], _ ? ColorQ, All]] >
+    Length[Union @ Cases[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}], _ ? ColorQ, All]]
+] & /@ {4, {1, 2, 3}}
 
 EndTestSection[]

--- a/SetReplace/performance.wlt
+++ b/SetReplace/performance.wlt
@@ -84,7 +84,7 @@ Table[
     Head[HypergraphPlot[$largeSet, "EdgeType" -> edgeType, GraphLayout -> layout]],
     Graphics,
     TimeConstraint -> (3 $normalPlotTiming),
-    MemoryConstraint -> (5 $normalPlotMemory)],
+    MemoryConstraint -> (6 $normalPlotMemory)],
   {edgeType, $edgeTypes},
   {layout, $layouts}]
 


### PR DESCRIPTION
## Changes

* Closes #87 .
* Implements `"GraphHighlight"` option of `HypergraphPlot`, which allows highlighting vertices and edges similar to `GraphPlot`.

## Tests

* Run unit tests: `./build.wls && ./install.wls && ./test.wls`.
* Highlight a vertex in a hypergraph:
```
In[] := HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {3}]
```
![image](https://user-images.githubusercontent.com/1479325/68106963-41e98400-feb1-11e9-9460-aee08b14a632.png)
* Highlight an edge:
```
In[] := HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {{1, 2, 3}}]
```
![image](https://user-images.githubusercontent.com/1479325/68106976-4dd54600-feb1-11e9-9ff3-189636e7eb8d.png)
* Highlight multiple vertices and edges:
```
In[] := HypergraphPlot[{{1, 2, 3}, {3, 4, 5}, {5, 6, 6}}, 
 GraphHighlight -> {{5, 6, 6}, {1, 2, 3}, 4}]
```
![image](https://user-images.githubusercontent.com/1479325/68106995-647b9d00-feb1-11e9-9abc-08ce21127c2c.png)
* This works with other layouts as well:
```
In[] := HypergraphPlot[{{1, 2, 3}, {3, 4, 5}, {5, 6, 6}}, 
 GraphHighlight -> {{5, 6, 6}, {1, 2, 3}, 4}, 
 GraphLayout -> "SpringElectricalEmbedding"]
```
![image](https://user-images.githubusercontent.com/1479325/68107012-765d4000-feb1-11e9-839d-e9f63d2421f6.png)
