### PR TITLE
EdgeType: "Cyclic"

### DIFF
--- a/SetReplace/HypergraphPlot.wlt
+++ b/SetReplace/HypergraphPlot.wlt
@@ -437,12 +437,16 @@ $selfLoopLength = FirstCase[
 
 VerificationTest[
   And @@ (
-    MemberQ[
-        Cases[
-          HypergraphPlot[#, GraphLayout -> "SpringElectricalEmbedding"],
-          Line[pts_] :> RegionMeasure[Line[pts]],
-          All],
-        $selfLoopLength] & /@ {
+    Abs[
+          First[
+              Nearest[
+                Cases[
+                  HypergraphPlot[#, GraphLayout -> "SpringElectricalEmbedding"],
+                  Line[pts_] :> RegionMeasure[Line[pts]],
+                  All],
+                $selfLoopLength]] -
+            $selfLoopLength] <
+        1.*^-10 & /@ {
       {{1, 1}},
       {{1, 2, 3}, {1, 1}},
       {{1, 2, 3}, {3, 4, 5}, {5, 5}},

--- a/SetReplace/HypergraphPlot.wlt
+++ b/SetReplace/HypergraphPlot.wlt
@@ -96,12 +96,7 @@ VerificationTest[
 ]
 
 VerificationTest[
-  Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "CyclicOpen"]],
-  Graphics
-]
-
-VerificationTest[
-  Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "CyclicClosed"]],
+  Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "Cyclic"]],
   Graphics
 ]
 
@@ -241,7 +236,7 @@ VerificationTest[
 
 (** Simple examples **)
 
-$edgeTypes = {"Ordered", "CyclicOpen", "CyclicClosed"};
+$edgeTypes = {"Ordered", "Cyclic"};
 
 $simpleHypergraphs = {
   {{1, 3}, {2, 4}},
@@ -287,7 +282,7 @@ $layoutTestHypergraphs = {
 
 VerificationTest[
   diskCoordinates[HypergraphPlot[#, "Ordered"]],
-  diskCoordinates[HypergraphPlot[#, "CyclicOpen"]],
+  diskCoordinates[HypergraphPlot[#, "Cyclic"]],
   SameTest -> (Not @* Equal)
 ] & /@ $layoutTestHypergraphs
 

--- a/SetReplace/RulePlot.m
+++ b/SetReplace/RulePlot.m
@@ -3,7 +3,7 @@ Package["SetReplace`"]
 (* Documentation *)
 
 $newOptions = {
-  "EdgeType" -> "CyclicOpen",
+  "EdgeType" -> "Ordered",
   GraphHighlightStyle -> RGBColor[0.5, 0.5, 0.95],
   GraphLayout -> "SpringElectricalPolygons",
   VertexCoordinateRules -> {},

--- a/SetReplace/RulePlot.wlt
+++ b/SetReplace/RulePlot.wlt
@@ -67,7 +67,7 @@ VerificationTest[
   Not[
     Or @@ SameQ @@@ Subsets[
       Rasterize[RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], "EdgeType" -> #]] & /@
-        {"Ordered", "CyclicOpen", "CyclicClosed"},
+        {"Ordered", "Cyclic"},
       {2}]]
 ]
 

--- a/SetReplace/performance.wlt
+++ b/SetReplace/performance.wlt
@@ -73,7 +73,7 @@ $largeSet = WolframModel[
 {$normalPlotTiming, $normalPlotMemory} =
   AbsoluteTiming[MaxMemoryUsed[GraphPlot[Rule @@@ Catenate[Partition[#, 2, 1] & /@ $largeSet]]]];
 
-$edgeTypes = {"Ordered", "CyclicOpen", "CyclicClosed"};
+$edgeTypes = {"Ordered", "Cyclic"};
 $layouts = {"SpringElectricalEmbedding", "SpringElectricalPolygons"};
 
 Table[


### PR DESCRIPTION
## Changes

* Closes #119.
* Replaces `"CyclicOpen"` and `"CyclicClosed"` edge types with a single `"Cyclic"` edge type.
* `"SpringElectricalPolygons"` with edge type `"Ordered"` is now rendered as it was rendered with edge type `"CyclicOpen"` previously.
* Otherwise, `"Cyclic"` is rendered as `"CyclicClosed"`.

## Tests

* Run tests: `./build.wls&&./install.wls&&./test.wls`
* `"Ordered"` edge type is now rendered semi-cyclically by `HypergraphPlot`:
```
In[] := HypergraphPlot[{{1, 2, 3}, {3, 4, 5}, {3, 6, 7}}, "Ordered"]
```
![image](https://user-images.githubusercontent.com/1479325/68699059-44eb1100-0550-11ea-9006-808442a41d7b.png)
* All supported layouts and edge types are:
```
In[] := Dataset@Association@
  Table[layout -> 
    Association@
     Table[edgeType -> 
       HypergraphPlot[{{1, 2, 3}, {3, 4, 5}, {3, 6, 7}}, edgeType, 
        GraphLayout -> layout], {edgeType, {"Ordered", 
        "Cyclic"}}], {layout, {"SpringElectricalEmbedding", 
     "SpringElectricalPolygons"}}]
```
![image](https://user-images.githubusercontent.com/1479325/68699317-c93d9400-0550-11ea-82b2-68e2bff7dd98.png)