### PR TITLE
HypergraphPlot: Edge type argument

### DIFF
--- a/SetReplace/HypergraphPlot.m
+++ b/SetReplace/HypergraphPlot.m
@@ -11,10 +11,9 @@ PackageScope["hypergraphPlot"]
 HypergraphPlot::usage = usageString[
 	"HypergraphPlot[`s`, `opts`] plots a list of vertex lists `s` as a hypergraph."];
 
-SyntaxInformation[HypergraphPlot] = {"ArgumentsPattern" -> {_, OptionsPattern[]}};
+SyntaxInformation[HypergraphPlot] = {"ArgumentsPattern" -> {_, _., OptionsPattern[]}};
 
 Options[HypergraphPlot] = Join[{
-	"EdgeType" -> "CyclicOpen",
 	GraphHighlight -> {},
 	GraphHighlightStyle -> Hue[1.0, 1.0, 0.7],
 	GraphLayout -> "SpringElectricalPolygons",
@@ -23,12 +22,16 @@ Options[HypergraphPlot] = Join[{
 	Options[Graphics]];
 
 $edgeTypes = {"Ordered", "CyclicClosed", "CyclicOpen"};
+$defaultEdgeType = "CyclicOpen";
 $graphLayouts = {"SpringElectricalEmbedding", "SpringElectricalPolygons"};
 
 (* Messages *)
 
 General::invalidEdges =
 	"First argument of HypergraphPlot must be list of lists, where elements represent vertices.";
+
+General::invalidEdgeType =
+	"Edge type `1` should be one of `2`.";
 
 General::invalidCoordinates =
 	"Coordinates `1` should be a list of rules from vertices to pairs of numbers.";
@@ -47,17 +50,26 @@ func : HypergraphPlot[args___] := Module[{result = hypergraphPlot$parse[args]},
 
 (* Arguments parsing *)
 
-hypergraphPlot$parse[args___] /; !Developer`CheckArgumentCount[HypergraphPlot[args], 1, 1] := $Failed
+hypergraphPlot$parse[args___] /; !Developer`CheckArgumentCount[HypergraphPlot[args], 1, 2] := $Failed
 
-hypergraphPlot$parse[edges : Except[{___List}], o : OptionsPattern[]] := (
+hypergraphPlot$parse[edges : Except[{___List}], edgeType_ : $defaultEdgeType, o : OptionsPattern[]] := (
 	Message[HypergraphPlot::invalidEdges];
 	$Failed
 )
 
-hypergraphPlot$parse[edges : {___List}, o : OptionsPattern[]] :=
-	hypergraphPlot[edges, ##, FilterRules[{o}, Options[Graphics]]] & @@
+hypergraphPlot$parse[
+		edges : {___List},
+		edgeType : Except[Alternatives[Alternatives @@ $edgeTypes, OptionsPattern[]]],
+		o : OptionsPattern[]] := (
+	Message[HypergraphPlot::invalidEdgeType, edgeType, $edgeTypes];
+	$Failed
+)
+
+hypergraphPlot$parse[
+		edges : {___List}, edgeType : Alternatives @@ $edgeTypes : $defaultEdgeType, o : OptionsPattern[]] :=
+	hypergraphPlot[edges, edgeType, ##, FilterRules[{o}, Options[Graphics]]] & @@
 			(OptionValue[HypergraphPlot, {o}, #] & /@ {
-				"EdgeType", GraphHighlight, GraphHighlightStyle, GraphLayout, VertexCoordinateRules, VertexLabels}) /;
+				GraphHighlight, GraphHighlightStyle, GraphLayout, VertexCoordinateRules, VertexLabels}) /;
 		correctHypergraphPlotOptionsQ[HypergraphPlot, Defer[HypergraphPlot[edges, o]], edges, {o}]
 
 hypergraphPlot$parse[___] := $Failed
@@ -65,7 +77,6 @@ hypergraphPlot$parse[___] := $Failed
 correctHypergraphPlotOptionsQ[head_, expr_, edges_, opts_] :=
 	knownOptionsQ[head, expr, opts] &&
 	(And @@ (supportedOptionQ[head, ##, opts] & @@@ {
-			{"EdgeType", $edgeTypes},
 			{GraphLayout, $graphLayouts}})) &&
 	correctCoordinateRulesQ[head, OptionValue[HypergraphPlot, opts, VertexCoordinateRules]] &&
 	correctHighlightQ[edges, OptionValue[HypergraphPlot, opts, GraphHighlight]] &&

--- a/SetReplace/HypergraphPlot.m
+++ b/SetReplace/HypergraphPlot.m
@@ -3,6 +3,7 @@ Package["SetReplace`"]
 PackageExport["HypergraphPlot"]
 
 PackageScope["correctHypergraphPlotOptionsQ"]
+PackageScope["$edgeTypes"]
 PackageScope["hypergraphEmbedding"]
 PackageScope["hypergraphPlot"]
 

--- a/SetReplace/HypergraphPlot.wlt
+++ b/SetReplace/HypergraphPlot.wlt
@@ -7,13 +7,13 @@ BeginTestSection["HypergraphPlot"]
 VerificationTest[
   HypergraphPlot[],
   HypergraphPlot[],
-  {HypergraphPlot::argx}
+  {HypergraphPlot::argt}
 ]
 
 VerificationTest[
-  HypergraphPlot[{{1, 2}}, {{1, 2}}],
-  HypergraphPlot[{{1, 2}}, {{1, 2}}],
-  {HypergraphPlot::argx}
+  HypergraphPlot[{{1, 2}}, {{1, 2}}, {{1, 2}}],
+  HypergraphPlot[{{1, 2}}, {{1, 2}}, {{1, 2}}],
+  {HypergraphPlot::argt}
 ]
 
 (** Valid edges **)
@@ -45,63 +45,63 @@ VerificationTest[
 (** Valid EdgeType **)
 
 VerificationTest[
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "EdgeType" -> None],
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "EdgeType" -> None],
-  {HypergraphPlot::invalidFiniteOption}
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, None],
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, None],
+  {HypergraphPlot::invalidEdgeType}
 ]
 
 VerificationTest[
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "EdgeType" -> "$$$Incorrect$$$"],
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "EdgeType" -> "$$$Incorrect$$$"],
-  {HypergraphPlot::invalidFiniteOption}
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "$$$Incorrect$$$"],
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "$$$Incorrect$$$"],
+  {HypergraphPlot::invalidEdgeType}
 ]
 
 VerificationTest[
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "EdgeType" -> {"$$$Incorrect$$$"}],
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "EdgeType" -> {"$$$Incorrect$$$"}],
-  {HypergraphPlot::invalidFiniteOption}
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, {"$$$Incorrect$$$"}],
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, {"$$$Incorrect$$$"}],
+  {HypergraphPlot::invalidEdgeType}
 ]
 
 VerificationTest[
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "EdgeType" -> {{1, 2, 3} -> "$$$Incorrect$$$"}],
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "EdgeType" -> {{1, 2, 3} -> "$$$Incorrect$$$"}],
-  {HypergraphPlot::invalidFiniteOption}
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, {{1, 2, 3} -> "$$$Incorrect$$$"}],
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, {{1, 2, 3} -> "$$$Incorrect$$$"}],
+  {HypergraphPlot::invalidEdgeType}
 ]
 
 VerificationTest[
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "EdgeType" -> {None, {1, 2, 3} -> "Ordered"}],
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "EdgeType" -> {None, {1, 2, 3} -> "Ordered"}],
-  {HypergraphPlot::invalidFiniteOption}
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, {None, {1, 2, 3} -> "Ordered"}],
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, {None, {1, 2, 3} -> "Ordered"}],
+  {HypergraphPlot::invalidEdgeType}
 ]
 
 VerificationTest[
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "EdgeType" -> {"$$$Incorrect$$$", {1, 2, 3} -> "Ordered"}],
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "EdgeType" -> {"$$$Incorrect$$$", {1, 2, 3} -> "Ordered"}],
-  {HypergraphPlot::invalidFiniteOption}
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, {"$$$Incorrect$$$", {1, 2, 3} -> "Ordered"}],
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, {"$$$Incorrect$$$", {1, 2, 3} -> "Ordered"}],
+  {HypergraphPlot::invalidEdgeType}
 ]
 
 VerificationTest[
   HypergraphPlot[
     {{1, 2, 3}, {3, 4, 5}},
-    "EdgeType" -> {{3, 4, 5} -> "Ordered", {1, 2, 3} -> "$$$Incorrect$$$"}],
+    {{3, 4, 5} -> "Ordered", {1, 2, 3} -> "$$$Incorrect$$$"}],
   HypergraphPlot[
     {{1, 2, 3}, {3, 4, 5}},
-    "EdgeType" -> {{3, 4, 5} -> "Ordered", {1, 2, 3} -> "$$$Incorrect$$$"}],
-  {HypergraphPlot::invalidFiniteOption}
+    {{3, 4, 5} -> "Ordered", {1, 2, 3} -> "$$$Incorrect$$$"}],
+  {HypergraphPlot::invalidEdgeType}
 ]
 
 VerificationTest[
-  Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "EdgeType" -> "Ordered"]],
+  Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "Ordered"]],
   Graphics
 ]
 
 VerificationTest[
-  Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "EdgeType" -> "CyclicOpen"]],
+  Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "CyclicOpen"]],
   Graphics
 ]
 
 VerificationTest[
-  Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "EdgeType" -> "CyclicClosed"]],
+  Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "CyclicClosed"]],
   Graphics
 ]
 
@@ -111,6 +111,18 @@ VerificationTest[
   HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "$$$InvalidOption###" -> True],
   HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "$$$InvalidOption###" -> True],
   {HypergraphPlot::optx}
+]
+
+VerificationTest[
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "Ordered", "$$$InvalidOption###" -> True],
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "Ordered", "$$$InvalidOption###" -> True],
+  {HypergraphPlot::optx}
+]
+
+VerificationTest[
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "$$$Incorrect$$$", "$$$InvalidOption###" -> True],
+  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "$$$Incorrect$$$", "$$$InvalidOption###" -> True],
+  {HypergraphPlot::invalidEdgeType}
 ]
 
 (* Valid coordinates *)
@@ -135,6 +147,11 @@ VerificationTest[
 
 VerificationTest[
   Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, VertexCoordinateRules -> {1 -> {0, 0}}]],
+  Graphics
+]
+
+VerificationTest[
+  Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "Ordered", VertexCoordinateRules -> {1 -> {0, 0}}]],
   Graphics
 ]
 
@@ -239,7 +256,7 @@ $simpleHypergraphs = {
 };
 
 Table[VerificationTest[
-  Head[HypergraphPlot[hypergraph, "EdgeType" -> #]],
+  Head[HypergraphPlot[hypergraph, #]],
   Graphics
 ] & /@ $edgeTypes, {hypergraph, $simpleHypergraphs}]
 
@@ -269,8 +286,8 @@ $layoutTestHypergraphs = {
 };
 
 VerificationTest[
-  diskCoordinates[HypergraphPlot[#, "EdgeType" -> "Ordered"]],
-  diskCoordinates[HypergraphPlot[#, "EdgeType" -> "CyclicOpen"]],
+  diskCoordinates[HypergraphPlot[#, "Ordered"]],
+  diskCoordinates[HypergraphPlot[#, "CyclicOpen"]],
   SameTest -> (Not @* Equal)
 ] & /@ $layoutTestHypergraphs
 

--- a/SetReplace/RulePlot.m
+++ b/SetReplace/RulePlot.m
@@ -90,9 +90,17 @@ hypergraphRulesSpecQ[rulesSpec_] := (
 correctOptionsQ[args_, {opts___}] :=
   knownOptionsQ[RulePlot, Defer[RulePlot[WolframModel[args], opts]], {opts}, $allowedOptions] &&
   supportedOptionQ[RulePlot, Frame, {True, False}, {opts}] &&
+  correctEdgeTypeQ[OptionValue[RulePlot, {opts}, "EdgeType"]] &&
   correctSpacingsQ[{opts}] &&
   correctHypergraphPlotOptionsQ[
     RulePlot, Defer[RulePlot[WolframModel[args], opts]], Automatic, FilterRules[{opts}, Options[HypergraphPlot]]]
+
+correctEdgeTypeQ[edgeType : Alternatives @@ $edgeTypes] := True
+
+correctEdgeTypeQ[edgeType_] := (
+  Message[RulePlot::invalidEdgeType, edgeType, $edgeTypes];
+  False
+)
 
 correctSpacingsQ[opts_] := Module[{spacings, correctQ},
   spacings = OptionValue[RulePlot, opts, Spacings];

--- a/SetReplace/RulePlot.wlt
+++ b/SetReplace/RulePlot.wlt
@@ -74,13 +74,13 @@ VerificationTest[
 VerificationTest[
   RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], "EdgeType" -> "Invalid"],
   RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], "EdgeType" -> "Invalid"],
-  {RulePlot::invalidFiniteOption}
+  {RulePlot::invalidEdgeType}
 ]
 
 VerificationTest[
   RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], "EdgeType" -> 3],
   RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], "EdgeType" -> 3],
-  {RulePlot::invalidFiniteOption}
+  {RulePlot::invalidEdgeType}
 ]
 
 (** GraphhighlightStyle **)

--- a/SetReplace/performance.wlt
+++ b/SetReplace/performance.wlt
@@ -78,7 +78,7 @@ $layouts = {"SpringElectricalEmbedding", "SpringElectricalPolygons"};
 
 Table[
   VerificationTest[
-    Head[HypergraphPlot[$largeSet, "EdgeType" -> edgeType, GraphLayout -> layout]],
+    Head[HypergraphPlot[$largeSet, edgeType, GraphLayout -> layout]],
     Graphics,
     TimeConstraint -> (4 $normalPlotTiming),
     MemoryConstraint -> (7 $normalPlotMemory)],


### PR DESCRIPTION
## Changes

* Closes #106.
* `"EdgeType"` is no longer an option in `HypergraphPlot`, but a second argument instead.

## Tests

* Run unit tests: `./build.wls && ./install.wls && ./test.wls`.
* Specify the edge type as a second argument:
```
In[] := HypergraphPlot[{{1, 2, 3}, {3, 4, 5}, {3, 6, 7}}, "Ordered"]
```
![image](https://user-images.githubusercontent.com/1479325/68695575-51b83680-0549-11ea-991a-32d62885156b.png)
```
In[] := HypergraphPlot[{{1, 2, 3}, {3, 4, 5}, {3, 6, 7}}, "CyclicClosed"]
```
![image](https://user-images.githubusercontent.com/1479325/68695606-5ed52580-0549-11ea-82dc-7748d6892b51.png)
* `"CyclicOpen"` is the default:
```
In[] := HypergraphPlot[{{1, 2, 3}, {3, 4, 5}, {3, 6, 7}}]
```
![image](https://user-images.githubusercontent.com/1479325/68695643-6a285100-0549-11ea-8927-27c3fa0b1cc6.png)