### PR TITLE
RulePlot

### DIFF
--- a/SetReplace/HypergraphPlot.m
+++ b/SetReplace/HypergraphPlot.m
@@ -199,7 +199,7 @@ edgeScale[{vertexEmbedding_, edgeEmbedding : Except[{}]}] := Module[{selfLoops},
 	Mean[lineLength /@ N /@ If[selfLoops =!= {}, $selfLoopsScale * selfLoops, edgeEmbedding[[All, 2]]]]
 ]
 
-edgeScale[{{}, _}] := 1
+edgeScale[{{} | {_ -> _}, _}] := 1
 
 edgeScale[{vertexEmbedding_, {}}] :=
 	lineLength[Transpose[MinMax /@ Transpose[vertexEmbedding[[All, 2]]]]] /

--- a/SetReplace/HypergraphPlot.m
+++ b/SetReplace/HypergraphPlot.m
@@ -58,6 +58,9 @@ hypergraphPlot$parse[edges : Except[{___List}], o : OptionsPattern[]] := (
 	$Failed
 )
 
+hypergraphPlot$parse[args : PatternSequence[edges_, o : OptionsPattern[]]] :=
+	$Failed /; !knownOptionsQ[HypergraphPlot, Defer[HypergraphPlot[args]], {o}]
+
 hypergraphPlot$parse[args : PatternSequence[edges_, o : OptionsPattern[]]] := With[{
 		unknownOptions = Complement @@ {{o}, Options[HypergraphPlot]}[[All, All, 1]]},
 	If[Length[unknownOptions] > 0,
@@ -71,15 +74,6 @@ hypergraphPlot$parse[edges_, o : OptionsPattern[]] /;
 			{"EdgeType", $edgeTypes},
 			{GraphLayout, $graphLayouts}})) :=
 	$Failed
-
-supportedOptionQ[func_, optionToCheck_, validValues_, opts_] := Module[{value, supportedQ},
-	value = OptionValue[func, {opts}, optionToCheck];
-	supportedQ = MemberQ[validValues, value];
-	If[!supportedQ,
-		Message[MessageName[func, "invalidFiniteOption"], optionToCheck, value, validValues]
-	];
-	supportedQ
-]
 
 hypergraphPlot$parse[edges_, o : OptionsPattern[]] := Module[{
 		result, vertexCoordinates},

--- a/SetReplace/HypergraphPlot.m
+++ b/SetReplace/HypergraphPlot.m
@@ -268,44 +268,10 @@ $highlightColor = Hue[1.0, 1.0, 0.7];
 $edgeColor = Hue[0.6, 0.7, 0.5];
 $vertexColor = Hue[0.6, 0.2, 0.8];
 
-arrow[arrowheadLength_, vertexSize_][pts_] := Module[{ptsStartToArrowEnd, ptsStartToLineEnd},
-	ptsStartToArrowEnd = lineTake[pts, vertexSize ;; - vertexSize];
-	ptsStartToLineEnd = lineTake[ptsStartToArrowEnd, 0 ;; - arrowheadLength];
-	{
-		Line[ptsStartToLineEnd],
-		If[Length[ptsStartToArrowEnd] > 1,
-			arrowhead[
-				Last[ptsStartToArrowEnd],
-				Normalize[ptsStartToArrowEnd[[-1]] - ptsStartToLineEnd[[-1]]],
-				arrowheadLength],
-			Nothing]
-	}
-]
-
 $arrowheadShape = Polygon[{
 	{-1.10196, -0.289756}, {-1.08585, -0.257073}, {-1.05025, -0.178048}, {-1.03171, -0.130243}, {-1.01512, -0.0824391},
 	{-1.0039, -0.037561}, {-1., 0.}, {-1.0039, 0.0341466}, {-1.01512, 0.0780486}, {-1.03171, 0.127805},
 	{-1.05025, 0.178538}, {-1.08585, 0.264878}, {-1.10196, 0.301464}, {0., 0.}, {-1.10196, -0.289756}}];
-
-arrowhead[endPt_, direction_, length_] :=
-	(Translate[#, endPt] &) @
-	(Rotate[#, {{1, 0}, direction}] &) @
-	(Scale[#, length, {0, 0}] &) @
-	$arrowheadShape
-
-lineTake[pts_, start_ ;; end_] := Reverse[lineDrop[Reverse[lineDrop[pts, start]], -end]]
-
-lineDrop[pts_, length_] /; Length[pts] > 2 := With[{
-		firstSegmentLength = EuclideanDistance @@ pts[[{1, 2}]]},
-	If[firstSegmentLength <= length,
-		lineDrop[Rest[pts], length - firstSegmentLength],
-		Join[lineDrop[pts[[{1, 2}]], length], Drop[pts, 2]]
-	]
-]
-
-lineDrop[{pt1_, pt2_}, length_] := {pt1 + Normalize[pt2 - pt1] * length, pt2}
-
-lineDrop[pts : ({_} | {}), _] := pts
 
 drawEmbedding[vertexLabels_, highlight_, vertexSize_, arrowheadLength_][embedding_] := Module[{
 		embeddingShapes, vertexPoints, lines, polygons, polygonBoundaries, edgePoints, labels, singleVertexEdgeCounts,
@@ -335,7 +301,7 @@ drawEmbedding[vertexLabels_, highlight_, vertexSize_, arrowheadLength_][embeddin
 				Directive[Opacity[1], $highlightColor],
 				Directive[Opacity[0.7], $edgeColor]
 			],
-			arrow[arrowheadLength, vertexSize][pts]},
+			arrow[$arrowheadShape, arrowheadLength, vertexSize][pts]},
 		highlighted[Polygon[pts_], h_] :> {
 			Opacity[0.3],
 			If[h,

--- a/SetReplace/HypergraphPlot.m
+++ b/SetReplace/HypergraphPlot.m
@@ -235,6 +235,8 @@ edgeScale[{vertexEmbedding_, edgeEmbedding : Except[{}]}] := Module[{selfLoops},
 	Mean[RegionMeasure /@ Line /@ N /@ If[selfLoops =!= {}, $selfLoopsScale * selfLoops, edgeEmbedding[[All, 2]]]]
 ]
 
+edgeScale[{{}, _}] := 1
+
 edgeScale[{vertexEmbedding_, {}}] :=
 	RegionMeasure[Line[Transpose[MinMax /@ Transpose[vertexEmbedding[[All, 2]]]]]] /
 		(Sqrt[N[Length[vertexEmbedding]] / 2])

--- a/SetReplace/HypergraphPlot.m
+++ b/SetReplace/HypergraphPlot.m
@@ -191,20 +191,22 @@ rescaleEmbedding[unscaledEmbedding_, {v_ -> pivotPoint_}] :=
 
 rescaleEmbedding[unscaledEmbedding_, {}] := rescaleEmbedding[unscaledEmbedding, {0 -> {0.0, 0.0}}]
 
+lineLength[pts_] := Total[EuclideanDistance @@@ Partition[pts, 2, 1]]
+
 $selfLoopsScale = 0.7;
 edgeScale[{vertexEmbedding_, edgeEmbedding : Except[{}]}] := Module[{selfLoops},
 	selfLoops = Select[#[[1, 1]] == #[[1, 2]] &][edgeEmbedding][[All, 2]];
-	Mean[RegionMeasure /@ Line /@ N /@ If[selfLoops =!= {}, $selfLoopsScale * selfLoops, edgeEmbedding[[All, 2]]]]
+	Mean[lineLength /@ N /@ If[selfLoops =!= {}, $selfLoopsScale * selfLoops, edgeEmbedding[[All, 2]]]]
 ]
 
 edgeScale[{{}, _}] := 1
 
 edgeScale[{vertexEmbedding_, {}}] :=
-	RegionMeasure[Line[Transpose[MinMax /@ Transpose[vertexEmbedding[[All, 2]]]]]] /
+	lineLength[Transpose[MinMax /@ Transpose[vertexEmbedding[[All, 2]]]]] /
 		(Sqrt[N[Length[vertexEmbedding]] / 2])
 
 rescaleEmbedding[embedding_, center_, factor_] := Map[
-	(#[[1]] -> (#[[2]] /. coords : {Repeated[_ ? NumericQ, {2}]} :> (coords - center) * factor + center)) &,
+	(#[[1]] -> (#[[2]] /. coords : {Repeated[_Real, {2}]} :> (coords - center) * factor + center)) &,
 	embedding,
 	{2}
 ]

--- a/SetReplace/HypergraphPlot.m
+++ b/SetReplace/HypergraphPlot.m
@@ -9,7 +9,7 @@ PackageScope["hypergraphPlot"]
 (* Documentation *)
 
 HypergraphPlot::usage = usageString[
-	"HypergraphPlot[`s`, `opts`] plots a list of vertex lists `s` as a hypergraph."]
+	"HypergraphPlot[`s`, `opts`] plots a list of vertex lists `s` as a hypergraph."];
 
 SyntaxInformation[HypergraphPlot] = {"ArgumentsPattern" -> {_, OptionsPattern[]}};
 

--- a/SetReplace/HypergraphPlot.m
+++ b/SetReplace/HypergraphPlot.m
@@ -141,42 +141,19 @@ toNormalEdges["CyclicOpen" | "CyclicClosed"][hyperedge : Except[{}]] :=
 toNormalEdges["CyclicOpen" | "CyclicClosed"][{}] := {}
 
 graphEmbedding[vertices_, vertexEmbeddingEdges_, edgeEmbeddingEdges_, layout_, coordinateRules_] := Module[{
-		relevantCoordinateRules, vertexCoordinates, unscaledEmbedding},
+		relevantCoordinateRules, vertexCoordinateRules, unscaledEmbedding},
 	relevantCoordinateRules = Normal[Merge[Select[MemberQ[vertices, #[[1]]] &][coordinateRules], Last]];
-	vertexCoordinates = constrainedGraphEmbedding[Graph[vertices, vertexEmbeddingEdges], layout, relevantCoordinateRules];
-	unscaledEmbedding = graphEmbedding[vertices, edgeEmbeddingEdges, layout, vertexCoordinates];
+	vertexCoordinateRules = graphEmbedding[vertices, vertexEmbeddingEdges, layout, relevantCoordinateRules][[1]];
+	unscaledEmbedding = graphEmbedding[vertices, edgeEmbeddingEdges, layout, vertexCoordinateRules];
 	rescaleEmbedding[unscaledEmbedding, relevantCoordinateRules]
 ]
 
-constrainedGraphEmbedding[graph_, layout_, coordinateRules_] := Module[{
-		indexGraph, vertexToIndex, graphPlot, graphPlotCoordinateRules, displacement},
-	indexGraph = IndexGraph[graph];
-	vertexToIndex = Thread[VertexList[graph] -> VertexList[indexGraph]];
-	graphPlot = GraphPlot[
-		indexGraph, {
-		Method -> layout,
-		PlotTheme -> "Classic",
-		If[Length[coordinateRules] > 1,
-			VertexCoordinateRules ->
-				Thread[(coordinateRules[[All, 1]] /. vertexToIndex) ->
-					coordinateRules[[All, 2]]],
-			Nothing]}];
-	graphPlotCoordinateRules = VertexCoordinateRules /. Cases[graphPlot, _Rule, Infinity];
-	If[Length[coordinateRules] != 1,
-		graphPlotCoordinateRules,
-		displacement =
-			coordinateRules[[1, 2]] -
-			(coordinateRules[[1, 1]] /. Thread[VertexList[graph] -> graphPlotCoordinateRules]);
-		# + displacement & /@ graphPlotCoordinateRules
-	]
-]
-
-graphEmbedding[vertices_, edges_, layout_, coordinates_] := Replace[
+graphEmbedding[vertices_, edges_, layout_, coordinateRules_] := Replace[
 	Reap[
 		GraphPlot[
 			Graph[vertices, edges],
 			GraphLayout -> layout,
-			VertexCoordinates -> coordinates,
+			VertexCoordinateRules -> coordinateRules,
 			VertexShapeFunction -> (Sow[#2 -> #, "v"] &),
 			EdgeShapeFunction -> (Sow[#2 -> #, "e"] &)],
 		{"v", "e"}][[2]],

--- a/SetReplace/HypergraphPlot.m
+++ b/SetReplace/HypergraphPlot.m
@@ -226,8 +226,11 @@ edgeScale[{vertexEmbedding_, {}}] :=
 	RegionMeasure[Line[Transpose[MinMax /@ Transpose[vertexEmbedding[[All, 2]]]]]] /
 		(Sqrt[N[Length[vertexEmbedding]] / 2])
 
-rescaleEmbedding[embedding_, center_, factor_] := embedding /.
-	coords : {Repeated[_ ? NumericQ, {2}]} :> (coords - center) * factor + center
+rescaleEmbedding[embedding_, center_, factor_] := Map[
+	(#[[1]] -> (#[[2]] /. coords : {Repeated[_ ? NumericQ, {2}]} :> (coords - center) * factor + center)) &,
+	embedding,
+	{2}
+]
 
 (*** SpringElectricalPolygons ***)
 

--- a/SetReplace/HypergraphPlot.m
+++ b/SetReplace/HypergraphPlot.m
@@ -274,20 +274,24 @@ $highlightColor = Hue[1.0, 1.0, 0.7];
 $edgeColor = Hue[0.6, 0.7, 0.5];
 $vertexColor = Hue[0.6, 0.2, 0.8];
 
-arrow[arrowheadLength_, vertexSize_][pts_] := Module[{truncatedPts},
-	truncatedPts = lineTake[pts, vertexSize ;; - vertexSize];
+arrow[arrowheadLength_, vertexSize_][pts_] := Module[{ptsStartToArrowEnd, ptsStartToLineEnd},
+	ptsStartToArrowEnd = lineTake[pts, vertexSize ;; - vertexSize];
+	ptsStartToLineEnd = lineTake[ptsStartToArrowEnd, 0 ;; - arrowheadLength];
 	{
-		Line[truncatedPts],
-		If[Length[truncatedPts] > 1,
-			arrowhead[Last[truncatedPts], Normalize[truncatedPts[[-1]] - truncatedPts[[-2]]], arrowheadLength],
+		Line[ptsStartToLineEnd],
+		If[Length[ptsStartToArrowEnd] > 1,
+			arrowhead[
+				Last[ptsStartToArrowEnd],
+				Normalize[ptsStartToArrowEnd[[-1]] - ptsStartToLineEnd[[-1]]],
+				arrowheadLength],
 			Nothing]
 	}
 ]
 
 $arrowheadShape = Polygon[{
-	{-1., -0.262947}, {-0.985386, -0.233288}, {-0.953077, -0.161575}, {-0.936254, -0.118193}, {-0.921201, -0.0748117},
-	{-0.911019, -0.0340858}, {-0.907478, 0.}, {-0.911019, 0.0309873}, {-0.921201, 0.0708274}, {-0.936254, 0.11598},
-	{-0.953077, 0.162019}, {-0.985386, 0.240371}, {-1., 0.273572}, {0., 0.}, {-1., -0.262947}}];
+	{-1.10196, -0.289756}, {-1.08585, -0.257073}, {-1.05025, -0.178048}, {-1.03171, -0.130243}, {-1.01512, -0.0824391},
+	{-1.0039, -0.037561}, {-1., 0.}, {-1.0039, 0.0341466}, {-1.01512, 0.0780486}, {-1.03171, 0.127805},
+	{-1.05025, 0.178538}, {-1.08585, 0.264878}, {-1.10196, 0.301464}, {0., 0.}, {-1.10196, -0.289756}}];
 
 arrowhead[endPt_, direction_, length_] :=
 	(Translate[#, endPt] &) @

--- a/SetReplace/HypergraphPlot.m
+++ b/SetReplace/HypergraphPlot.m
@@ -89,7 +89,7 @@ hypergraphPlot$parse[edges_, o : OptionsPattern[]] := Module[{
 hypergraphPlot$parse[edges_, o : OptionsPattern[]] := Module[{
 		highlight, vertices, validQ},
 	highlight = OptionValue[HypergraphPlot, {o}, GraphHighlight];
-	vertices = Union[Catenate[edges]];
+	vertices = vertexList[edges];
 	validQ = ListQ[highlight] && (And @@ (MemberQ[Join[vertices, edges], #] & /@ highlight));
 	If[!validQ, Message[HypergraphPlot::invalidHighlight, highlight]];
 	$Failed /; !validQ
@@ -128,9 +128,9 @@ hypergraphPlot[
 
 (*** SpringElectricalEmbedding ***)
 
-hypergraphEmbedding[edgeType_, layout : "SpringElectricalEmbedding", vertexCoordinates_][edges_] := Module[{
+hypergraphEmbedding[edgeType_, layout : "SpringElectricalEmbedding", coordinateRules_][edges_] := Module[{
 		vertices, vertexEmbeddingNormalEdges, edgeEmbeddingNormalEdges},
-	vertices = Union[Catenate[edges]];
+	vertices = vertexList[edges];
 	vertexEmbeddingNormalEdges = toNormalEdges[edgeType] /@ edges;
 	edgeEmbeddingNormalEdges = If[edgeType === "CyclicOpen",
 		If[# === {}, Identity[#], Most[#]] & /@ # &,
@@ -144,7 +144,7 @@ hypergraphEmbedding[edgeType_, layout : "SpringElectricalEmbedding", vertexCoord
 			Catenate[vertexEmbeddingNormalEdges],
 			Catenate[edgeEmbeddingNormalEdges],
 			layout,
-			vertexCoordinates]]
+			coordinateRules]]
 ]
 
 toNormalEdges["Ordered"][hyperedge_] :=

--- a/SetReplace/HypergraphPlot.m
+++ b/SetReplace/HypergraphPlot.m
@@ -143,7 +143,10 @@ toNormalEdges["CyclicOpen" | "CyclicClosed"][{}] := {}
 graphEmbedding[vertices_, vertexEmbeddingEdges_, edgeEmbeddingEdges_, layout_, coordinateRules_] := Module[{
 		relevantCoordinateRules, vertexCoordinateRules, unscaledEmbedding},
 	relevantCoordinateRules = Normal[Merge[Select[MemberQ[vertices, #[[1]]] &][coordinateRules], Last]];
-	vertexCoordinateRules = graphEmbedding[vertices, vertexEmbeddingEdges, layout, relevantCoordinateRules][[1]];
+	vertexCoordinateRules = If[vertexEmbeddingEdges === edgeEmbeddingEdges,
+		relevantCoordinateRules,
+		graphEmbedding[vertices, vertexEmbeddingEdges, layout, relevantCoordinateRules][[1]]
+	];
 	unscaledEmbedding = graphEmbedding[vertices, edgeEmbeddingEdges, layout, vertexCoordinateRules];
 	rescaleEmbedding[unscaledEmbedding, relevantCoordinateRules]
 ]

--- a/SetReplace/HypergraphPlot.m
+++ b/SetReplace/HypergraphPlot.m
@@ -31,9 +31,6 @@ HypergraphPlot::notImplemented =
 HypergraphPlot::invalidEdges =
 	"First argument of HypergraphPlot must be list of lists, where elements represent vertices.";
 
-HypergraphPlot::invalidFiniteOption =
-	"Value `2` of option `1` should be one of `3`.";
-
 HypergraphPlot::invalidCoordinates =
 	"Coordinates `1` should be a list of rules from vertices to pairs of numbers.";
 

--- a/SetReplace/HypergraphPlot.wlt
+++ b/SetReplace/HypergraphPlot.wlt
@@ -319,4 +319,49 @@ VerificationTest[
     Length[Union @ Cases[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}], _ ? ColorQ, All]]
 ] & /@ {4, {1, 2, 3}}
 
+(* Scaling consistency *)
+(* Vertex sizes, arrow sizes, average edge lengths, and loop lengths should always be the same. *)
+
+VerificationTest[
+  SameQ @@ (
+    Union[Cases[HypergraphPlot[#], Disk[_, r_] :> r, All]] & /@
+      {{{1}}, {{1, 2, 3}}, {{1, 2, 3}, {3, 4, 5}}, RandomInteger[10, {5, 5}]})
+]
+
+VerificationTest[
+  SameQ @@ (
+    Union[Cases[HypergraphPlot[#, GraphLayout -> "SpringElectricalEmbedding"], p : Polygon[___] :> Area[p], All]] & /@
+      {{{1, 2}}, {{1, 2, 3}}, {{1, 2, 3}, {3, 4, 5}}, RandomInteger[10, {5, 5}]})
+]
+
+VerificationTest[
+  Equal @@ (
+    Mean[Cases[
+        HypergraphPlot[#, GraphLayout -> "SpringElectricalEmbedding"],
+        Line[pts_] :> EuclideanDistance @@ pts,
+        All]] & /@
+      {{{1, 2}}, {{1, 2, 3}}, {{1, 2, 3}, {3, 4, 5}}, {{1, 2, 3}, {3, 4, 5}, {5, 6, 1}}, {{1, 2, 3, 4, 5, 1}}})
+]
+
+$selfLoopLength = FirstCase[
+  HypergraphPlot[{{1, 1}}, GraphLayout -> "SpringElectricalEmbedding"],
+  Line[pts_] :> RegionMeasure[Line[pts]],
+  Missing[],
+  All];
+
+VerificationTest[
+  And @@ (
+    MemberQ[
+        Cases[
+          HypergraphPlot[#, GraphLayout -> "SpringElectricalEmbedding"],
+          Line[pts_] :> RegionMeasure[Line[pts]],
+          All],
+        $selfLoopLength] & /@ {
+      {{1, 1}},
+      {{1, 2, 3}, {1, 1}},
+      {{1, 2, 3}, {3, 4, 5}, {5, 5}},
+      {{1, 2, 3}, {3, 4, 5}, {5, 6, 1, 1}},
+      {{1, 2, 3, 4, 5, 5, 1}}})
+]
+
 EndTestSection[]

--- a/SetReplace/HypergraphPlot.wlt
+++ b/SetReplace/HypergraphPlot.wlt
@@ -116,25 +116,25 @@ VerificationTest[
 (* Valid coordinates *)
 
 VerificationTest[
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, VertexCoordinates -> $$$invalid$$$],
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, VertexCoordinates -> $$$invalid$$$],
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, VertexCoordinateRules -> $$$invalid$$$],
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, VertexCoordinateRules -> $$$invalid$$$],
   {HypergraphPlot::invalidCoordinates}
 ]
 
 VerificationTest[
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, VertexCoordinates -> {{0, 0}}],
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, VertexCoordinates -> {{0, 0}}],
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, VertexCoordinateRules -> {{0, 0}}],
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, VertexCoordinateRules -> {{0, 0}}],
   {HypergraphPlot::invalidCoordinates}
 ]
 
 VerificationTest[
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, VertexCoordinates -> {1 -> {0}}],
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, VertexCoordinates -> {1 -> {0}}],
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, VertexCoordinateRules -> {1 -> {0}}],
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, VertexCoordinateRules -> {1 -> {0}}],
   {HypergraphPlot::invalidCoordinates}
 ]
 
 VerificationTest[
-  Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, VertexCoordinates -> {1 -> {0, 0}}]],
+  Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, VertexCoordinateRules -> {1 -> {0, 0}}]],
   Graphics
 ]
 
@@ -291,13 +291,13 @@ VerificationTest[
     All]]
 ]
 
-(* VertexCoordinates *)
+(* VertexCoordinateRules *)
 
 VerificationTest[
   And @@ (MemberQ[
       diskCoordinates[HypergraphPlot[
         {{1, 2, 3}, {3, 4, 5}, {3, 3}},
-        VertexCoordinates -> {1 -> {0, 0}, 2 -> {1, 0}}]],
+        VertexCoordinateRules -> {1 -> {0, 0}, 2 -> {1, 0}}]],
       #] & /@
     {{0., 0.}, {1., 0.}})
 ]
@@ -305,7 +305,7 @@ VerificationTest[
 VerificationTest[
   Chop @ diskCoordinates[HypergraphPlot[
     {{1, 2, 3}, {3, 4, 5}},
-    VertexCoordinates -> {3 -> {0, 0}}]],
+    VertexCoordinateRules -> {3 -> {0, 0}}]],
   Table[{0, 0}, 5],
   SameTest -> (Not @* Equal)
 ]
@@ -313,7 +313,7 @@ VerificationTest[
 VerificationTest[
   Chop @ diskCoordinates[HypergraphPlot[
     {{1, 2, 3}, {3, 4, 5}},
-    VertexCoordinates -> {3 -> {1, 0}, 3 -> {0, 0}}]],
+    VertexCoordinateRules -> {3 -> {1, 0}, 3 -> {0, 0}}]],
   Table[{0, 0}, 5],
   SameTest -> (Not @* Equal)
 ]

--- a/SetReplace/HypergraphPlot.wlt
+++ b/SetReplace/HypergraphPlot.wlt
@@ -312,6 +312,14 @@ VerificationTest[
   SameTest -> (Not @* Equal)
 ]
 
+(** Same coordinates should not produce any messages **)
+VerificationTest[
+  And @@ Cases[
+    HypergraphPlot[{{1, 2, 3}}, VertexCoordinateRules -> {1 -> {1, 0}, 2 -> {1, 0}}],
+    Rotate[_, {v1_, v2_}] :> v1 != {0, 0} && v2 != {0, 0},
+    All]
+]
+
 (* GraphHighlight *)
 
 VerificationTest[

--- a/SetReplace/HypergraphPlot.wlt
+++ b/SetReplace/HypergraphPlot.wlt
@@ -228,25 +228,19 @@ VerificationTest[
 ] & /@ $layoutTestHypergraphs
 
 VerificationTest[
-  diskCoordinates[HypergraphPlot[#, "EdgeType" -> "CyclicOpen"]],
-  diskCoordinates[HypergraphPlot[#, "EdgeType" -> "CyclicClosed"]],
-  SameTest -> Equal
-] & /@ $layoutTestHypergraphs
-
-VerificationTest[
-  MissingQ[FirstCase[
+  Length[Union[Cases[
     HypergraphPlot[#, GraphLayout -> "SpringElectricalEmbedding"],
     Polygon[___],
-    Missing[],
-    All]]
+    All]]],
+  1
 ] & /@ $layoutTestHypergraphs
 
 VerificationTest[
-  !MissingQ[FirstCase[
+  Length[Union[Cases[
     HypergraphPlot[#, GraphLayout -> "SpringElectricalPolygons"],
     Polygon[___],
-    Missing[],
-    All]]
+    All]]],
+  1 + Length[#]
 ] & /@ $layoutTestHypergraphs
 
 (* VertexLabels *)

--- a/SetReplace/RulePlot.m
+++ b/SetReplace/RulePlot.m
@@ -20,7 +20,7 @@ Options[RulePlot] = Join[Options[RulePlot], $newOptions];
 SyntaxInformation[RulePlot] = Join[
   FilterRules[SyntaxInformation[RulePlot], Except["OptionNames"]],
   {"OptionNames" -> Join[("OptionNames" /. SyntaxInformation[RulePlot]), $newOptions[[All, 1]]]}
-]
+];
 Protect[RulePlot];
 
 (* Parameters *)
@@ -35,7 +35,7 @@ RulePlot::patternRules =
   "RulePlot for pattern rules `1` is not implemented.";
 
 RulePlot::notHypergraphRule =
-  "Rule `1` should be a rule operating on hyperedges (set elements should be lists)."
+  "Rule `1` should be a rule operating on hyperedges (set elements should be lists).";
 
 (* Evaluation *)
 

--- a/SetReplace/RulePlot.m
+++ b/SetReplace/RulePlot.m
@@ -4,7 +4,7 @@ Package["SetReplace`"]
 
 $allowedOptions = Join[
   FilterRules[Options[RulePlot], Options[Graphics]][[All, 1]], {
-  Frame, FrameStyle}];
+  Frame, FrameStyle, PlotLegends}];
 
 (* Parameters *)
 
@@ -38,7 +38,7 @@ rulePlot$parse[{
           rulesSpec,
           ##,
           FilterRules[{opts}, FilterRules[Options[Graphics], Except[Frame]]]] & @@
-        OptionValue[RulePlot, {opts}, {Frame, FrameStyle}] /;
+        OptionValue[RulePlot, {opts}, {Frame, FrameStyle, PlotLegends}] /;
       correctOptionsQ[{rulesSpec, o}, {opts}]
 ]
 
@@ -50,11 +50,13 @@ correctOptionsQ[args_, opts_] :=
 
 rulePlot[rule_Rule, args___] := rulePlot[{rule}, args]
 
-rulePlot[rules_List, frameQ_, frameStyle_, graphicsOpts_] :=
-  Graphics[
-      First[graphicsRiffle[#[[All, 1]], #[[All, 2]], {}, {{0, 1}, {0, 1}}, 0, 0.01, If[frameQ, frameStyle, None]]],
-      graphicsOpts] & @
-    (singleRulePlot /@ rules)
+rulePlot[rules_List, frameQ_, frameStyle_, plotLegends_, graphicsOpts_] :=
+  If[PlotLegends === None, Identity, Legended[#, Replace[plotLegends, "Text" -> Placed[StandardForm[rules], Below]]] &][
+    Graphics[
+        First[graphicsRiffle[#[[All, 1]], #[[All, 2]], {}, {{0, 1}, {0, 1}}, 0, 0.01, If[frameQ, frameStyle, None]]],
+        graphicsOpts] & @
+      (singleRulePlot /@ rules)
+  ]
 
 $vertexSize = 0.1;
 $arrowheadsLength = 0.3;

--- a/SetReplace/RulePlot.m
+++ b/SetReplace/RulePlot.m
@@ -1,5 +1,9 @@
 Package["SetReplace`"]
 
+(* Documentation *)
+
+$allowedOptions = FilterRules[Options[RulePlot], Options[Graphics]];
+
 (* Parameters *)
 
 $nodeSizeAmplification = 3;
@@ -28,17 +32,18 @@ rulePlot$parse[{
       Message[RulePlot::patternRules, rulesSpec];
       Return[$Failed]
     ];
-    rulePlot[rulesSpec] /; correctOptionsQ[{rulesSpec, o}, {opts}]
+    rulePlot[rulesSpec, {opts}] /; correctOptionsQ[{rulesSpec, o}, {opts}]
 ]
 
-correctOptionsQ[args_, opts_] := knownOptionsQ[RulePlot, Defer[RulePlot[WolframModel[args], opts]], opts]
+correctOptionsQ[args_, opts_] :=
+  knownOptionsQ[RulePlot, Defer[RulePlot[WolframModel[args], opts]], opts, $allowedOptions]
 
 (* Implementation *)
 
-rulePlot[rule_Rule] := rulePlot[{rule}]
+rulePlot[rule_Rule, opts_] := rulePlot[{rule}, opts]
 
-rulePlot[rules_List] :=
-  Graphics[First[graphicsRiffle[#[[All, 1]], #[[All, 2]], {}, {{0, 1}, {0, 1}}, 0, 0.01, True]]] & @
+rulePlot[rules_List, opts_] :=
+  Graphics[First[graphicsRiffle[#[[All, 1]], #[[All, 2]], {}, {{0, 1}, {0, 1}}, 0, 0.01, True]], opts] & @
     (singleRulePlot /@ rules)
 
 $vertexSize = 0.1;

--- a/SetReplace/RulePlot.m
+++ b/SetReplace/RulePlot.m
@@ -94,7 +94,7 @@ $ruleArrowShape = {Line[{{-1, 0.7}, {0, 0}, {-1, -0.7}}], Line[{{-1, 0}, {0, 0}}
 
 (* returns {shapes, plotRange} *)
 combinedRuleParts[sides_, plotRange_] := Module[{maxRange, xRange, yRange, xDisplacement, frame, separator},
-  maxRange = Max[plotRange[[1, 2]] - plotRange[[1, 1]], plotRange[[2, 2]] - plotRange[[2, 1]]];
+  maxRange = Max[plotRange[[1, 2]] - plotRange[[1, 1]], plotRange[[2, 2]] - plotRange[[2, 1]], 1];
   {xRange, yRange} = Mean[#] + maxRange * {-0.5, 0.5} & /@ plotRange;
   xDisplacement = 1.5 (xRange[[2]] - xRange[[1]]);
   frame = {Gray, Dotted, Line[{

--- a/SetReplace/RulePlot.m
+++ b/SetReplace/RulePlot.m
@@ -74,7 +74,7 @@ completePlotRange[graphics_] := Last @ Last @ Reap[Rasterize[
     ImageSize -> 0],
   ImageResolution -> 1]]
 
-$openArrowhead = Graphics[Line[{{-1, 1}, {0, 0}, {-1, -1}}]];
+$openArrowhead = Graphics[Line[{{-1, 0.7}, {0, 0}, {-1, -0.7}}]];
 arrow[pts_] := Graphics[{Arrowheads[{{0.03, 1, {$openArrowhead, 0}}}], GrayLevel[0.2], Arrow[pts]}];
 
 combinedRuleParts[sides_, plotRange_] := Module[{maxRange, xRange, yRange, xDisplacement, frame},

--- a/SetReplace/RulePlot.m
+++ b/SetReplace/RulePlot.m
@@ -49,7 +49,10 @@ singleRulePlot[rule_] := Module[{vertexCoordinateRules, ruleSidePlots},
     List @@ rule;
   plotRange =
     CoordinateBounds[Catenate[List @@ (Transpose[completePlotRange[#]] & /@ ruleSidePlots)], Scaled[0.1]];
-  Show[#, PlotRange -> plotRange] & /@ (ruleSidePlots[[1]] -> ruleSidePlots[[2]])
+  Framed[
+      Show[#, PlotRange -> plotRange],
+      BaseStyle -> Directive[Gray, Dotted]] & /@
+    (ruleSidePlots[[1]] -> ruleSidePlots[[2]])
 ]
 
 ruleCoordinateRules[in_ -> out_] :=

--- a/SetReplace/RulePlot.m
+++ b/SetReplace/RulePlot.m
@@ -35,11 +35,11 @@ rulePlot[rule_Rule] := rulePlot[{rule}]
 
 rulePlot[rules_List] := GraphicsRow[singleRulePlot /@ rules, Frame -> All, FrameStyle -> GrayLevel[0.8]]
 
-singleRulePlot[rule_] := Module[{vertexCoordinateRules, ruleSidePlots},
+$vertexSize = 0.1;
+$arrowheadsLength = 0.3;
+
+singleRulePlot[rule_] := Module[{vertexCoordinateRules, sharedVertices, ruleSidePlots, plotRange},
   vertexCoordinateRules = ruleCoordinateRules[rule];
-  roughPlotRange = #2 - #1 & @@ MinMax[vertexCoordinateRules[[All, 2]]];
-  vertexSize = $nodeSizeAmplification * computeVertexSize[roughPlotRange];
-  arrowheadsSize = computeArrowheadsSize[Length[vertexCoordinateRules], roughPlotRange, vertexSize];
   sharedVertices = sharedRuleVertices[rule];
   ruleSidePlots = hypergraphPlot[
       #,
@@ -49,8 +49,8 @@ singleRulePlot[rule_] := Module[{vertexCoordinateRules, ruleSidePlots},
       vertexCoordinateRules,
       None,
       {},
-      vertexSize,
-      arrowheadsSize] & /@
+      $vertexSize,
+      $arrowheadsLength] & /@
     List @@ rule;
   plotRange =
     CoordinateBounds[Catenate[List @@ (Transpose[completePlotRange[#]] & /@ ruleSidePlots)], $padding];

--- a/SetReplace/RulePlot.m
+++ b/SetReplace/RulePlot.m
@@ -48,23 +48,18 @@ WolframModel /: func : RulePlot[wm : WolframModel[args___] /; Quiet[Developer`Ch
 (* Arguments parsing *)
 
 rulePlot$parse[{
-  rulesSpec_ ? hypergraphRulesSpecQ,
-  o : OptionsPattern[] /; unrecognizedOptions[WolframModel, {o}] === {}},
-  {opts : OptionsPattern[]}] := Module[{},
-    If[AssociationQ[rulesSpec],
-      Message[RulePlot::patternRules, rulesSpec];
-      Return[$Failed]
-    ];
-    rulePlot[
-          rulesSpec,
-          ##,
-          FilterRules[{opts}, FilterRules[Options[Graphics], Except[Frame]]]] & @@
-        OptionValue[
-          RulePlot,
-          {opts},
-          {"EdgeType", GraphLayout, VertexCoordinateRules, VertexLabels, Frame, FrameStyle, PlotLegends, Spacings}] /;
-      correctOptionsQ[{rulesSpec, o}, {opts}]
-]
+    rulesSpec_ ? hypergraphRulesSpecQ,
+    o : OptionsPattern[] /; unrecognizedOptions[WolframModel, {o}] === {}},
+    {opts : OptionsPattern[]}] :=
+  rulePlot[
+        rulesSpec,
+        ##,
+        FilterRules[{opts}, FilterRules[Options[Graphics], Except[Frame]]]] & @@
+      OptionValue[
+        RulePlot,
+        {opts},
+        {"EdgeType", GraphLayout, VertexCoordinateRules, VertexLabels, Frame, FrameStyle, PlotLegends, Spacings}] /;
+    correctOptionsQ[{rulesSpec, o}, {opts}]
 
 hypergraphRulesSpecQ[rulesSpec_List ? wolframModelRulesSpecQ] := Fold[# && hypergraphRulesSpecQ[#2] &, True, rulesSpec]
 
@@ -74,6 +69,11 @@ hypergraphRulesSpecQ[ruleSpec_Rule ? wolframModelRulesSpecQ] := If[
   Message[RulePlot::notHypergraphRule, ruleSpec];
   False
 ]
+
+hypergraphRulesSpecQ[rulesSpec_Association ? wolframModelRulesSpecQ] := (
+  Message[RulePlot::patternRules, rulesSpec];
+  False
+)
 
 hypergraphRulesSpecQ[rulesSpec_] := (
   Message[RulePlot::invalidRules, rulesSpec];

--- a/SetReplace/RulePlot.m
+++ b/SetReplace/RulePlot.m
@@ -25,7 +25,8 @@ Protect[RulePlot];
 
 (* Parameters *)
 
-$nodeSizeAmplification = 3;
+$vertexSize = 0.1;
+$arrowheadsLength = 0.3;
 $graphPadding = Scaled[0.1];
 $ruleSidesSpacing = 0.2;
 
@@ -36,6 +37,9 @@ RulePlot::patternRules =
 
 RulePlot::notHypergraphRule =
   "Rule `1` should be a rule operating on hyperedges (set elements should be lists).";
+
+RulePlot::invalidSpacings =
+  "Spacings `1` should be either a single number, or a two-by-two list.";
 
 (* Evaluation *)
 
@@ -140,9 +144,6 @@ rulePlot[
       First[graphicsRiffle[#[[All, 1]], #[[All, 2]], {}, {{0, 1}, {0, 1}}, 0, 0.01, If[frameQ, frameStyle, None]]],
       graphicsOpts] & @
     (singleRulePlot[edgeType, graphLayout, vertexCoordinateRules, vertexLabels, spacings] /@ rules)
-
-$vertexSize = 0.1;
-$arrowheadsLength = 0.3;
 
 (* returns {shapes, plotRange} *)
 singleRulePlot[edgeType_, graphLayout_, externalVertexCoordinateRules_, vertexLabels_, spacings_][rule_] := Module[{

--- a/SetReplace/RulePlot.m
+++ b/SetReplace/RulePlot.m
@@ -39,7 +39,7 @@ RulePlot::notHypergraphRule =
 
 (* Evaluation *)
 
-WolframModel /: func : RulePlot[WolframModel[args___], opts___] := Module[{result = rulePlot$parse[{args}, {opts}]},
+WolframModel /: func : RulePlot[wm : WolframModel[args___] /; Quiet[Developer`CheckArgumentCount[wm, 1, 1]], opts___] := Module[{result = rulePlot$parse[{args}, {opts}]},
   If[Head[result] === rulePlot$parse,
     result = $Failed];
   result /; result =!= $Failed
@@ -75,7 +75,10 @@ hypergraphRulesSpecQ[ruleSpec_Rule ? wolframModelRulesSpecQ] := If[
   False
 ]
 
-hypergraphRulesSpecQ[rulesSpec_] := False
+hypergraphRulesSpecQ[rulesSpec_] := (
+  Message[RulePlot::invalidRules, rulesSpec];
+  False
+)
 
 correctOptionsQ[args_, {opts___}] :=
   knownOptionsQ[RulePlot, Defer[RulePlot[WolframModel[args], opts]], {opts}, $allowedOptions] &&

--- a/SetReplace/RulePlot.m
+++ b/SetReplace/RulePlot.m
@@ -12,7 +12,7 @@ RulePlot::patternRules =
 
 (* Evaluation *)
 
-WolframModel /: func : RulePlot[WolframModel[args___]] := Module[{result = rulePlot$parse[{args}]},
+WolframModel /: func : RulePlot[WolframModel[args___], opts___] := Module[{result = rulePlot$parse[{args}, {opts}]},
   If[Head[result] === rulePlot$parse,
     result = $Failed];
   result /; result =!= $Failed
@@ -22,12 +22,16 @@ WolframModel /: func : RulePlot[WolframModel[args___]] := Module[{result = ruleP
 
 rulePlot$parse[{
   rulesSpec_ ? wolframModelRulesSpecQ,
-  o : OptionsPattern[] /; unrecognizedOptions[WolframModel, {o}] === {}}] := Module[{},
+  o : OptionsPattern[] /; unrecognizedOptions[WolframModel, {o}] === {}},
+  {opts : OptionsPattern[]}] := Module[{},
     If[AssociationQ[rulesSpec],
       Message[RulePlot::patternRules, rulesSpec];
-      Return[$Failed]];
-    rulePlot[rulesSpec]
+      Return[$Failed]
+    ];
+    rulePlot[rulesSpec] /; correctOptionsQ[{rulesSpec, o}, {opts}]
 ]
+
+correctOptionsQ[args_, opts_] := knownOptionsQ[RulePlot, Defer[RulePlot[WolframModel[args], opts]], opts]
 
 (* Implementation *)
 
@@ -95,6 +99,8 @@ combinedRuleParts[sides_, plotRange_] := Module[{maxRange, xRange, yRange, xDisp
       {xRange[[2]] + 0.05 xDisplacement, Mean[yRange]},
       {xRange[[1]] + 0.95 xDisplacement, Mean[yRange]}}],
     Graphics[Translate[sides[[2, 1]], {xDisplacement, 0}]],
-    PlotRange -> {{xRange[[1]] - 0.01 xDisplacement, xRange[[2]] + 1.01 xDisplacement}, {yRange[[1]] - 0.01 xDisplacement, yRange[[2]] + 0.01 xDisplacement}},
+    PlotRange -> {
+      {xRange[[1]] - 0.01 xDisplacement, xRange[[2]] + 1.01 xDisplacement},
+      {yRange[[1]] - 0.01 xDisplacement, yRange[[2]] + 0.01 xDisplacement}},
     ImageSize -> 300 {1, 1 / 2.5}]
 ]

--- a/SetReplace/RulePlot.m
+++ b/SetReplace/RulePlot.m
@@ -61,9 +61,18 @@ singleRulePlot[rule_] := Module[{vertexCoordinateRules, sharedVertices, ruleSide
   combinedRuleParts[ruleSidePlots, plotRange]
 ]
 
+connectedQ[edges_] := ConnectedGraphQ[Graph[UndirectedEdge @@@ Catenate[Partition[#, 2, 1] & /@ edges]]]
+
+layoutReferenceSide[in_, out_] := Module[{inConnectedQ, outConnectedQ},
+  {inConnectedQ, outConnectedQ} = connectedQ /@ {in, out};
+  If[inConnectedQ && !outConnectedQ, Return[out]];
+  If[outConnectedQ && !inConnectedQ, Return[in]];
+  If[Length[in] > Length[out], in, out]
+]
+
 ruleCoordinateRules[in_ -> out_] :=
   #[[1]] -> #[[2, 1, 1]] & /@
-    hypergraphEmbedding["CyclicOpen", "SpringElectricalEmbedding", {}][If[Length[in] > Length[out], in, out]][[1]]
+    hypergraphEmbedding["CyclicOpen", "SpringElectricalEmbedding", {}][layoutReferenceSide[in, out]][[1]]
 
 sharedRuleVertices[in_ -> out_] := Intersection @@ (Catenate /@ {in, out})
 

--- a/SetReplace/RulePlot.m
+++ b/SetReplace/RulePlot.m
@@ -39,11 +39,12 @@ RulePlot::notHypergraphRule =
 
 (* Evaluation *)
 
-WolframModel /: func : RulePlot[wm : WolframModel[args___] /; Quiet[Developer`CheckArgumentCount[wm, 1, 1]], opts___] := Module[{result = rulePlot$parse[{args}, {opts}]},
-  If[Head[result] === rulePlot$parse,
-    result = $Failed];
-  result /; result =!= $Failed
-]
+WolframModel /: func : RulePlot[wm : WolframModel[args___] /; Quiet[Developer`CheckArgumentCount[wm, 1, 1]], opts___] :=
+  Module[{result = rulePlot$parse[{args}, {opts}]},
+    If[Head[result] === rulePlot$parse,
+      result = $Failed];
+    result /; result =!= $Failed
+  ]
 
 (* Arguments parsing *)
 
@@ -96,10 +97,8 @@ correctSpacingsQ[opts_] := Module[{spacings, correctQ},
 
 (* Implementation *)
 
-rulePlot[rule_Rule, args___] := rulePlot[{rule}, args]
-
 rulePlot[
-    rules_List,
+    rules_,
     edgeType_,
     graphLayout_,
     vertexCoordinateRules_,
@@ -110,11 +109,37 @@ rulePlot[
     spacings_,
     graphicsOpts_] :=
   If[PlotLegends === None, Identity, Legended[#, Replace[plotLegends, "Text" -> Placed[StandardForm[rules], Below]]] &][
-    Graphics[
-        First[graphicsRiffle[#[[All, 1]], #[[All, 2]], {}, {{0, 1}, {0, 1}}, 0, 0.01, If[frameQ, frameStyle, None]]],
-        graphicsOpts] & @
-      (singleRulePlot[edgeType, graphLayout, vertexCoordinateRules, vertexLabels, spacings] /@ rules)
+    rulePlot[
+      rules, edgeType, graphLayout, vertexCoordinateRules, vertexLabels, frameQ, frameStyle, spacings, graphicsOpts]
   ]
+
+rulePlot[
+    rule_Rule,
+    edgeType_,
+    graphLayout_,
+    vertexCoordinateRules_,
+    vertexLabels_,
+    frameQ_,
+    frameStyle_,
+    spacings_,
+    graphicsOpts_] :=
+  rulePlot[
+    {rule}, edgeType, graphLayout, vertexCoordinateRules, vertexLabels, frameQ, frameStyle, spacings, graphicsOpts]
+
+rulePlot[
+    rules_List,
+    edgeType_,
+    graphLayout_,
+    vertexCoordinateRules_,
+    vertexLabels_,
+    frameQ_,
+    frameStyle_,
+    spacings_,
+    graphicsOpts_] :=
+  Graphics[
+      First[graphicsRiffle[#[[All, 1]], #[[All, 2]], {}, {{0, 1}, {0, 1}}, 0, 0.01, If[frameQ, frameStyle, None]]],
+      graphicsOpts] & @
+    (singleRulePlot[edgeType, graphLayout, vertexCoordinateRules, vertexLabels, spacings] /@ rules)
 
 $vertexSize = 0.1;
 $arrowheadsLength = 0.3;

--- a/SetReplace/RulePlot.m
+++ b/SetReplace/RulePlot.m
@@ -1,5 +1,10 @@
 Package["SetReplace`"]
 
+(* Parameters *)
+
+$nodeSizeAmplification = 3;
+$padding = Scaled[0.1];
+
 (* Messages *)
 
 RulePlot::patternRules =
@@ -33,7 +38,7 @@ rulePlot[rules_List] := Column[singleRulePlot /@ rules]
 singleRulePlot[rule_] := Module[{vertexCoordinateRules, ruleSidePlots},
   vertexCoordinateRules = ruleCoordinateRules[rule];
   roughPlotRange = #2 - #1 & @@ MinMax[vertexCoordinateRules[[All, 2]]];
-  vertexSize = computeVertexSize[roughPlotRange];
+  vertexSize = $nodeSizeAmplification * computeVertexSize[roughPlotRange];
   arrowheadsSize = computeArrowheadsSize[Length[vertexCoordinateRules], roughPlotRange, vertexSize];
   sharedVertices = sharedRuleVertices[rule];
   ruleSidePlots = hypergraphPlot[
@@ -48,7 +53,7 @@ singleRulePlot[rule_] := Module[{vertexCoordinateRules, ruleSidePlots},
       arrowheadsSize] & /@
     List @@ rule;
   plotRange =
-    CoordinateBounds[Catenate[List @@ (Transpose[completePlotRange[#]] & /@ ruleSidePlots)], Scaled[0.1]];
+    CoordinateBounds[Catenate[List @@ (Transpose[completePlotRange[#]] & /@ ruleSidePlots)], $padding];
   Framed[
       Show[#, PlotRange -> plotRange],
       BaseStyle -> Directive[Gray, Dotted]] & /@

--- a/SetReplace/RulePlot.m
+++ b/SetReplace/RulePlot.m
@@ -74,8 +74,8 @@ completePlotRange[graphics_] := Last @ Last @ Reap[Rasterize[
     ImageSize -> 0],
   ImageResolution -> 1]]
 
-$openArrowhead = Graphics[{Dashing[None], Line[{{-1, 1/3}, {0, 0}, {-1, -1/3}}]}];
-arrow[pts_] := Graphics[{Arrowheads[{{0.03, 1, {$openArrowhead, 1}}}], GrayLevel[0.2], Dotted, Arrow[pts]}];
+$openArrowhead = Graphics[Line[{{-1, 1}, {0, 0}, {-1, -1}}]];
+arrow[pts_] := Graphics[{Arrowheads[{{0.03, 1, {$openArrowhead, 0}}}], GrayLevel[0.2], Arrow[pts]}];
 
 combinedRuleParts[sides_, plotRange_] := Module[{maxRange, xRange, yRange, xDisplacement, frame},
   maxRange = Max[plotRange[[1, 2]] - plotRange[[1, 1]], plotRange[[2, 2]] - plotRange[[2, 1]]];

--- a/SetReplace/RulePlot.m
+++ b/SetReplace/RulePlot.m
@@ -69,7 +69,7 @@ rulePlot$parse[{
 hypergraphRulesSpecQ[rulesSpec_List ? wolframModelRulesSpecQ] := Fold[# && hypergraphRulesSpecQ[#2] &, True, rulesSpec]
 
 hypergraphRulesSpecQ[ruleSpec_Rule ? wolframModelRulesSpecQ] := If[
-  And @@ (Depth[#] >= 3 & /@ ruleSpec),
+  MatchQ[ruleSpec, {___List} -> {___List}],
   True,
   Message[RulePlot::notHypergraphRule, ruleSpec];
   False
@@ -164,7 +164,7 @@ singleRulePlot[edgeType_, graphLayout_, externalVertexCoordinateRules_, vertexLa
       $arrowheadsLength] & /@
     List @@ rule;
   plotRange =
-    CoordinateBounds[Catenate[List @@ (Transpose[completePlotRange[#]] & /@ ruleSidePlots)], $graphPadding];
+    CoordinateBounds[Catenate[List @@ (Transpose[PlotRange[#]] & /@ ruleSidePlots)], $graphPadding];
   combinedRuleParts[ruleSidePlots[[All, 1]], plotRange, spacings]
 ]
 
@@ -182,17 +182,6 @@ ruleCoordinateRules[edgeType_, graphLayout_, externalVertexCoordinateRules_, in_
     hypergraphEmbedding[edgeType, graphLayout, externalVertexCoordinateRules][layoutReferenceSide[in, out]][[1]]
 
 sharedRuleVertices[in_ -> out_] := Intersection @@ (Catenate /@ {in, out})
-
-(* https://mathematica.stackexchange.com/a/18040 *)
-completePlotRange[graphics_] := Last @ Last @ Reap[Rasterize[
-  Show[
-    graphics,
-    Axes -> True,
-    Frame -> False,
-    Ticks -> ((Sow[{##}]; Automatic) &),
-    DisplayFunction -> Identity,
-    ImageSize -> 0],
-  ImageResolution -> 1]]
 
 $ruleArrowShape = {Line[{{-1, 0.7}, {0, 0}, {-1, -0.7}}], Line[{{-1, 0}, {0, 0}}]};
 

--- a/SetReplace/RulePlot.m
+++ b/SetReplace/RulePlot.m
@@ -1,0 +1,70 @@
+Package["SetReplace`"]
+
+(* Messages *)
+
+RulePlot::patternRules =
+  "RulePlot for pattern rules `1` is not implemented.";
+
+(* Evaluation *)
+
+WolframModel /: func : RulePlot[WolframModel[args___]] := Module[{result = rulePlot$parse[{args}]},
+  If[Head[result] === rulePlot$parse,
+    result = $Failed];
+  result /; result =!= $Failed
+]
+
+(* Arguments parsing *)
+
+rulePlot$parse[{
+  rulesSpec_ ? wolframModelRulesSpecQ,
+  o : OptionsPattern[] /; unrecognizedOptions[WolframModel, {o}] === {}}] := Module[{},
+    If[AssociationQ[rulesSpec],
+      Message[RulePlot::patternRules, rulesSpec];
+      Return[$Failed]];
+    rulePlot[rulesSpec]
+]
+
+(* Implementation *)
+
+rulePlot[rule_Rule] := rulePlot[{rule}]
+
+rulePlot[rules_List] := Column[singleRulePlot /@ rules]
+
+singleRulePlot[rule_] := Module[{vertexCoordinateRules, ruleSidePlots},
+  vertexCoordinateRules = ruleCoordinateRules[rule];
+  roughPlotRange = #2 - #1 & @@ MinMax[vertexCoordinateRules[[All, 2]]];
+  vertexSize = computeVertexSize[roughPlotRange];
+  arrowheadsSize = computeArrowheadsSize[Length[vertexCoordinateRules], roughPlotRange, vertexSize];
+  sharedVertices = sharedRuleVertices[rule];
+  ruleSidePlots = hypergraphPlot[
+      #,
+      "CyclicOpen",
+      sharedVertices,
+      "SpringElectricalPolygons",
+      vertexCoordinateRules,
+      None,
+      {},
+      vertexSize,
+      arrowheadsSize] & /@
+    List @@ rule;
+  plotRange =
+    CoordinateBounds[Catenate[List @@ (Transpose[completePlotRange[#]] & /@ ruleSidePlots)], Scaled[0.1]];
+  Show[#, PlotRange -> plotRange] & /@ (ruleSidePlots[[1]] -> ruleSidePlots[[2]])
+]
+
+ruleCoordinateRules[in_ -> out_] :=
+  #[[1]] -> #[[2, 1, 1]] & /@
+    hypergraphEmbedding["CyclicOpen", "SpringElectricalEmbedding", {}][If[Length[in] > Length[out], in, out]][[1]]
+
+sharedRuleVertices[in_ -> out_] := Intersection @@ (Catenate /@ {in, out})
+
+(* https://mathematica.stackexchange.com/a/18040 *)
+completePlotRange[graphics_] := Last @ Last @ Reap[Rasterize[
+  Show[
+    graphics,
+    Axes -> True,
+    Frame -> False,
+    Ticks -> ((Sow[{##}]; Automatic) &),
+    DisplayFunction -> Identity,
+    ImageSize -> 0],
+  ImageResolution -> 1]]

--- a/SetReplace/RulePlot.m
+++ b/SetReplace/RulePlot.m
@@ -75,9 +75,9 @@ completePlotRange[graphics_] := Last @ Last @ Reap[Rasterize[
   ImageResolution -> 1]]
 
 $openArrowhead = Graphics[{Dashing[None], Line[{{-1, 1/3}, {0, 0}, {-1, -1/3}}]}];
-arrow[pts_] = Graphics[{Arrowheads[{{0.03, 1, {$openArrowhead, 1}}}], GrayLevel[0.2], Dotted, Arrow[pts]}];
+arrow[pts_] := Graphics[{Arrowheads[{{0.03, 1, {$openArrowhead, 1}}}], GrayLevel[0.2], Dotted, Arrow[pts]}];
 
-combinedRuleParts[sides_, plotRange_] := Module[{xRange},
+combinedRuleParts[sides_, plotRange_] := Module[{maxRange, xRange, yRange, xDisplacement, frame},
   maxRange = Max[plotRange[[1, 2]] - plotRange[[1, 1]], plotRange[[2, 2]] - plotRange[[2, 1]]];
   {xRange, yRange} = Mean[#] + maxRange * {-0.5, 0.5} & /@ plotRange;
   xDisplacement = 1.5 (xRange[[2]] - xRange[[1]]);

--- a/SetReplace/RulePlot.wlt
+++ b/SetReplace/RulePlot.wlt
@@ -1,0 +1,277 @@
+BeginTestSection["RulePlot"]
+
+(* Rule correctness checking *)
+
+VerificationTest[
+  RulePlot[WolframModel[1]],
+  RulePlot[WolframModel[1]],
+  {RulePlot::invalidRules}
+]
+
+VerificationTest[
+  RulePlot[WolframModel[1 -> 2]],
+  RulePlot[WolframModel[1 -> 2]],
+  {RulePlot::notHypergraphRule}
+]
+
+VerificationTest[
+  RulePlot[WolframModel[{1} -> {2}]],
+  RulePlot[WolframModel[{1} -> {2}]],
+  {RulePlot::notHypergraphRule}
+]
+
+VerificationTest[
+  RulePlot[WolframModel[{{1}} -> {2}]],
+  RulePlot[WolframModel[{{1}} -> {2}]],
+  {RulePlot::notHypergraphRule}
+]
+
+VerificationTest[
+  Head[RulePlot[WolframModel[{{1}} -> {{2}}]]],
+  Graphics
+]
+
+VerificationTest[
+  RulePlot[WolframModel[<|"PatternRules" -> {{1}} -> {{2}}|>]],
+  RulePlot[WolframModel[<|"PatternRules" -> {{1}} -> {{2}}|>]],
+  {RulePlot::patternRules}
+]
+
+VerificationTest[
+  Head[RulePlot[WolframModel[{{1}} -> {{2}}, Method -> "$$$AnyMethod$$$"]]],
+  Graphics
+]
+
+VerificationTest[
+  RulePlot[WolframModel[{{{1}} -> {{2}}, 1}]],
+  RulePlot[WolframModel[{{{1}} -> {{2}}, 1}]],
+  {RulePlot::invalidRules}
+]
+
+VerificationTest[
+  RulePlot[WolframModel[{{{1}} -> {{2}}, 1 -> 2}]],
+  RulePlot[WolframModel[{{{1}} -> {{2}}, 1 -> 2}]],
+  {RulePlot::notHypergraphRule}
+]
+
+VerificationTest[
+  Head[RulePlot[WolframModel[{{{1}} -> {{2}}, {{1}} -> {{2}}}]]],
+  Graphics
+]
+
+(* Options *)
+
+(** EdgeType **)
+
+VerificationTest[
+  Not[
+    Or @@ SameQ @@@ Subsets[
+      Rasterize[RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], "EdgeType" -> #]] & /@
+        {"Ordered", "CyclicOpen", "CyclicClosed"},
+      {2}]]
+]
+
+VerificationTest[
+  RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], "EdgeType" -> "Invalid"],
+  RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], "EdgeType" -> "Invalid"],
+  {RulePlot::invalidFiniteOption}
+]
+
+VerificationTest[
+  RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], "EdgeType" -> 3],
+  RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], "EdgeType" -> 3],
+  {RulePlot::invalidFiniteOption}
+]
+
+(** GraphLayout **)
+
+VerificationTest[
+  Not[
+    Or @@ SameQ @@@ Subsets[
+      Rasterize[RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], GraphLayout -> #]] & /@
+        {"SpringElectricalEmbedding", "SpringElectricalPolygons"},
+      {2}]]
+]
+
+VerificationTest[
+  RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], GraphLayout -> "Invalid"],
+  RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], GraphLayout -> "Invalid"],
+  {RulePlot::invalidFiniteOption}
+]
+
+VerificationTest[
+  RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], GraphLayout -> 3],
+  RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], GraphLayout -> 3],
+  {RulePlot::invalidFiniteOption}
+]
+
+(** VertexCoordinateRules **)
+
+VerificationTest[
+  SameQ @@
+    Cases[
+      RulePlot[
+        WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}],
+        VertexCoordinateRules -> {1 -> {0, 0}, 2 -> {1, 0}, 3 -> {2, 0}, 4 -> {3, 0}, 5 -> {4, 0}}],
+      Disk[p_, _] :> p,
+      All][[All, 2]]
+]
+
+(*** Due to scaling and translation being computed in the frontend instead of ahead of time,
+      coordinates on both sides of the rule might be the same. ***)
+VerificationTest[
+  Length[
+      Union[
+        Cases[
+          RulePlot[
+            WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}],
+            VertexCoordinateRules -> {1 -> {0, 0}, 2 -> {0, 0}, 3 -> {0, 0}, 4 -> {0, 0}, 5 -> {0, 0}}],
+          Disk[p_, _] :> p,
+          All]]]
+    <= 2
+]
+
+VerificationTest[
+  Head[RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], VertexCoordinateRules -> {}]],
+  Graphics
+]
+
+VerificationTest[
+  RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], VertexCoordinateRules -> {1}],
+  RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], VertexCoordinateRules -> {1}],
+  {RulePlot::invalidCoordinates}
+]
+
+(** VertexLabels **)
+
+VerificationTest[
+  Sort[Cases[RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], VertexLabels -> Automatic], Text[i_, ___] :> i, All]],
+  {1, 2, 3, 3, 4, 5}
+]
+
+VerificationTest[
+  Length[Cases[RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], VertexLabels -> x], Text[x, ___], All]],
+  6
+]
+
+(** Graphics **)
+
+VerificationTest[
+  Background /. AbsoluteOptions[RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], Background -> Black], Background],
+  Black,
+  SameTest -> Equal
+]
+
+(** Frame **)
+
+VerificationTest[
+  Not[
+    Or @@ SameQ @@@ Subsets[
+      Rasterize[RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], Frame -> #]] & /@ {False, True}, {2}]]
+]
+
+VerificationTest[
+  RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], Frame -> "Invalid"],
+  RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], Frame -> "Invalid"],
+  {RulePlot::invalidFiniteOption}
+]
+
+(** FrameStyle **)
+
+VerificationTest[
+  MemberQ[
+    Cases[
+      RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], FrameStyle -> RGBColor[0.33, 0.66, 0.77]][[1]],
+      _ ? ColorQ,
+      All],
+    RGBColor[0.33, 0.66, 0.77]]
+]
+
+VerificationTest[
+  Not @ MemberQ[
+    Cases[
+      RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], FrameStyle -> RGBColor[0.33, 0.66, 0.77], Frame -> False][[1]],
+      _ ? ColorQ,
+      All],
+    RGBColor[0.33, 0.66, 0.77]]
+]
+
+(** PlotLegends **)
+
+VerificationTest[
+  MatchQ[
+    RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], PlotLegends -> "Text"],
+    Legended[_, Placed[StandardForm[{{1, 2, 3}} -> {{3, 4, 5}}], Below]]]
+]
+
+VerificationTest[
+  MatchQ[RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], PlotLegends -> "test"], Legended[_, "test"]]
+]
+
+VerificationTest[
+  Not @ MatchQ[RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}]], Legended[___]]
+]
+
+(** Spacings **)
+
+VerificationTest[
+  Not[Or @@ SameQ @@@ Subsets[
+    Rasterize[RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], Spacings -> #]] & /@
+      {0, 1, {{1, 0}, {0, 0}}, {{0, 1}, {0, 0}}, {{0, 0}, {1, 0}}, {{0, 0}, {0, 1}}},
+    {2}]]
+]
+
+VerificationTest[
+  And @@ SameQ @@
+    (Rasterize[RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], Spacings -> #]] & /@ {1, {{1, 1}, {1, 1}}})
+]
+
+VerificationTest[
+  RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], Spacings -> #],
+  RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], Spacings -> #],
+  {RulePlot::invalidSpacings}
+] & /@ {
+  "Incorrect",
+  {1, 1},
+  {{1, 2}, 1},
+  {1, {1, 2}},
+  {{1, 2, 3}, {1, 2}},
+  {{1, {2, 3}}, {1, 2}}
+}
+
+(* Scaling consistency *)
+
+(** Vertex amplification **)
+
+VerificationTest[
+  First[Cases[RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}]], Disk[_, r_] :> r, All]] > 
+    First[Cases[HypergraphPlot[{{1, 2, 3}}], Disk[_, r_] :> r, All]]
+]
+
+(** Consistent vertex sizes **)
+
+$rules = {
+  {{1}} -> {{1}},
+  {{1}} -> {{2}},
+  {{1, 2}} -> {{1}},
+  {{1, 2}} -> {{1, 2}},
+  {{1, 2, 3}} -> {{1}},
+  {{1, 2, 3}} -> {{1, 2}},
+  {{1}, {2}} -> {{2}, {3}},
+  {{1}, {2}, {3}} -> {{2}, {3}, {4}},
+  {{1, 2, 3}} -> {{3, 4, 5}},
+  {{1, 2, 3}} -> {{1, 2}, {2, 3}},
+  {{1, 2, 3}} -> {{2, 3}, {3, 4}}};
+
+VerificationTest[
+  And @@ (SameQ @@ Cases[RulePlot[WolframModel[#]], Disk[_, r_] :> r, All] & /@ $rules)
+]
+
+(** Shared vertices are colored **)
+
+VerificationTest[
+  Length[Union[Cases[RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}]], _ ? ColorQ, All]]] > 
+    Length[Union[Cases[RulePlot[WolframModel[{{1, 2, 3}} -> {{4, 5, 6}}]], _ ? ColorQ, All]]]
+]
+
+EndTestSection[]

--- a/SetReplace/WolframModel.m
+++ b/SetReplace/WolframModel.m
@@ -13,8 +13,10 @@ Package["SetReplace`"]
 
 PackageExport["WolframModel"]
 PackageExport["$WolframModelProperties"]
-PackageExport["unrecognizedOptions"]
-PackageExport["wolframModelRulesSpecQ"]
+
+
+PackageScope["unrecognizedOptions"]
+PackageScope["wolframModelRulesSpecQ"]
 
 
 (* ::Section:: *)

--- a/SetReplace/WolframModel.m
+++ b/SetReplace/WolframModel.m
@@ -13,6 +13,8 @@ Package["SetReplace`"]
 
 PackageExport["WolframModel"]
 PackageExport["$WolframModelProperties"]
+PackageExport["unrecognizedOptions"]
+PackageExport["wolframModelRulesSpecQ"]
 
 
 (* ::Section:: *)

--- a/SetReplace/WolframModel.m
+++ b/SetReplace/WolframModel.m
@@ -338,7 +338,7 @@ WolframModel[
 (*Rules*)
 
 
-WolframModel::invalidRules =
+General::invalidRules =
 	"The rule specification `1` should be either a Rule, " ~~
 	"a List of rules, or <|\"PatternRules\" -> rules|>, where " ~~
 	"rules is either a Rule, RuleDelayed, or a List of them.";
@@ -346,7 +346,7 @@ WolframModel::invalidRules =
 
 expr : WolframModel[
 		rulesSpec_ ? (Not @* wolframModelRulesSpecQ),
-		args___] /; Quiet[Developer`CheckArgumentCount[expr, 1, 4]] := 0 /;
+		args___] /; Quiet[Developer`CheckArgumentCount[expr, 2, 4]] := 0 /;
 	Message[WolframModel::invalidRules, rulesSpec]
 
 

--- a/SetReplace/WolframModel.m
+++ b/SetReplace/WolframModel.m
@@ -341,7 +341,7 @@ WolframModel[
 WolframModel::invalidRules =
 	"The rule specification `1` should be either a Rule, " ~~
 	"a List of rules, or <|\"PatternRules\" -> rules|>, where " ~~
-	"rules is either a Rule, RuleDelayed, or a List of them."
+	"rules is either a Rule, RuleDelayed, or a List of them.";
 
 
 expr : WolframModel[

--- a/SetReplace/WolframModel.wlt
+++ b/SetReplace/WolframModel.wlt
@@ -18,7 +18,7 @@ VerificationTest[
 VerificationTest[
   WolframModel[x],
   WolframModel[x],
-  {WolframModel::invalidRules}
+  {}
 ]
 
 VerificationTest[
@@ -60,7 +60,7 @@ VerificationTest[
 VerificationTest[
   WolframModel[x, f -> 3],
   WolframModel[x, f -> 3],
-  {WolframModel::invalidRules}
+  {}
 ]
 
 VerificationTest[
@@ -222,25 +222,25 @@ VerificationTest[
 VerificationTest[
   WolframModel[<|"PatternRule" -> 1 -> 2|>],
   WolframModel[<|"PatternRule" -> 1 -> 2|>],
-  {WolframModel::invalidRules}
+  {}
 ]
 
 VerificationTest[
   WolframModel[<|"PatternRule" -> 1 -> 2|>][{1}],
   WolframModel[<|"PatternRule" -> 1 -> 2|>][{1}],
-  {WolframModel::invalidRules}
+  {}
 ]
 
 VerificationTest[
   WolframModel[<|"PatternRules" -> 1 -> 2, "f" -> 2|>],
   WolframModel[<|"PatternRules" -> 1 -> 2, "f" -> 2|>],
-  {WolframModel::invalidRules}
+  {}
 ]
 
 VerificationTest[
   WolframModel[<|"PatternRules" -> 1 -> 2, "f" -> 2|>][{1}],
   WolframModel[<|"PatternRules" -> 1 -> 2, "f" -> 2|>][{1}],
-  {WolframModel::invalidRules}
+  {}
 ]
 
 VerificationTest[

--- a/SetReplace/WolframModelEvolutionObject.m
+++ b/SetReplace/WolframModelEvolutionObject.m
@@ -107,7 +107,7 @@ $propertyArgumentCounts = <|
 |>;
 
 
-$propertiesParameterless = Keys @ Select[#[[1]] == 0 &] @ $propertyArgumentCounts
+$propertiesParameterless = Keys @ Select[#[[1]] == 0 &] @ $propertyArgumentCounts;
 
 
 (* ::Subsection:: *)

--- a/SetReplace/argumentsChecking.m
+++ b/SetReplace/argumentsChecking.m
@@ -1,0 +1,21 @@
+Package["SetReplace`"]
+
+PackageScope["supportedOptionQ"]
+PackageScope["knownOptionsQ"]
+
+supportedOptionQ[func_, optionToCheck_, validValues_, opts_] := Module[{value, supportedQ},
+  value = OptionValue[func, {opts}, optionToCheck];
+  supportedQ = MemberQ[validValues, value];
+  If[!supportedQ,
+    Message[MessageName[func, "invalidFiniteOption"], optionToCheck, value, validValues]
+  ];
+  supportedQ
+]
+
+knownOptionsQ[func_, funcCall_, opts_] := With[{
+    unknownOptions = Complement @@ {opts, Options[func]}[[All, All, 1]]},
+  If[Length[unknownOptions] > 0,
+    Message[func::optx, unknownOptions[[1]], funcCall]
+  ];
+  Length[unknownOptions] == 0
+]

--- a/SetReplace/argumentsChecking.m
+++ b/SetReplace/argumentsChecking.m
@@ -3,18 +3,21 @@ Package["SetReplace`"]
 PackageScope["supportedOptionQ"]
 PackageScope["knownOptionsQ"]
 
+General::invalidFiniteOption =
+  "Value `2` of option `1` should be one of `3`.";
+
 supportedOptionQ[func_, optionToCheck_, validValues_, opts_] := Module[{value, supportedQ},
   value = OptionValue[func, {opts}, optionToCheck];
   supportedQ = MemberQ[validValues, value];
   If[!supportedQ,
-    Message[MessageName[func, "invalidFiniteOption"], optionToCheck, value, validValues]
+    Message[func::invalidFiniteOption, optionToCheck, value, validValues]
   ];
   supportedQ
 ]
 
 knownOptionsQ[func_, funcCall_, opts_, allowedOptions_ : Automatic] := With[{
     unknownOptions =
-      Complement @@ {opts, If[allowedOptions === Automatic, Options[func], allowedOptions]}[[All, All, 1]]},
+      Complement @@ {opts[[All, 1]], If[allowedOptions === Automatic, Options[func][[All, 1]], allowedOptions]}},
   If[Length[unknownOptions] > 0,
     Message[func::optx, unknownOptions[[1]], funcCall]
   ];

--- a/SetReplace/argumentsChecking.m
+++ b/SetReplace/argumentsChecking.m
@@ -12,8 +12,9 @@ supportedOptionQ[func_, optionToCheck_, validValues_, opts_] := Module[{value, s
   supportedQ
 ]
 
-knownOptionsQ[func_, funcCall_, opts_] := With[{
-    unknownOptions = Complement @@ {opts, Options[func]}[[All, All, 1]]},
+knownOptionsQ[func_, funcCall_, opts_, allowedOptions_ : Automatic] := With[{
+    unknownOptions =
+      Complement @@ {opts, If[allowedOptions === Automatic, Options[func], allowedOptions]}[[All, All, 1]]},
   If[Length[unknownOptions] > 0,
     Message[func::optx, unknownOptions[[1]], funcCall]
   ];

--- a/SetReplace/arrow.m
+++ b/SetReplace/arrow.m
@@ -17,6 +17,8 @@ arrow[shape_, arrowheadLength_, vertexSize_][pts_] := Module[{ptsStartToArrowEnd
   }
 ]
 
+arrowhead[shape_, endPt_, {0 | 0., 0 | 0.}, length_] := {}
+
 arrowhead[shape_, endPt_, direction_, length_] :=
   (Translate[#, endPt] &) @
   (Rotate[#, {{1, 0}, direction}] &) @

--- a/SetReplace/arrow.m
+++ b/SetReplace/arrow.m
@@ -1,0 +1,38 @@
+Package["SetReplace`"]
+
+PackageScope["arrow"]
+
+arrow[shape_, arrowheadLength_, vertexSize_][pts_] := Module[{ptsStartToArrowEnd, ptsStartToLineEnd},
+  ptsStartToArrowEnd = lineTake[pts, vertexSize ;; - vertexSize];
+  ptsStartToLineEnd = lineTake[ptsStartToArrowEnd, 0 ;; - arrowheadLength];
+  {
+    Line[ptsStartToLineEnd],
+    If[Length[ptsStartToArrowEnd] > 1,
+      arrowhead[
+        shape,
+        Last[ptsStartToArrowEnd],
+        Normalize[ptsStartToArrowEnd[[-1]] - ptsStartToLineEnd[[-1]]],
+        arrowheadLength],
+      Nothing]
+  }
+]
+
+arrowhead[shape_, endPt_, direction_, length_] :=
+  (Translate[#, endPt] &) @
+  (Rotate[#, {{1, 0}, direction}] &) @
+  (Scale[#, length, {0, 0}] &) @
+  shape
+
+lineTake[pts_, start_ ;; end_] := Reverse[lineDrop[Reverse[lineDrop[pts, start]], -end]]
+
+lineDrop[pts_, length_] /; Length[pts] > 2 := With[{
+    firstSegmentLength = EuclideanDistance @@ pts[[{1, 2}]]},
+  If[firstSegmentLength <= length,
+    lineDrop[Rest[pts], length - firstSegmentLength],
+    Join[lineDrop[pts[[{1, 2}]], length], Drop[pts, 2]]
+  ]
+]
+
+lineDrop[{pt1_, pt2_}, length_] := {pt1 + Normalize[pt2 - pt1] * length, pt2}
+
+lineDrop[pts : ({_} | {}), _] := pts

--- a/SetReplace/hypergraphUtilities.m
+++ b/SetReplace/hypergraphUtilities.m
@@ -1,0 +1,5 @@
+Package["SetReplace`"]
+
+PackageScope["vertexList"]
+
+vertexList[edges_] := Union[Catenate[edges]]

--- a/SetReplace/performance.wlt
+++ b/SetReplace/performance.wlt
@@ -11,12 +11,11 @@ $rule =
       {$0, b}, {$1, c}, {$2, d}, {b, $2}, {d, $0}}]};
 
 VerificationTest[
-  SetReplace[
+  Head[SetReplace[
     $init,
     $rule,
-    1000],
-  {0},
-  SameTest -> (ListQ[#1] && ListQ[#2] &),
+    1000]],
+  List,
   TimeConstraint -> 3,
   MemoryConstraint -> 5*^6
 ]
@@ -24,13 +23,12 @@ VerificationTest[
 (** WL performance **)
 
 VerificationTest[
-  SetReplace[
+  Head[SetReplace[
     $init,
     $rule,
     100,
-    Method -> "Symbolic"],
-  {0},
-  SameTest -> (ListQ[#1] && ListQ[#2] &),
+    Method -> "Symbolic"]],
+  List,
   TimeConstraint -> 60,
   MemoryConstraint -> 5*^6
 ]
@@ -38,14 +36,13 @@ VerificationTest[
 (** Naming function performance **)
 
 VerificationTest[
-  WolframModel[
+  Head[WolframModel[
     <|"PatternRules" -> $rule|>,
     $init,
     <|"Events" -> 1000|>,
     "FinalState",
-    "NodeNamingFunction" -> All],
-  {0},
-  SameTest -> (ListQ[#1] && ListQ[#2] &),
+    "NodeNamingFunction" -> All]],
+  List,
   TimeConstraint -> 3,
   MemoryConstraint -> 10*^6
 ]

--- a/SetReplace/performance.wlt
+++ b/SetReplace/performance.wlt
@@ -84,7 +84,7 @@ Table[
     Head[HypergraphPlot[$largeSet, "EdgeType" -> edgeType, GraphLayout -> layout]],
     Graphics,
     TimeConstraint -> (4 $normalPlotTiming),
-    MemoryConstraint -> (6 $normalPlotMemory)],
+    MemoryConstraint -> (7 $normalPlotMemory)],
   {edgeType, $edgeTypes},
   {layout, $layouts}]
 

--- a/SetReplace/performance.wlt
+++ b/SetReplace/performance.wlt
@@ -83,7 +83,7 @@ Table[
   VerificationTest[
     Head[HypergraphPlot[$largeSet, "EdgeType" -> edgeType, GraphLayout -> layout]],
     Graphics,
-    TimeConstraint -> (3 $normalPlotTiming),
+    TimeConstraint -> (4 $normalPlotTiming),
     MemoryConstraint -> (6 $normalPlotMemory)],
   {edgeType, $edgeTypes},
   {layout, $layouts}]

--- a/SetReplace/setSubstitutionSystem$cpp.m
+++ b/SetReplace/setSubstitutionSystem$cpp.m
@@ -28,7 +28,7 @@ With[{libraryFile = FindLibrary["libSetReplace"]},
 				{Integer, 1}, (* initial set *)
 				{Integer, 1}}, (* {generations, steps} *)
 			{Integer, 1}],
-		$Failed]]
+		$Failed]];
 
 
 (* ::Section:: *)


### PR DESCRIPTION
## Changes

* Closes #84 .
* Implements `RulePlot` for hypergraph rules of `WolframModel` (pattern rules are not supported).
* `RulePlot` supports the following options: `"EdgeType"`, `GraphLayout`, `VertexCoordianteRules`, `VertexLabels`, `Frame`, `FrameStyle`, `PlotLegends`, `Spacings`, and all `Graphics` options.
* Improves scaling in `HypergraphPlot`:
  * Vertices are now always the same size.
  * Arrows are replaced with custom-implemented arrows that are always the same absolute size.
  * Self-loops are always the same size assuming 1 or fewer coordinate constraints.
  * Average edge lengths are always the same assuming 1 or fewer coordinate constraints.
* Fixes a bug where specifying the same vertex constraint twice would generate invalid `Graphics`.

## Known issues

* Scaling will not work correctly if 2 or more coordinate constraints are specified. This has to do with limitations of `GraphPlot`.
* `HypergraphPlot` performance is now 4 times worse in time, and 7 times worse in memory compared to `GraphPlot` (down from 3 and 6 respectively).

## Tests

* Run unit tests: `./build.wls && ./install.wls && ./test.wls`.
* Plot a simple rule:
```
In[] := RulePlot[WolframModel[{{1, 2, 3}, {3, 4, 5}} -> {{3, 4, 5}, {5, 6, 
     7}}]]
```
![image](https://user-images.githubusercontent.com/1479325/68523579-328b8180-0289-11ea-8f69-ca8b053becd7.png)
* Label vertices:
```
In[] := RulePlot[WolframModel[{{1, 2, 3}, {3, 4, 5}} -> {{3, 4, 5}, {5, 6, 
     7}}], VertexLabels -> Automatic]
```
![image](https://user-images.githubusercontent.com/1479325/68523582-40d99d80-0289-11ea-823f-275961e07b22.png)
* Plot a rule from the readme:
```
In[] := RulePlot[WolframModel[{{0, 1}, {0, 2}, {0, 3}} -> {{4, 5}, {5, 4}, {4,
      6}, {6, 4}, {5, 6}, {6, 5}, {4, 1}, {5, 2}, {6, 3}}]]
```
![image](https://user-images.githubusercontent.com/1479325/68523594-5d75d580-0289-11ea-8627-d31e59f608a9.png)
* And another one:
```
In[] := RulePlot[WolframModel[{{1, 2, 3}} -> {{5, 6, 1}, {6, 4, 2}, {4, 5, 
     3}}]]
```
![image](https://user-images.githubusercontent.com/1479325/68523604-6f577880-0289-11ea-829a-f14b15de1595.png)
* And another one:
```
In[] := RulePlot[WolframModel[{{0, 1}, {0, 2}, {0, 3}} -> {{4, 5}, {5, 4}, {4,
      6}, {6, 4}, {5, 6}, {6, 5}, {4, 1}, {5, 2}, {6, 3}, {1, 6}, {3, 
     4}}]]
```
![image](https://user-images.githubusercontent.com/1479325/68523611-7f6f5800-0289-11ea-84b2-d0b6b5a45599.png)
* Finally,
```
In[] := RulePlot[WolframModel[{{0, 1}, {0, 2}, {0, 3}} -> {{1, 6}, {6, 4}, {6,
      5}, {5, 6}, {6, 3}, {3, 4}, {5, 2}}], PlotLegends -> "Text"]
```
![image](https://user-images.githubusercontent.com/1479325/68523639-cbba9800-0289-11ea-986d-a383215fb5eb.png)
* Note, the arrows are always the same size relative to the vertices (and end at the edge instead of the middle of the vertex):
```
In[] := HypergraphPlot[{{1, 2}}]
```
![image](https://user-images.githubusercontent.com/1479325/68523629-ae85c980-0289-11ea-8b41-d1dbae22e613.png)
```
In[] := HypergraphPlot[{{1, 2, 3, 4, 5, 6}}]
```
![image](https://user-images.githubusercontent.com/1479325/68523632-b47baa80-0289-11ea-90cd-eb8cffb3867d.png)
