### PR TITLE
fromCounts

### DIFF
--- a/SetReplace/utilities.m
+++ b/SetReplace/utilities.m
@@ -1,6 +1,7 @@
 Package["SetReplace`"]
 
 PackageScope["vertexList"]
+PackageScope["fromCounts"]
 
 vertexList[edges_] := Union[Catenate[edges]]
 

--- a/SetReplace/utilities.m
+++ b/SetReplace/utilities.m
@@ -3,3 +3,5 @@ Package["SetReplace`"]
 PackageScope["vertexList"]
 
 vertexList[edges_] := Union[Catenate[edges]]
+
+fromCounts[association_] := Catenate @ KeyValueMap[ConstantArray] @ association


### PR DESCRIPTION
## Changes

* Adds `fromCounts` function to utilities.

## Tests

* `fromCounts` is a reverse of `Counts`:
```
In[] := fromCounts[<|1 -> 3, 2 -> 2, "x" -> 4|>]
```
```
Out[] = {1, 1, 1, 2, 2, "x", "x", "x", "x"}
```
```
In[] := fromCounts[Counts@#] == # &[{1, 2, 3, 3, 3, 4, 5, 6, 6, 7}]
```
```
Out[] = True
```