### PR TITLE
multisetIntersection

### DIFF
--- a/SetReplace/utilities.m
+++ b/SetReplace/utilities.m
@@ -2,7 +2,10 @@ Package["SetReplace`"]
 
 PackageScope["vertexList"]
 PackageScope["fromCounts"]
+PackageScope["multisetIntersection"]
 
 vertexList[edges_] := Union[Catenate[edges]]
 
 fromCounts[association_] := Catenate @ KeyValueMap[ConstantArray] @ association
+
+multisetIntersection[sets___] := fromCounts[Merge[KeyIntersection[Counts /@ {sets}], Min]]


### PR DESCRIPTION
## Changes

* Adds `multisetIntersection` to utilities.

## Tests

* Find common elements in three multisets:
```
In[] := SetReplace`PackageScope`multisetIntersection[
 {1, 1, 2, 2, 3}, {1, 2, 2, 2, 4}, {1, 2, 2}]
```
```
Out[] = {1, 2, 2}
```