### PR TITLE
RulePlot: Highlight shared edges

### DIFF
--- a/SetReplace/RulePlot.m
+++ b/SetReplace/RulePlot.m
@@ -147,15 +147,14 @@ rulePlot[
 
 (* returns {shapes, plotRange} *)
 singleRulePlot[edgeType_, graphLayout_, externalVertexCoordinateRules_, vertexLabels_, spacings_][rule_] := Module[{
-    vertexCoordinateRules, sharedVertices, ruleSidePlots, plotRange},
+    vertexCoordinateRules, ruleSidePlots, plotRange},
   vertexCoordinateRules = Join[
     ruleCoordinateRules[edgeType, graphLayout, externalVertexCoordinateRules, rule],
     externalVertexCoordinateRules];
-  sharedVertices = sharedRuleVertices[rule];
   ruleSidePlots = hypergraphPlot[
       #,
       edgeType,
-      sharedVertices,
+      sharedRuleElements[rule],
       graphLayout,
       vertexCoordinateRules,
       vertexLabels,
@@ -181,7 +180,7 @@ ruleCoordinateRules[edgeType_, graphLayout_, externalVertexCoordinateRules_, in_
   #[[1]] -> #[[2, 1, 1]] & /@
     hypergraphEmbedding[edgeType, graphLayout, externalVertexCoordinateRules][layoutReferenceSide[in, out]][[1]]
 
-sharedRuleVertices[in_ -> out_] := Intersection @@ (Catenate /@ {in, out})
+sharedRuleElements[in_ -> out_] := multisetIntersection @@ (Join[vertexList[#], #] & /@ {in, out})
 
 $ruleArrowShape = {Line[{{-1, 0.7}, {0, 0}, {-1, -0.7}}], Line[{{-1, 0}, {0, 0}}]};
 


### PR DESCRIPTION
## Changes

* Closes #102 .
* `RulePlot` now highlights shared edges as well, not just vertices.

## Tests

* Check unit tests still pass: `./build.wls && ./install.wls && ./test.wls`.
* Shared edges are now highlighted:
```
In[] := RulePlot[WolframModel[{{1, 2}} -> {{1, 2}, {2, 3}}]]
```
![image](https://user-images.githubusercontent.com/1479325/68633855-6e109080-04c1-11ea-964d-0b7ee06ffca8.png)
* That includes hyperedges:
```
In[] := RulePlot[WolframModel[{{1, 2, 3}, {3, 4, 5}} -> {{3, 4, 5}, {5, 6, 
     7}}]]
```
![image](https://user-images.githubusercontent.com/1479325/68633862-77016200-04c1-11ea-82af-5a17dcb0767f.png)
* Makes it easier to see that an edge orientation has changed, for example:
```
In[] := RulePlot[WolframModel[{{1, 2, 3}} -> {{2, 3, 1}}]]
```
![image](https://user-images.githubusercontent.com/1479325/68633880-884a6e80-04c1-11ea-9273-349e1fbe4da5.png)