### PR TITLE
TimeConstraint and result on Abort

### DIFF
--- a/SetReplace/SetReplace.m
+++ b/SetReplace/SetReplace.m
@@ -72,7 +72,7 @@ Options[SetReplace] := Options[setSubstitutionSystem]
 SetReplace[set_, rules_, events : Except[_ ? OptionQ] : 1, o : OptionsPattern[]] :=
 	Module[{result},
 		result = Check[
-			setSubstitutionSystem[rules, set, Infinity, events, SetReplace, o][-1],
+			setSubstitutionSystem[rules, set, Infinity, events, SetReplace, False, o][-1],
 			$Failed];
 		result /; result =!= $Failed
 	]

--- a/SetReplace/SetReplace.m
+++ b/SetReplace/SetReplace.m
@@ -72,7 +72,7 @@ Options[SetReplace] := Options[setSubstitutionSystem]
 SetReplace[set_, rules_, events : Except[_ ? OptionQ] : 1, o : OptionsPattern[]] :=
 	Module[{result},
 		result = Check[
-			setSubstitutionSystem[rules, set, Infinity, events, SetReplace, False, o][-1],
+			setSubstitutionSystem[rules, set, Infinity, events, SetReplace, False, o],
 			$Failed];
-		result /; result =!= $Failed
+		If[result === $Aborted, result, result[-1]] /; result =!= $Failed
 	]

--- a/SetReplace/SetReplace.wlt
+++ b/SetReplace/SetReplace.wlt
@@ -78,6 +78,14 @@ VerificationTest[
 	{SetReplace::invalidMethod}
 ]
 
+(** TimeConstraint is valid **)
+
+VerificationTest[
+  SetReplace[{{0, 0}}, ToPatternRules[{{1, 2}} -> {{1, 3}, {3, 2}}], 100, TimeConstraint -> #],
+  SetReplace[{{0, 0}}, ToPatternRules[{{1, 2}} -> {{1, 3}, {3, 2}}], 100, TimeConstraint -> #],
+  {SetReplace::timc}
+] & /@ {0, -1, "x"}
+
 (* Implementation *)
 
 (** Simple examples **)
@@ -205,5 +213,17 @@ VerificationTest[
 	SetReplace[{{1, 2}, {3, 4}}, {} -> {{1, 3}, {2, 4}}, Method -> "LowLevel"],
 	{SetReplace::lowLevelNotImplemented}
 ]
+
+(* TimeConstraint *)
+
+VerificationTest[
+	SetReplace[{{0, 0}}, ToPatternRules[{{1, 2}} -> {{1, 3}, {3, 2}}], 100000, Method -> #, TimeConstraint -> 0.1],
+	$Aborted
+] & /@ $SetReplaceMethods
+
+VerificationTest[
+	TimeConstrained[SetReplace[{{0, 0}}, ToPatternRules[{{1, 2}} -> {{1, 3}, {3, 2}}], 100000, Method -> #], 0.1],
+	$Aborted
+] & /@ $SetReplaceMethods
 
 EndTestSection[]

--- a/SetReplace/SetReplaceAll.m
+++ b/SetReplace/SetReplaceAll.m
@@ -69,7 +69,7 @@ SetReplaceAll[
 	Module[{result},
 		result = Check[
 			setSubstitutionSystem[
-				rules, set, generations, Infinity, SetReplaceAll, False, o][-1],
+				rules, set, generations, Infinity, SetReplaceAll, False, o],
 			$Failed];
-		result /; result =!= $Failed
+		If[result === $Aborted, result, result[-1]] /; result =!= $Failed
 	]

--- a/SetReplace/SetReplaceAll.m
+++ b/SetReplace/SetReplaceAll.m
@@ -69,7 +69,7 @@ SetReplaceAll[
 	Module[{result},
 		result = Check[
 			setSubstitutionSystem[
-				rules, set, generations, Infinity, SetReplaceAll, o][-1],
+				rules, set, generations, Infinity, SetReplaceAll, False, o][-1],
 			$Failed];
 		result /; result =!= $Failed
 	]

--- a/SetReplace/SetReplaceAll.wlt
+++ b/SetReplace/SetReplaceAll.wlt
@@ -147,4 +147,16 @@ VerificationTest[
   {{0, 4}}
 ]
 
+(* TimeConstraint *)
+
+VerificationTest[
+  SetReplaceAll[{{0, 0}}, ToPatternRules[{{1, 2}} -> {{1, 3}, {3, 2}}], 100, Method -> #, TimeConstraint -> 0.1],
+  $Aborted
+] & /@ $SetReplaceMethods
+
+VerificationTest[
+  TimeConstrained[SetReplaceAll[{{0, 0}}, ToPatternRules[{{1, 2}} -> {{1, 3}, {3, 2}}], 100, Method -> #], 0.1],
+  $Aborted
+] & /@ $SetReplaceMethods
+
 EndTestSection[]

--- a/SetReplace/SetReplaceFixedPoint.m
+++ b/SetReplace/SetReplaceFixedPoint.m
@@ -62,7 +62,7 @@ Options[SetReplaceFixedPoint] := Options[setSubstitutionSystem]
 SetReplaceFixedPoint[set_, rules_, o : OptionsPattern[]] := Module[{result},
 	result = Check[
 		setSubstitutionSystem[
-			rules, set, Infinity, Infinity, SetReplaceFixedPoint, False, o][-1],
+			rules, set, Infinity, Infinity, SetReplaceFixedPoint, False, o],
 		$Failed];
-	result /; result =!= $Failed
+	If[result === $Aborted, result, result[-1]] /; result =!= $Failed
 ]

--- a/SetReplace/SetReplaceFixedPoint.m
+++ b/SetReplace/SetReplaceFixedPoint.m
@@ -62,7 +62,7 @@ Options[SetReplaceFixedPoint] := Options[setSubstitutionSystem]
 SetReplaceFixedPoint[set_, rules_, o : OptionsPattern[]] := Module[{result},
 	result = Check[
 		setSubstitutionSystem[
-			rules, set, Infinity, Infinity, SetReplaceFixedPoint, o][-1],
+			rules, set, Infinity, Infinity, SetReplaceFixedPoint, False, o][-1],
 		$Failed];
 	result /; result =!= $Failed
 ]

--- a/SetReplace/SetReplaceFixedPoint.wlt
+++ b/SetReplace/SetReplaceFixedPoint.wlt
@@ -69,4 +69,16 @@ VerificationTest[
   $Aborted
 ]
 
+(* TimeConstraint *)
+
+VerificationTest[
+  SetReplaceFixedPoint[{{0, 0}}, ToPatternRules[{{1, 2}} -> {{1, 3}, {3, 2}}], Method -> #, TimeConstraint -> 0.1],
+  $Aborted
+] & /@ $SetReplaceMethods
+
+VerificationTest[
+  TimeConstrained[SetReplaceFixedPoint[{{0, 0}}, ToPatternRules[{{1, 2}} -> {{1, 3}, {3, 2}}], Method -> #], 0.1],
+  $Aborted
+] & /@ $SetReplaceMethods
+
 EndTestSection[]

--- a/SetReplace/SetReplaceFixedPointList.m
+++ b/SetReplace/SetReplaceFixedPointList.m
@@ -63,6 +63,6 @@ SetReplaceFixedPointList[set_, rules_, o : OptionsPattern[]] := Module[{result},
 		setSubstitutionSystem[
 			rules, set, Infinity, Infinity, SetReplaceFixedPointList, False, o],
 		$Failed];
-	result["SetAfterEvent", #] & /@ Range[0, result["EventsCount"]] /;
+	If[result === $Aborted, result, result["SetAfterEvent", #] & /@ Range[0, result["EventsCount"]]] /;
 		result =!= $Failed
 ]

--- a/SetReplace/SetReplaceFixedPointList.m
+++ b/SetReplace/SetReplaceFixedPointList.m
@@ -61,7 +61,7 @@ Options[SetReplaceFixedPointList] := Options[setSubstitutionSystem]
 SetReplaceFixedPointList[set_, rules_, o : OptionsPattern[]] := Module[{result},
 	result = Check[
 		setSubstitutionSystem[
-			rules, set, Infinity, Infinity, SetReplaceFixedPointList, o],
+			rules, set, Infinity, Infinity, SetReplaceFixedPointList, False, o],
 		$Failed];
 	result["SetAfterEvent", #] & /@ Range[0, result["EventsCount"]] /;
 		result =!= $Failed

--- a/SetReplace/SetReplaceFixedPointList.wlt
+++ b/SetReplace/SetReplaceFixedPointList.wlt
@@ -69,4 +69,16 @@ VerificationTest[
   $Aborted
 ]
 
+(* TimeConstraint *)
+
+VerificationTest[
+  SetReplaceFixedPointList[{{0, 0}}, ToPatternRules[{{1, 2}} -> {{1, 3}, {3, 2}}], Method -> #, TimeConstraint -> 0.1],
+  $Aborted
+] & /@ $SetReplaceMethods
+
+VerificationTest[
+  TimeConstrained[SetReplaceFixedPointList[{{0, 0}}, ToPatternRules[{{1, 2}} -> {{1, 3}, {3, 2}}], Method -> #], 0.1],
+  $Aborted
+] & /@ $SetReplaceMethods
+
 EndTestSection[]

--- a/SetReplace/SetReplaceList.m
+++ b/SetReplace/SetReplaceList.m
@@ -59,7 +59,7 @@ Options[SetReplaceList] := Options[setSubstitutionSystem]
 SetReplaceList[set_, rules_, events : Except[_ ? OptionQ] : 1, o : OptionsPattern[]] :=
 	Module[{result},
 		result = Check[
-			setSubstitutionSystem[rules, set, Infinity, events, SetReplaceList, o],
+			setSubstitutionSystem[rules, set, Infinity, events, SetReplaceList, False, o],
 			$Failed];
 		result["SetAfterEvent", #] & /@ Range[0, result["EventsCount"]] /;
 			result =!= $Failed

--- a/SetReplace/SetReplaceList.m
+++ b/SetReplace/SetReplaceList.m
@@ -61,6 +61,6 @@ SetReplaceList[set_, rules_, events : Except[_ ? OptionQ] : 1, o : OptionsPatter
 		result = Check[
 			setSubstitutionSystem[rules, set, Infinity, events, SetReplaceList, False, o],
 			$Failed];
-		result["SetAfterEvent", #] & /@ Range[0, result["EventsCount"]] /;
+		If[result === $Aborted, result, result["SetAfterEvent", #] & /@ Range[0, result["EventsCount"]]] /;
 			result =!= $Failed
 	]

--- a/SetReplace/SetReplaceList.wlt
+++ b/SetReplace/SetReplaceList.wlt
@@ -82,4 +82,16 @@ VerificationTest[
   {{{1, 2}}, {{1, 2}}, {{1, 2}}}
 ]
 
+(* TimeConstraint *)
+
+VerificationTest[
+  SetReplaceList[{{0, 0}}, ToPatternRules[{{1, 2}} -> {{1, 3}, {3, 2}}], 100000, Method -> #, TimeConstraint -> 0.1],
+  $Aborted
+] & /@ $SetReplaceMethods
+
+VerificationTest[
+  TimeConstrained[SetReplaceList[{{0, 0}}, ToPatternRules[{{1, 2}} -> {{1, 3}, {3, 2}}], 100000, Method -> #], 0.1],
+  $Aborted
+] & /@ $SetReplaceMethods
+
 EndTestSection[]

--- a/SetReplace/WolframModel.m
+++ b/SetReplace/WolframModel.m
@@ -164,6 +164,7 @@ WolframModel[
 				generations,
 				events,
 				WolframModel,
+				True,
 				Method -> OptionValue[Method]],
 			$Failed];
 		renamedNodesEvolution = If[evolution =!= $Failed,

--- a/SetReplace/WolframModel.m
+++ b/SetReplace/WolframModel.m
@@ -165,7 +165,8 @@ WolframModel[
 				events,
 				WolframModel,
 				True,
-				Method -> OptionValue[Method]],
+				Method -> OptionValue[Method],
+				TimeConstraint -> OptionValue[TimeConstraint]],
 			$Failed];
 		renamedNodesEvolution = If[evolution =!= $Failed,
 			Check[

--- a/SetReplace/WolframModel.m
+++ b/SetReplace/WolframModel.m
@@ -164,10 +164,11 @@ WolframModel[
 				generations,
 				events,
 				WolframModel,
-				True,
+				property === "EvolutionObject",
 				Method -> OptionValue[Method],
 				TimeConstraint -> OptionValue[TimeConstraint]],
 			$Failed];
+		If[evolution === $Aborted, Return[$Aborted]];
 		renamedNodesEvolution = If[evolution =!= $Failed,
 			Check[
 				renameNodes[

--- a/SetReplace/WolframModel.wlt
+++ b/SetReplace/WolframModel.wlt
@@ -840,6 +840,12 @@ VerificationTest[
   $Aborted
 ] & /@ $SetReplaceMethods
 
+(*** $Aborted should be returned if not an evolution object is asked for. ***)
+VerificationTest[
+  WolframModel[$timeConstraintRule, $timeConstraintInit, 100, "FinalState", Method -> #, TimeConstraint -> 0.1],
+  $Aborted
+] & /@ $SetReplaceMethods
+
 EndTestSection[]
 
 

--- a/SetReplace/WolframModel.wlt
+++ b/SetReplace/WolframModel.wlt
@@ -212,6 +212,12 @@ VerificationTest[
   {WolframModel::argx}
 ]
 
+VerificationTest[
+  WolframModel[{{1, 2}} -> {{1, 3}, {3, 2}}, {{0, 0}}, 100, TimeConstraint -> #],
+  WolframModel[{{1, 2}} -> {{1, 3}, {3, 2}}, {{0, 0}}, 100, TimeConstraint -> #],
+  {WolframModel::timc}
+] & /@ {0, -1, "x"}
+
 (** PatternRules **)
 
 VerificationTest[
@@ -811,6 +817,28 @@ VerificationTest[
     "NodeNamingFunction" -> All],
   {{1, 3}, {3, 2}}
 ]
+
+(** TimeConstraint **)
+
+$timeConstraintRule = {{1, 2}} -> {{1, 3}, {3, 2}};
+$timeConstraintInit = {{0, 0}};
+
+(*** Check that aborted evaluation still produces correct evolutions. ***)
+Table[VerificationTest[
+  And @@ Table[
+    With[{
+        output =
+          WolframModel[$timeConstraintRule, $timeConstraintInit, 100, Method -> method, TimeConstraint -> time]},
+      WolframModel[$timeConstraintRule, $timeConstraintInit, <|"Events" -> output["EventsCount"]|>] === output],
+    100],
+  TimeConstraint -> 60
+], {method, $SetReplaceMethods}, {time, {1.*^-100, 0.1}}]
+
+(*** This does not work with TimeConstrained though, $Aborted is returned in that case. ***)
+VerificationTest[
+  TimeConstrained[WolframModel[$timeConstraintRule, $timeConstraintInit, 100, Method -> #], 0.1],
+  $Aborted
+] & /@ $SetReplaceMethods
 
 EndTestSection[]
 

--- a/SetReplace/setSubstitutionSystem$cpp.m
+++ b/SetReplace/setSubstitutionSystem$cpp.m
@@ -168,7 +168,7 @@ $cppSetReplaceAvailable = $cpp$setReplace =!= $Failed;
 $maxInt = 2^31 - 1;
 
 
-setSubstitutionSystem$cpp[rules_, set_, generations_, steps_, returnOnAbortQ_] /;
+setSubstitutionSystem$cpp[rules_, set_, generations_, steps_, returnOnAbortQ_, timeConstraint_] /;
 			$cppSetReplaceAvailable := Module[{
 		canonicalRules,
 		setAtoms, atomsInRules, globalAtoms, globalIndex,
@@ -191,10 +191,12 @@ setSubstitutionSystem$cpp[rules_, set_, generations_, steps_, returnOnAbortQ_] /
 	setPtr = $cpp$setCreate[
 		encodeNestedLists[List @@@ mappedRules],
 		encodeNestedLists[mappedSet]];
-	CheckAbort[
-		$cpp$setReplace[setPtr, {generations, steps} /. {\[Infinity] -> $maxInt}],
-		If[!returnOnAbortQ, Abort[]]
-	];
+	TimeConstrained[
+		CheckAbort[
+			$cpp$setReplace[setPtr, {generations, steps} /. {\[Infinity] -> $maxInt}],
+			If[!returnOnAbortQ, Abort[]]],
+		timeConstraint,
+		If[!returnOnAbortQ, Return[$Aborted]]];
 	cppOutput = decodeExpressions @ $cpp$setExpressions[setPtr];
 	$cpp$setDelete[setPtr];
 	resultAtoms = Union[Flatten[cppOutput[$atomLists]]];

--- a/SetReplace/setSubstitutionSystem$cpp.m
+++ b/SetReplace/setSubstitutionSystem$cpp.m
@@ -168,7 +168,7 @@ $cppSetReplaceAvailable = $cpp$setReplace =!= $Failed;
 $maxInt = 2^31 - 1;
 
 
-setSubstitutionSystem$cpp[rules_, set_, generations_, steps_] /;
+setSubstitutionSystem$cpp[rules_, set_, generations_, steps_, returnOnAbortQ_] /;
 			$cppSetReplaceAvailable := Module[{
 		canonicalRules,
 		setAtoms, atomsInRules, globalAtoms, globalIndex,
@@ -191,7 +191,10 @@ setSubstitutionSystem$cpp[rules_, set_, generations_, steps_] /;
 	setPtr = $cpp$setCreate[
 		encodeNestedLists[List @@@ mappedRules],
 		encodeNestedLists[mappedSet]];
-	$cpp$setReplace[setPtr, {generations, steps} /. {\[Infinity] -> $maxInt}];
+	CheckAbort[
+		$cpp$setReplace[setPtr, {generations, steps} /. {\[Infinity] -> $maxInt}],
+		If[!returnOnAbortQ, Abort[]]
+	];
 	cppOutput = decodeExpressions @ $cpp$setExpressions[setPtr];
 	$cpp$setDelete[setPtr];
 	resultAtoms = Union[Flatten[cppOutput[$atomLists]]];

--- a/SetReplace/setSubstitutionSystem$wl.m
+++ b/SetReplace/setSubstitutionSystem$wl.m
@@ -111,15 +111,21 @@ toNormalRules[rules_List] := Module[{
 (*This function just does the replacements, but it does not keep track of any metadata (generations and events).*)
 
 
-setReplace$wl[set_, rules_, n_, returnOnAbortQ_] := Module[{normalRules, partialResult},
+setReplace$wl[set_, rules_, n_, returnOnAbortQ_, timeConstraint_] := Module[{normalRules, partialResult},
 	normalRules = toNormalRules @ rules;
-	CheckAbort[
-		FixedPoint[(partialResult = ReplaceAll[#, normalRules]) &, List @@ set, n],
+	partialResult = set;
+	TimeConstrained[
+		CheckAbort[
+			FixedPoint[AbortProtect[partialResult = ReplaceAll[#, normalRules]] &, List @@ set, n],
+			If[returnOnAbortQ,
+				partialResult,
+				Abort[]
+			]],
+		timeConstraint,
 		If[returnOnAbortQ,
 			partialResult,
-			Abort[]
-		]
-	]
+			Return[$Aborted]
+		]]
 ]
 
 
@@ -200,7 +206,7 @@ addMetadataManagement[
 (*This function runs a modified version of the set replace system that also keeps track of metadata such as generations and events. It uses setReplace$wl to evaluate that modified system.*)
 
 
-setSubstitutionSystem$wl[rules_, set_, generations_, steps_, returnOnAbortQ_] := Module[{
+setSubstitutionSystem$wl[rules_, set_, generations_, steps_, returnOnAbortQ_, timeConstraint_] := Module[{
 		setWithMetadata, rulesWithMetadata, outputWithMetadata, result,
 		nextExpressionID = 1, nextEventID = 1, nextExpression},
 	nextExpression = nextExpressionID++ &;
@@ -208,7 +214,8 @@ setSubstitutionSystem$wl[rules_, set_, generations_, steps_, returnOnAbortQ_] :=
 	setWithMetadata = {nextExpression[], 0, \[Infinity], 0, #} & /@ set;
 	rulesWithMetadata = addMetadataManagement[
 		#, nextEventID++ &, nextExpression, generations] & /@ toCanonicalRules[rules];
-	outputWithMetadata = Reap[setReplace$wl[setWithMetadata, rulesWithMetadata, steps, returnOnAbortQ]];
+	outputWithMetadata = Reap[setReplace$wl[setWithMetadata, rulesWithMetadata, steps, returnOnAbortQ, timeConstraint]];
+	If[outputWithMetadata[[1]] === $Aborted, Return[$Aborted]];
 	result = SortBy[
 		Join[
 			outputWithMetadata[[1]],

--- a/SetReplace/setSubstitutionSystem.m
+++ b/SetReplace/setSubstitutionSystem.m
@@ -158,7 +158,7 @@ setSubstitutionSystem[
 			&& MatchQ[canonicalRules, {___ ? simpleRuleQ}],
 		If[$cppSetReplaceAvailable,
 			Return[
-				setSubstitutionSystem$cpp[rules, set, generations, steps]]]];
+				setSubstitutionSystem$cpp[rules, set, generations, steps, returnOnAbortQ]]]];
 	If[MatchQ[method, $cppMethod],
 		failedQ = True;
 		If[!$cppSetReplaceAvailable,

--- a/SetReplace/setSubstitutionSystem.m
+++ b/SetReplace/setSubstitutionSystem.m
@@ -41,7 +41,7 @@ $SetReplaceMethods::usage = usageString[
 
 
 setSubstitutionSystem[
-		rules_, set_, generations_, maxEvents_, caller_, o : OptionsPattern[]] := 0 /;
+		rules_, set_, generations_, maxEvents_, caller_, returnOnAbortQ_, o : OptionsPattern[]] := 0 /;
 	!ListQ[set] &&
 	makeMessage[caller, "setNotList", set]
 
@@ -55,7 +55,7 @@ setReplaceRulesQ[rules_] :=
 
 
 setSubstitutionSystem[
-		rules_, set_, generations_, maxEvents_, caller_, o : OptionsPattern[]] := 0 /;
+		rules_, set_, generations_, maxEvents_, caller_, returnOnAbortQ_, o : OptionsPattern[]] := 0 /;
 	!setReplaceRulesQ[rules] &&
 	makeMessage[caller, "invalidRules", rules]
 
@@ -68,13 +68,13 @@ stepCountQ[n_] := IntegerQ[n] && n >= 0 || n == \[Infinity]
 
 
 setSubstitutionSystem[
-		rules_, set_, generations_, maxEvents_, caller_, o : OptionsPattern[]] := 0 /;
+		rules_, set_, generations_, maxEvents_, caller_, returnOnAbortQ_, o : OptionsPattern[]] := 0 /;
 	!stepCountQ[generations] &&
 	makeMessage[caller, "nonIntegerIterations", "generations", generations]
 
 
 setSubstitutionSystem[
-		rules_, set_, generations_, maxEvents_, caller_, o : OptionsPattern[]] := 0 /;
+		rules_, set_, generations_, maxEvents_, caller_, returnOnAbortQ_, o : OptionsPattern[]] := 0 /;
 	!stepCountQ[maxEvents] &&
 	makeMessage[caller, "nonIntegerIterations", "replacements", maxEvents]
 
@@ -91,7 +91,7 @@ $SetReplaceMethods = {Automatic, $cppMethod, $wlMethod};
 
 
 setSubstitutionSystem[
-		rules_, set_, generations_, maxEvents_, caller_, o : OptionsPattern[]] := 0 /;
+		rules_, set_, generations_, maxEvents_, caller_, returnOnAbortQ_, o : OptionsPattern[]] := 0 /;
 	!MatchQ[OptionValue[Method], Alternatives @@ $SetReplaceMethods] &&
 	makeMessage[caller, "invalidMethod"]
 
@@ -149,6 +149,7 @@ setSubstitutionSystem[
 			generations_ ? stepCountQ,
 			steps_ ? stepCountQ,
 			caller_,
+			returnOnAbortQ_,
 			o : OptionsPattern[]] := Module[{
 		method = OptionValue[Method], canonicalRules, failedQ = False},
 	canonicalRules = toCanonicalRules[rules];
@@ -165,5 +166,5 @@ setSubstitutionSystem[
 			makeMessage[caller, "lowLevelNotImplemented"]]];
 	If[failedQ || !MatchQ[OptionValue[Method], Alternatives @@ $SetReplaceMethods],
 		$Failed,
-		setSubstitutionSystem$wl[rules, set, generations, steps]]
+		setSubstitutionSystem$wl[rules, set, generations, steps, returnOnAbortQ]]
 ]


### PR DESCRIPTION
## Changes

* `WolframModel` now *usually* returns an evolution object when abort is triggered.
* Sometimes an abort would be triggered before or after the evolution of the system was computed, in which case the result will not be returned.
* If you are really in a hurry, just press cmd+. twice, and it will abort immediately without returning a result.
* New option `TimeConstraint` is implemented for `WolframModel` and related functions. This is guaranteed to return a result if evolution object is supposed to be returned, and will always return `$Aborted` otherwise.

## Caveats

* Right now, it is not possible to determine if the evolution is complete or not if generations count is requested, because the last generation might not be complete.
* Possible solution is to include "evolution targets" to the evolution object, together with the current status, which could be "ReachedFixedPoint", "Complete", or "Incomplete".
* Then, the status can be requested as an evolution object property.
* This will also make it easier to resume evolution of the object, because it will just need to be passed to `WolframModel` without any other arguments.

## Tests

* Run unit tests: `./build.wls && ./install.wls && ./test.wls`
* Try running a model for a ridiculous number of generations, but abort early:
```
In[] := model = WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{0, 0}}, 
  100]
```
![image](https://user-images.githubusercontent.com/1479325/68536639-eccfc700-0323-11ea-911b-3f007dd8fdca.png)
* In this case, `34293` events were computed so far (yours will be different). Now, check that if we make an evolution object from scratch with the same number of events, we will get exactly the same result:
```
In[] := WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{0, 0}}, <|
   "Events" -> 34293|>] === model
```
```
Out[] = True
```
* Similar result can be achieved with a `TimeConstraint` option:
```
In[] := WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{0, 0}}, 100, 
 TimeConstraint -> 1]
```
![image](https://user-images.githubusercontent.com/1479325/68536690-ca8a7900-0324-11ea-8a58-49d7e436950f.png)