### PR TITLE
libSetReplace interactive API

### DIFF
--- a/SetReplace/libSetReplace/Match.hpp
+++ b/SetReplace/libSetReplace/Match.hpp
@@ -39,13 +39,12 @@ namespace SetReplace {
          */
         Matcher(const std::vector<Rule>& rules,
                 AtomsIndex& atomsIndex,
-                const std::function<AtomsVector(ExpressionID)> getAtomsVector,
-                const std::function<bool()> shouldAbort);
+                const std::function<AtomsVector(ExpressionID)> getAtomsVector);
         
         /** @brief Finds and adds to the index all matches involving specified expressions.
          * @details Calls shouldAbort() frequently, and throws Error::Aborted if that returns true. Otherwise might take significant time to evaluate depending on the system.
          */
-        void addMatchesInvolvingExpressions(const std::vector<ExpressionID>& expressionIDs);
+        void addMatchesInvolvingExpressions(const std::vector<ExpressionID>& expressionIDs, const std::function<bool()> shouldAbort);
         
         /** @brief Removes matches containing specified expression IDs from the index.
          */

--- a/SetReplace/libSetReplace/Set.hpp
+++ b/SetReplace/libSetReplace/Set.hpp
@@ -19,24 +19,22 @@ namespace SetReplace {
         
         /** @brief Creates a new set with a given set of evolution rules, and initial condition.
          * @param rules substittion rules used for evolution. Note, these rules cannot be changed.
-         * @param initialExpressions initial condition, which will be indexed at constraction, so this operation is not instant.
-         * @param shouldAbort function that should return true if Wolfram Language abort is in progress.
-         * @param maxGeneration largest generation created. Events will never be created which have this generation expressions as inputs.
+         * @param initialExpressions initial condition. It will be lazily indexed before the first replacement.
          */
         Set(const std::vector<Rule>& rules,
-            const std::vector<AtomsVector>& initialExpressions,
-            const std::function<bool()> shouldAbort,
-            const Generation maxGeneration = std::numeric_limits<Generation>::max());
+            const std::vector<AtomsVector>& initialExpressions);
         
         /** @brief Perform a single substitution, create the corresponding event, and output expressions.
+         * @param shouldAbort function that should return true if Wolfram Language abort is in progress.
          * @return 1 if substitution was made, 0 if no matches were found.
          */
-        int replaceOnce();
+        int replaceOnce(const std::function<bool()> shouldAbort);
         
-        /** @brief Run replaceOnce() substitutionCount times.
+        /** @brief Run replaceOnce() substitutionCount times, or until the next expression produced has generation larger than maxGeneration.
+         * @param shouldAbort function that should return true if Wolfram Language abort is in progress.
          * @return The number of subtitutions made, could be between 0 and substitutionCount.
          */
-        int replace(const int substitutionCount = std::numeric_limits<int>::max());
+        int replace(const Generation maxGeneration, const int substitutionCount, const std::function<bool()> shouldAbort);
         
         /** @brief List of all expressions in the set, past and present.
          */

--- a/SetReplace/libSetReplace/SetReplace.hpp
+++ b/SetReplace/libSetReplace/SetReplace.hpp
@@ -11,6 +11,22 @@ EXTERN_C DLLEXPORT int WolframLibrary_initialize(WolframLibraryData libData);
 
 EXTERN_C DLLEXPORT void WolframLibrary_uninitialize(WolframLibraryData libData);
 
+/** @brief Creates a new set object.
+ * @return Pointer to the newly created set in memory.
+ * @note Memory is not managed, the set needs to be destroyed manually.
+*/
+EXTERN_C DLLEXPORT int setCreate(WolframLibraryData libData, mint argc, MArgument *argv, MArgument result);
+
+/** @brief Destroys a set given a pointer.
+ */
+EXTERN_C DLLEXPORT int setDelete(WolframLibraryData libData, mint argc, MArgument *argv, MArgument result);
+
+/** @brief Performs a specified number of replacements, but does not return anything.
+ */
 EXTERN_C DLLEXPORT int setReplace(WolframLibraryData libData, mint argc, MArgument *argv, MArgument result);
+
+/** @brief Returns a list of expressions for a specified set pointer.
+ */
+EXTERN_C DLLEXPORT int setExpressions(WolframLibraryData libData, mint argc, MArgument *argv, MArgument result);
 
 #endif /* SetReplace_hpp */


### PR DESCRIPTION
## Changes

* Adds an interactive API to libSetReplace. Initially four functions are implemented:
  * `setCreate`: creates a `Set` instance from rules and init and returns a pointer to it as an `Integer`.
  * `setReplace`: atomically performs a requested number of replacements on the set given a pointer and steps spec. Does not return anything, updates the set in-place.
  * `setExpressions`: returns expressions given the set pointer.
  * `setDelete`: deletes the set from memory.
* `setSubstitutionSystem$cpp` is updated to use these functions.

## Discussion

* This makes all kinds of things possible:
  * Evaluation of `setReplace` can be aborted without losing results. Results can still be obtained with `setExpressions`.
  * It is possible to pause and resume evaluation.
  * Using that, one can implement progress monitoring.
  * We can even change `WolframModelEvolutionObject` to just store the pointer instead of data, which would allow lightning-fast evaluation of properties and such.

## Caveats

* Manual memory management on Wolfram Language side is required to avoid memory leaks.

## Tests

* Run unit tests to make sure nothing's broken: `./build.wls && ./install.wls && ./test.wls`.
* Create a set with rule `{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}` and initial set `{{0, 0}}`. The output is literally the pointer to the memory where the set is located:
```
In[] := SetReplace`setSubstitutionSystem$cpp`PackagePrivate`$cpp$setCreate[
 SetReplace`setSubstitutionSystem$cpp`PackagePrivate`\
encodeNestedLists[{{{{-1, -2}}, {{-1, -3}, {-1, -3}, {-3, -2}}}}], 
 SetReplace`setSubstitutionSystem$cpp`PackagePrivate`\
encodeNestedLists[{{1, 1}}]]
```
```
Out[] = 140549036217664
```
* Run the set for `100` events (generations set to `2^31 - 1`, which is infinity):
```
In[] := SetReplace`setSubstitutionSystem$cpp`PackagePrivate`$cpp$setReplace[\
140549036217664, {2^31 - 1, 100}]
```
* Extract and plot final expressions:
```
In[] := WolframModelEvolutionObject[
   Join[SetReplace`setSubstitutionSystem$cpp`PackagePrivate`\
decodeExpressions[
     SetReplace`setSubstitutionSystem$cpp`PackagePrivate`$cpp$\
setExpressions[140549036217664]], <|
     SetReplace`PackageScope`$rules -> Missing[]|>]][
  "FinalState"] // HypergraphPlot
```
![image](https://user-images.githubusercontent.com/1479325/68534824-1af2de00-0307-11ea-8922-ebb928f9e276.png)
* Run another `100` events:
```
In[] := SetReplace`setSubstitutionSystem$cpp`PackagePrivate`$cpp$setReplace[\
140549036217664, {2^31 - 1, 100}]
```
```
In[] := WolframModelEvolutionObject[
   Join[SetReplace`setSubstitutionSystem$cpp`PackagePrivate`\
decodeExpressions[
     SetReplace`setSubstitutionSystem$cpp`PackagePrivate`$cpp$\
setExpressions[140549036217664]], <|
     SetReplace`PackageScope`$rules -> Missing[]|>]][
  "FinalState"] // HypergraphPlot
```
![image](https://user-images.githubusercontent.com/1479325/68534828-30680800-0307-11ea-8bd6-b1fefa784488.png)
* Run for `10000` events which would take a bit longer:
```
In[] := SetReplace`setSubstitutionSystem$cpp`PackagePrivate`$cpp$setReplace[\
140549036217664, {2^31 - 1, 10000}]
```
* Notice this takes about 0.4 seconds. Now, run one extra step:
```
In[] := SetReplace`setSubstitutionSystem$cpp`PackagePrivate`$cpp$setReplace[\
140549036217664, {2^31 - 1, 1}]
```
* Notice that was instant. Now, check that all events evaluated so far have been accumulated to a single evolution object:
```
In[] := WolframModelEvolutionObject[
 Join[SetReplace`setSubstitutionSystem$cpp`PackagePrivate`\
decodeExpressions[
   SetReplace`setSubstitutionSystem$cpp`PackagePrivate`$cpp$\
setExpressions[140549036217664]], <|
   SetReplace`PackageScope`$rules -> Missing[]|>]]
```
![image](https://user-images.githubusercontent.com/1479325/68534850-6dcc9580-0307-11ea-9f25-e618a36c4774.png)
* Complete `11` generations:
```
In[] := SetReplace`setSubstitutionSystem$cpp`PackagePrivate`$cpp$setReplace[\
140549036217664, {11, 2^31 - 1}]
```
```
In[] := WolframModelEvolutionObject[
 Join[SetReplace`setSubstitutionSystem$cpp`PackagePrivate`\
decodeExpressions[
   SetReplace`setSubstitutionSystem$cpp`PackagePrivate`$cpp$\
setExpressions[140549036217664]], <|
   SetReplace`PackageScope`$rules -> Missing[]|>]]
```
![image](https://user-images.githubusercontent.com/1479325/68534870-b4ba8b00-0307-11ea-9aec-c28c6ba2bfbd.png)
* Check that what we got is the same as if we ran `11` generations from the beginning:
```
In[] := WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 11, 
  "FinalState"] === %["FinalState"]
```
```
Out[] = True
```