### PR TITLE
Fix handling of nested lists in C++ interface

### DIFF
--- a/SetReplace/WolframModel.wlt
+++ b/SetReplace/WolframModel.wlt
@@ -692,6 +692,29 @@ VerificationTest[
   {{v[1], v[3]}}
 ]
 
+(** Nested lists as vertices **)
+
+VerificationTest[
+  Head[
+    WolframModel[{{{2, 2, 1}, {2, 2, 2}} -> {{1, 1, 3}, {1, 1, 1}, {2, 1, 2}, {3, 3, 2}}}, {Table[{0, 0, 0}, 3]}, 2]],
+  WolframModelEvolutionObject
+]
+
+VerificationTest[
+  WolframModel[
+    {{{2, 2, 1}, {2, 2, 2}} -> {{1, 1, 3}, {1, 1, 1}, {2, 1, 2}, {3, 3, 2}}},
+    {{{2}, {2}, 1}, {{2}, {2}, {2}}},
+    1,
+    "FinalState",
+    Method -> #],
+  {{1, 1, 2}, {1, 1, 1}, {{2}, 1, {2}}, {2, 2, {2}}}
+] & /@ $SetReplaceMethods
+
+VerificationTest[
+  WolframModel[{{{1, 1, 1}} -> {{1, 1, 1, 1}}}, {Table[{0, 0, 0}, 3]}, 2, "FinalState", Method -> #],
+  {ConstantArray[{0, 0, 0}, 4]}
+] & /@ $SetReplaceMethods
+
 (** NodeNamingFunction **)
 
 VerificationTest[

--- a/SetReplace/WolframModelEvolutionObject.m
+++ b/SetReplace/WolframModelEvolutionObject.m
@@ -531,8 +531,7 @@ WolframModelEvolutionObject[args___] := 0 /;
 
 
 WolframModelEvolutionObject::corrupt =
-	"WolframModelEvolutionObject does not have a correct format. " ~~
-	"Use SetSubstitutionSystem for construction.";
+	"WolframModelEvolutionObject does not have a correct format. Use WolframModel for construction.";
 
 
 evolutionDataQ[data_Association] := Sort[Keys[data]] ===

--- a/SetReplace/setSubstitutionSystem$cpp.m
+++ b/SetReplace/setSubstitutionSystem$cpp.m
@@ -117,13 +117,13 @@ ruleAtoms[left_ :> right : Except[_Module]] :=
 
 ruleAtoms[left_ :> right_Module] := Module[{
 		leftVertices, patterns, leftAtoms, patternSymbols, createdAtoms, rightAtoms},
-	leftVertices = Union @ Flatten[left];
+	leftVertices = Union @ Catenate[left];
 	leftAtoms = Select[leftVertices, AtomQ];
 	patterns = Complement[leftVertices, leftAtoms];
 	patternSymbols = Map[Hold, patterns, {2}][[All, 1]];
 	createdAtoms = Map[Hold, Hold[right], {3}][[1, 1]];
 	rightAtoms = Complement[
-		Union @ Flatten @ Map[Hold, Hold[right], {4}][[1, 2]],
+		Union @ Catenate @ Map[Hold, Hold[right], {4}][[1, 2]],
 		Join[patternSymbols, createdAtoms]];
 	(* {global, local} *)
 	{Union @ Join[Hold /@ leftAtoms, rightAtoms],
@@ -175,9 +175,9 @@ setSubstitutionSystem$cpp[rules_, set_, generations_, steps_, returnOnAbortQ_, t
 		mappedSet, localIndices, mappedRules, setPtr, cppOutput, resultAtoms,
 		inversePartialGlobalMap, inverseGlobalMap},
 	canonicalRules = toCanonicalRules[rules];
-	setAtoms = Hold /@ Union[Flatten[set]];
+	setAtoms = Hold /@ Union[Catenate[set]];
 	atomsInRules = ruleAtoms /@ canonicalRules;
-	globalAtoms = Union @ Flatten @ {setAtoms, atomsInRules[[All, 1]]};
+	globalAtoms = Union @ Join[setAtoms, Catenate[atomsInRules[[All, 1]]]];
 	globalIndex = Association @ Thread[globalAtoms -> Range[Length[globalAtoms]]];
 	mappedSet = Map[globalIndex, Map[Hold, set, {2}], {2}];
 	localIndices =
@@ -199,7 +199,7 @@ setSubstitutionSystem$cpp[rules_, set_, generations_, steps_, returnOnAbortQ_, t
 		If[!returnOnAbortQ, Return[$Aborted]]];
 	cppOutput = decodeExpressions @ $cpp$setExpressions[setPtr];
 	$cpp$setDelete[setPtr];
-	resultAtoms = Union[Flatten[cppOutput[$atomLists]]];
+	resultAtoms = Union[Catenate[cppOutput[$atomLists]]];
 	inversePartialGlobalMap = Association[Reverse /@ Normal @ globalIndex];
 	inverseGlobalMap = Association @ Thread[resultAtoms
 		-> (Lookup[inversePartialGlobalMap, #, Unique["v"]] & /@ resultAtoms)];


### PR DESCRIPTION
## Changes

* Resolves #116.
* Fixes handling of nested lists in the initial condition of `WolframModel` and related functions.

## Tests

* Run unit tests, old and new: `./build.wls && ./install.wls && ./test.wls`.
* The following now works as expected:
```
In[] := WolframModel[{{{2, 2, 1}, {2, 2, 2}} -> {{1, 1, 3}, {1, 1, 1}, {2, 1, 
     2}, {3, 3, 2}}}, {Table[{0, 0, 0}, 3]}, 2]
```
![image](https://user-images.githubusercontent.com/1479325/68639356-4d046b80-04d2-11ea-902b-6af095e37dce.png)
* Specifically, in that case, each `{0, 0, 0}` is a vertex and there is a single hyperedge consisting of three of them:
```
In[] := WolframModel[{{{1, 1, 1}} -> {{1, 1, 1, 1}}}, {Table[{0, 0, 0}, 
   3]}, 2, "FinalState"]
```
```
Out[] = {{{0, 0, 0}, {0, 0, 0}, {0, 0, 0}, {0, 0, 0}}}
```