### PR TITLE
GraphHighlightStyle

### DIFF
--- a/SetReplace/HypergraphPlot.m
+++ b/SetReplace/HypergraphPlot.m
@@ -268,10 +268,7 @@ drawEmbedding[vertexLabels_, highlight_, highlightColor_, vertexSize_, arrowhead
 
 	vertexPoints = Cases[embeddingShapes[[1]], #, All] & /@ {
 		highlighted[Point[p_], h_] :> {
-			If[h,
-				Directive[highlightColor, EdgeForm[Directive[highlightColor, Opacity[1]]]],
-				Directive[$vertexColor, EdgeForm[Directive[GrayLevel[0], Opacity[0.7]]]]
-			],
+			Directive[If[h, highlightColor, $vertexColor], EdgeForm[Directive[GrayLevel[0], Opacity[0.7]]]],
 			Disk[p, vertexSize]}
 	};
 

--- a/SetReplace/HypergraphPlot.m
+++ b/SetReplace/HypergraphPlot.m
@@ -16,6 +16,7 @@ SyntaxInformation[HypergraphPlot] = {"ArgumentsPattern" -> {_, OptionsPattern[]}
 Options[HypergraphPlot] = Join[{
 	"EdgeType" -> "CyclicOpen",
 	GraphHighlight -> {},
+	GraphHighlightStyle -> Hue[1.0, 1.0, 0.7],
 	GraphLayout -> "SpringElectricalPolygons",
 	VertexCoordinateRules -> {},
 	VertexLabels -> None},
@@ -35,6 +36,9 @@ General::invalidCoordinates =
 HypergraphPlot::invalidHighlight =
 	"GraphHighlight value `1` should be a list of vertices and edges.";
 
+General::invalidHighlightStyle =
+	"GraphHighlightStyle `1` should be a color.";
+
 (* Evaluation *)
 
 func : HypergraphPlot[args___] := Module[{result = hypergraphPlot$parse[args]},
@@ -53,7 +57,7 @@ hypergraphPlot$parse[edges : Except[{___List}], o : OptionsPattern[]] := (
 hypergraphPlot$parse[edges : {___List}, o : OptionsPattern[]] :=
 	hypergraphPlot[edges, ##, FilterRules[{o}, Options[Graphics]]] & @@
 			(OptionValue[HypergraphPlot, {o}, #] & /@ {
-				"EdgeType", GraphHighlight, GraphLayout, VertexCoordinateRules, VertexLabels}) /;
+				"EdgeType", GraphHighlight, GraphHighlightStyle, GraphLayout, VertexCoordinateRules, VertexLabels}) /;
 		correctHypergraphPlotOptionsQ[HypergraphPlot, Defer[HypergraphPlot[edges, o]], edges, {o}]
 
 hypergraphPlot$parse[___] := $Failed
@@ -64,7 +68,8 @@ correctHypergraphPlotOptionsQ[head_, expr_, edges_, opts_] :=
 			{"EdgeType", $edgeTypes},
 			{GraphLayout, $graphLayouts}})) &&
 	correctCoordinateRulesQ[head, OptionValue[HypergraphPlot, opts, VertexCoordinateRules]] &&
-	correctHighlightQ[edges, OptionValue[HypergraphPlot, opts, GraphHighlight]]
+	correctHighlightQ[edges, OptionValue[HypergraphPlot, opts, GraphHighlight]] &&
+	correctHighlightStyleQ[head, OptionValue[HypergraphPlot, opts, GraphHighlightStyle]]
 
 correctCoordinateRulesQ[head_, coordinateRules_] :=
 	If[!MatchQ[coordinateRules,
@@ -85,6 +90,9 @@ correctHighlightQ[edges : Except[Automatic], highlight_] := Module[{
 
 correctHighlightQ[Automatic, _] := True
 
+correctHighlightStyleQ[head_, highlightStyle_] :=
+	If[ColorQ[highlightStyle], True, Message[head::invalidHighlightStyle, highlightStyle]; False]
+
 (* Implementation *)
 
 $vertexSize = 0.06;
@@ -94,13 +102,14 @@ hypergraphPlot[
 		edges_,
 		edgeType_,
 		highlight_,
+		highlightColor_,
 		layout_,
 		vertexCoordinates_,
 		vertexLabels_,
 		graphicsOptions_,
 		vertexSize_ : $vertexSize,
 		arrowheadsSize_ : $arrowheadLength] := Catch[Show[
-	drawEmbedding[vertexLabels, highlight, vertexSize, arrowheadsSize] @
+	drawEmbedding[vertexLabels, highlight, highlightColor, vertexSize, arrowheadsSize] @
 		hypergraphEmbedding[edgeType, layout, vertexCoordinates] @
 		edges,
 	graphicsOptions
@@ -236,7 +245,6 @@ hypergraphEmbedding[edgeType_, layout : "SpringElectricalPolygons", vertexCoordi
 
 (** Drawing **)
 
-$highlightColor = Hue[1.0, 1.0, 0.7];
 $edgeColor = Hue[0.6, 0.7, 0.5];
 $vertexColor = Hue[0.6, 0.2, 0.8];
 
@@ -245,7 +253,7 @@ $arrowheadShape = Polygon[{
 	{-1.0039, -0.037561}, {-1., 0.}, {-1.0039, 0.0341466}, {-1.01512, 0.0780486}, {-1.03171, 0.127805},
 	{-1.05025, 0.178538}, {-1.08585, 0.264878}, {-1.10196, 0.301464}, {0., 0.}, {-1.10196, -0.289756}}];
 
-drawEmbedding[vertexLabels_, highlight_, vertexSize_, arrowheadLength_][embedding_] := Module[{
+drawEmbedding[vertexLabels_, highlight_, highlightColor_, vertexSize_, arrowheadLength_][embedding_] := Module[{
 		highlightCounts, embeddingShapes, vertexPoints, lines, polygons, polygonBoundaries, edgePoints, labels,
 		singleVertexEdgeCounts, getSingleVertexEdgeRadius},
 	highlightCounts = Counts[highlight];
@@ -261,7 +269,7 @@ drawEmbedding[vertexLabels_, highlight_, vertexSize_, arrowheadLength_][embeddin
 	vertexPoints = Cases[embeddingShapes[[1]], #, All] & /@ {
 		highlighted[Point[p_], h_] :> {
 			If[h,
-				Directive[$highlightColor, EdgeForm[Directive[$highlightColor, Opacity[1]]]],
+				Directive[highlightColor, EdgeForm[Directive[highlightColor, Opacity[1]]]],
 				Directive[$vertexColor, EdgeForm[Directive[GrayLevel[0], Opacity[0.7]]]]
 			],
 			Disk[p, vertexSize]}
@@ -275,14 +283,14 @@ drawEmbedding[vertexLabels_, highlight_, vertexSize_, arrowheadLength_][embeddin
 	{lines, polygons, polygonBoundaries, edgePoints} = Cases[embeddingShapes[[2]], #, All] & /@ {
 		highlighted[Line[pts_], h_] :> {
 			If[h,
-				Directive[Opacity[1], $highlightColor],
+				Directive[Opacity[1], highlightColor],
 				Directive[Opacity[0.7], $edgeColor]
 			],
 			arrow[$arrowheadShape, arrowheadLength, vertexSize][pts]},
 		highlighted[Polygon[pts_], h_] :> {
 			Opacity[0.3],
 			If[h,
-				$highlightColor,
+				highlightColor,
 				Lighter[$edgeColor, 0.7]
 			],
 			Polygon[pts]},
@@ -292,7 +300,7 @@ drawEmbedding[vertexLabels_, highlight_, vertexSize_, arrowheadLength_][embeddin
 			Polygon[pts]},
 		highlighted[Point[p_], h_] :> {
 			If[h,
-				Directive[Opacity[1], $highlightColor],
+				Directive[Opacity[1], highlightColor],
 				Directive[Opacity[0.7], $edgeColor]
 			],
 			Circle[p, getSingleVertexEdgeRadius[p]]}

--- a/SetReplace/HypergraphPlot.wlt
+++ b/SetReplace/HypergraphPlot.wlt
@@ -195,6 +195,31 @@ VerificationTest[
   Graphics
 ]
 
+(* Valid GraphHighlightStyle *)
+
+VerificationTest[
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {1}, GraphHighlightStyle -> None],
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {1}, GraphHighlightStyle -> None],
+  {HypergraphPlot::invalidHighlightStyle}
+]
+
+VerificationTest[
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {1}, GraphHighlightStyle -> 2],
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {1}, GraphHighlightStyle -> 2],
+  {HypergraphPlot::invalidHighlightStyle}
+]
+
+VerificationTest[
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {1}, GraphHighlightStyle -> "Dashed"],
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {1}, GraphHighlightStyle -> "Dashed"],
+  {HypergraphPlot::invalidHighlightStyle}
+]
+
+VerificationTest[
+  Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {1}, GraphHighlightStyle -> Black]],
+  Graphics
+]
+
 (* Implementation *)
 
 (** Simple examples **)
@@ -356,6 +381,16 @@ VerificationTest[
       (HypergraphPlot[{{1, 2}, {1, 2}}, GraphLayout -> "SpringElectricalEmbedding", GraphHighlight -> #] &) /@
       {{}, {{1, 2}}, {{1, 2}, {1, 2}}}],
   {1, -1}
+]
+
+(* GraphHighlightStyle *)
+
+VerificationTest[
+  With[{
+      color = RGBColor[0.4, 0.6, 0.2]},
+    FreeQ[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> #, GraphHighlightStyle -> color], color] & /@
+      {{}, {4}, {{1, 2, 3}}}],
+  {True, False, False}
 ]
 
 (* Scaling consistency *)

--- a/SetReplace/RulePlot.m
+++ b/SetReplace/RulePlot.m
@@ -4,7 +4,7 @@ Package["SetReplace`"]
 
 $newOptions = {
   "EdgeType" -> "CyclicOpen",
-  GraphHighlightStyle -> Black,
+  GraphHighlightStyle -> RGBColor[0.5, 0.5, 0.95],
   GraphLayout -> "SpringElectricalPolygons",
   VertexCoordinateRules -> {},
   VertexLabels -> None

--- a/SetReplace/RulePlot.m
+++ b/SetReplace/RulePlot.m
@@ -4,6 +4,7 @@ Package["SetReplace`"]
 
 $newOptions = {
   "EdgeType" -> "CyclicOpen",
+  GraphHighlightStyle -> Black,
   GraphLayout -> "SpringElectricalPolygons",
   VertexCoordinateRules -> {},
   VertexLabels -> None
@@ -63,7 +64,8 @@ rulePlot$parse[{
       OptionValue[
         RulePlot,
         {opts},
-        {"EdgeType", GraphLayout, VertexCoordinateRules, VertexLabels, Frame, FrameStyle, PlotLegends, Spacings}] /;
+        {"EdgeType", GraphHighlightStyle, GraphLayout, VertexCoordinateRules, VertexLabels, Frame, FrameStyle,
+          PlotLegends, Spacings}] /;
     correctOptionsQ[{rulesSpec, o}, {opts}]
 
 hypergraphRulesSpecQ[rulesSpec_List ? wolframModelRulesSpecQ] := Fold[# && hypergraphRulesSpecQ[#2] &, True, rulesSpec]
@@ -104,6 +106,7 @@ correctSpacingsQ[opts_] := Module[{spacings, correctQ},
 rulePlot[
     rules_,
     edgeType_,
+    graphHighlightStyle_,
     graphLayout_,
     vertexCoordinateRules_,
     vertexLabels_,
@@ -114,12 +117,14 @@ rulePlot[
     graphicsOpts_] :=
   If[PlotLegends === None, Identity, Legended[#, Replace[plotLegends, "Text" -> Placed[StandardForm[rules], Below]]] &][
     rulePlot[
-      rules, edgeType, graphLayout, vertexCoordinateRules, vertexLabels, frameQ, frameStyle, spacings, graphicsOpts]
+      rules, edgeType, graphHighlightStyle, graphLayout, vertexCoordinateRules, vertexLabels, frameQ, frameStyle,
+        spacings, graphicsOpts]
   ]
 
 rulePlot[
     rule_Rule,
     edgeType_,
+    graphHighlightStyle_,
     graphLayout_,
     vertexCoordinateRules_,
     vertexLabels_,
@@ -128,11 +133,13 @@ rulePlot[
     spacings_,
     graphicsOpts_] :=
   rulePlot[
-    {rule}, edgeType, graphLayout, vertexCoordinateRules, vertexLabels, frameQ, frameStyle, spacings, graphicsOpts]
+    {rule}, edgeType, graphHighlightStyle, graphLayout, vertexCoordinateRules, vertexLabels, frameQ, frameStyle,
+      spacings, graphicsOpts]
 
 rulePlot[
     rules_List,
     edgeType_,
+    graphHighlightStyle_,
     graphLayout_,
     vertexCoordinateRules_,
     vertexLabels_,
@@ -143,10 +150,17 @@ rulePlot[
   Graphics[
       First[graphicsRiffle[#[[All, 1]], #[[All, 2]], {}, {{0, 1}, {0, 1}}, 0, 0.01, If[frameQ, frameStyle, None]]],
       graphicsOpts] & @
-    (singleRulePlot[edgeType, graphLayout, vertexCoordinateRules, vertexLabels, spacings] /@ rules)
+    (singleRulePlot[edgeType, graphHighlightStyle, graphLayout, vertexCoordinateRules, vertexLabels, spacings] /@ rules)
 
 (* returns {shapes, plotRange} *)
-singleRulePlot[edgeType_, graphLayout_, externalVertexCoordinateRules_, vertexLabels_, spacings_][rule_] := Module[{
+singleRulePlot[
+      edgeType_,
+      graphHighlightStyle_,
+      graphLayout_,
+      externalVertexCoordinateRules_,
+      vertexLabels_,
+      spacings_][
+      rule_] := Module[{
     vertexCoordinateRules, ruleSidePlots, plotRange},
   vertexCoordinateRules = Join[
     ruleCoordinateRules[edgeType, graphLayout, externalVertexCoordinateRules, rule],
@@ -155,6 +169,7 @@ singleRulePlot[edgeType_, graphLayout_, externalVertexCoordinateRules_, vertexLa
       #,
       edgeType,
       sharedRuleElements[rule],
+      graphHighlightStyle,
       graphLayout,
       vertexCoordinateRules,
       vertexLabels,

--- a/SetReplace/RulePlot.wlt
+++ b/SetReplace/RulePlot.wlt
@@ -83,6 +83,22 @@ VerificationTest[
   {RulePlot::invalidFiniteOption}
 ]
 
+(** GraphhighlightStyle **)
+
+VerificationTest[
+  RulePlot[WolframModel[{{1, 2, 3}, {3, 4, 5}} -> {{3, 4, 5}, {5, 6, 7}}], GraphHighlightStyle -> 1],
+  RulePlot[WolframModel[{{1, 2, 3}, {3, 4, 5}} -> {{3, 4, 5}, {5, 6, 7}}], GraphHighlightStyle -> 1],
+  {RulePlot::invalidHighlightStyle}
+]
+
+VerificationTest[
+  With[{
+      color = RGBColor[0.4, 0.6, 0.2]},
+    FreeQ[RulePlot[WolframModel[#], GraphHighlightStyle -> color], color] & /@
+      {{{1}} -> {{2}}, {{1}} -> {{1}}, {{1, 2}} -> {{1, 2}}, {{1, 2}} -> {{2, 3}}, {{1, 2}} -> {{3, 4}}}],
+  {True, False, False, False, True}
+]
+
 (** GraphLayout **)
 
 VerificationTest[
@@ -270,8 +286,9 @@ VerificationTest[
 (** Shared vertices are colored **)
 
 VerificationTest[
-  Length[Union[Cases[RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}]], _ ? ColorQ, All]]] > 
-    Length[Union[Cases[RulePlot[WolframModel[{{1, 2, 3}} -> {{4, 5, 6}}]], _ ? ColorQ, All]]]
+  Cases[RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}]], _ ? ColorQ, All],
+  Cases[RulePlot[WolframModel[{{1, 2, 3}} -> {{4, 5, 6}}]], _ ? ColorQ, All],
+  SameTest -> Not @* SameQ
 ]
 
 EndTestSection[]


### PR DESCRIPTION
## Changes

* Closes #103.
* Closes #104.
* Adds `GraphHighlightStyle` option for `HypergraphPlot` and `RulePlot`. Currently, it only supports colors.

## Tests

* Build and test: `./build.wls&&./install.wls&&./test.wls`
* Highlighting can now be done in style:
```
In[] := HypergraphPlot[{{1}, {1}, {1, 2}, {1, 2}, {2, 3, 4}}, 
 GraphHighlight -> {{1}, {1, 2}, {2, 3, 4}}, 
 GraphHighlightStyle -> Purple]
```
![image](https://user-images.githubusercontent.com/1479325/68636517-be8bec00-04c9-11ea-9d45-0cc3fc16d3a7.png)
* `RulePlot` now uses a shade of violet by default:
```
In[] := RulePlot[WolframModel[{{3}, {1, 2, 3}} -> {{1, 2, 3}, {3, 4, 5}}]]
```
![image](https://user-images.githubusercontent.com/1479325/68721105-5ac3fa80-057f-11ea-94da-aafea6fa7e21.png)
* It also supports `GraphHighlightStyle` options:
```
In[] := RulePlot[WolframModel[{{3}, {1, 2, 3}} -> {{1, 2, 3}, {3, 4, 5}}], 
 GraphHighlightStyle -> Orange]
```
![image](https://user-images.githubusercontent.com/1479325/68721142-74fdd880-057f-11ea-88f8-e65e29907f2b.png)