### PR TITLE
HyperedgeRendering

### DIFF
--- a/SetReplace/HypergraphPlot.wlt
+++ b/SetReplace/HypergraphPlot.wlt
@@ -288,7 +288,7 @@ VerificationTest[
 
 VerificationTest[
   Length[Union[Cases[
-    HypergraphPlot[#, GraphLayout -> "SpringElectricalEmbedding"],
+    HypergraphPlot[#, "HyperedgeRendering" -> "Subgraphs"],
     Polygon[___],
     All]]],
   1
@@ -296,7 +296,7 @@ VerificationTest[
 
 VerificationTest[
   Length[Union[Cases[
-    HypergraphPlot[#, GraphLayout -> "SpringElectricalPolygons"],
+    HypergraphPlot[#, "HyperedgeRendering" -> "Polygons"],
     Polygon[___],
     All]]],
   1 + Length[#]
@@ -390,7 +390,7 @@ VerificationTest[
 VerificationTest[
   Differences[
     Length[Union[Cases[#, _?ColorQ, All]]] & /@
-      (HypergraphPlot[{{1, 2}, {1, 2}}, GraphLayout -> "SpringElectricalEmbedding", GraphHighlight -> #] &) /@
+      (HypergraphPlot[{{1, 2}, {1, 2}}, "HyperedgeRendering" -> "Subgraphs", GraphHighlight -> #] &) /@
       {{}, {{1, 2}}, {{1, 2}, {1, 2}}}],
   {1, -1}
 ]
@@ -416,21 +416,21 @@ VerificationTest[
 
 VerificationTest[
   SameQ @@ (
-    Union[Cases[HypergraphPlot[#, GraphLayout -> "SpringElectricalEmbedding"], p : Polygon[___] :> Area[p], All]] & /@
+    Union[Cases[HypergraphPlot[#, "HyperedgeRendering" -> "Subgraphs"], p : Polygon[___] :> Area[p], All]] & /@
       {{{1, 2}}, {{1, 2, 3}}, {{1, 2, 3}, {3, 4, 5}}, RandomInteger[10, {5, 5}]})
 ]
 
 VerificationTest[
   Equal @@ (
     Mean[Cases[
-        HypergraphPlot[#, GraphLayout -> "SpringElectricalEmbedding"],
+        HypergraphPlot[#, "HyperedgeRendering" -> "Subgraphs"],
         Line[pts_] :> EuclideanDistance @@ pts,
         All]] & /@
       {{{1, 2}}, {{1, 2, 3}}, {{1, 2, 3}, {3, 4, 5}}, {{1, 2, 3}, {3, 4, 5}, {5, 6, 1}}, {{1, 2, 3, 4, 5, 1}}})
 ]
 
 $selfLoopLength = FirstCase[
-  HypergraphPlot[{{1, 1}}, GraphLayout -> "SpringElectricalEmbedding"],
+  HypergraphPlot[{{1, 1}}, "HyperedgeRendering" -> "Subgraphs"],
   Line[pts_] :> RegionMeasure[Line[pts]],
   Missing[],
   All];
@@ -441,7 +441,7 @@ VerificationTest[
           First[
               Nearest[
                 Cases[
-                  HypergraphPlot[#, GraphLayout -> "SpringElectricalEmbedding"],
+                  HypergraphPlot[#, "HyperedgeRendering" -> "Subgraphs"],
                   Line[pts_] :> RegionMeasure[Line[pts]],
                   All],
                 $selfLoopLength]] -

--- a/SetReplace/RulePlot.m
+++ b/SetReplace/RulePlot.m
@@ -5,7 +5,7 @@ Package["SetReplace`"]
 $newOptions = {
   "EdgeType" -> "Ordered",
   GraphHighlightStyle -> RGBColor[0.5, 0.5, 0.95],
-  GraphLayout -> "SpringElectricalPolygons",
+  "HyperedgeRendering" -> "Polygons",
   VertexCoordinateRules -> {},
   VertexLabels -> None
 };
@@ -64,7 +64,7 @@ rulePlot$parse[{
       OptionValue[
         RulePlot,
         {opts},
-        {"EdgeType", GraphHighlightStyle, GraphLayout, VertexCoordinateRules, VertexLabels, Frame, FrameStyle,
+        {"EdgeType", GraphHighlightStyle, "HyperedgeRendering", VertexCoordinateRules, VertexLabels, Frame, FrameStyle,
           PlotLegends, Spacings}] /;
     correctOptionsQ[{rulesSpec, o}, {opts}]
 
@@ -115,7 +115,7 @@ rulePlot[
     rules_,
     edgeType_,
     graphHighlightStyle_,
-    graphLayout_,
+    hyperedgeRendering_,
     vertexCoordinateRules_,
     vertexLabels_,
     frameQ_,
@@ -125,7 +125,7 @@ rulePlot[
     graphicsOpts_] :=
   If[PlotLegends === None, Identity, Legended[#, Replace[plotLegends, "Text" -> Placed[StandardForm[rules], Below]]] &][
     rulePlot[
-      rules, edgeType, graphHighlightStyle, graphLayout, vertexCoordinateRules, vertexLabels, frameQ, frameStyle,
+      rules, edgeType, graphHighlightStyle, hyperedgeRendering, vertexCoordinateRules, vertexLabels, frameQ, frameStyle,
         spacings, graphicsOpts]
   ]
 
@@ -133,7 +133,7 @@ rulePlot[
     rule_Rule,
     edgeType_,
     graphHighlightStyle_,
-    graphLayout_,
+    hyperedgeRendering_,
     vertexCoordinateRules_,
     vertexLabels_,
     frameQ_,
@@ -141,14 +141,14 @@ rulePlot[
     spacings_,
     graphicsOpts_] :=
   rulePlot[
-    {rule}, edgeType, graphHighlightStyle, graphLayout, vertexCoordinateRules, vertexLabels, frameQ, frameStyle,
+    {rule}, edgeType, graphHighlightStyle, hyperedgeRendering, vertexCoordinateRules, vertexLabels, frameQ, frameStyle,
       spacings, graphicsOpts]
 
 rulePlot[
     rules_List,
     edgeType_,
     graphHighlightStyle_,
-    graphLayout_,
+    hyperedgeRendering_,
     vertexCoordinateRules_,
     vertexLabels_,
     frameQ_,
@@ -158,27 +158,28 @@ rulePlot[
   Graphics[
       First[graphicsRiffle[#[[All, 1]], #[[All, 2]], {}, {{0, 1}, {0, 1}}, 0, 0.01, If[frameQ, frameStyle, None]]],
       graphicsOpts] & @
-    (singleRulePlot[edgeType, graphHighlightStyle, graphLayout, vertexCoordinateRules, vertexLabels, spacings] /@ rules)
+    (singleRulePlot[edgeType, graphHighlightStyle, hyperedgeRendering, vertexCoordinateRules, vertexLabels, spacings] /@
+        rules)
 
 (* returns {shapes, plotRange} *)
 singleRulePlot[
       edgeType_,
       graphHighlightStyle_,
-      graphLayout_,
+      hyperedgeRendering_,
       externalVertexCoordinateRules_,
       vertexLabels_,
       spacings_][
       rule_] := Module[{
     vertexCoordinateRules, ruleSidePlots, plotRange},
   vertexCoordinateRules = Join[
-    ruleCoordinateRules[edgeType, graphLayout, externalVertexCoordinateRules, rule],
+    ruleCoordinateRules[edgeType, hyperedgeRendering, externalVertexCoordinateRules, rule],
     externalVertexCoordinateRules];
   ruleSidePlots = hypergraphPlot[
       #,
       edgeType,
       sharedRuleElements[rule],
       graphHighlightStyle,
-      graphLayout,
+      hyperedgeRendering,
       vertexCoordinateRules,
       vertexLabels,
       {},
@@ -199,9 +200,9 @@ layoutReferenceSide[in_, out_] := Module[{inConnectedQ, outConnectedQ},
   If[Length[in] > Length[out], in, out]
 ]
 
-ruleCoordinateRules[edgeType_, graphLayout_, externalVertexCoordinateRules_, in_ -> out_] :=
+ruleCoordinateRules[edgeType_, hyperedgeRendering_, externalVertexCoordinateRules_, in_ -> out_] :=
   #[[1]] -> #[[2, 1, 1]] & /@
-    hypergraphEmbedding[edgeType, graphLayout, externalVertexCoordinateRules][layoutReferenceSide[in, out]][[1]]
+    hypergraphEmbedding[edgeType, hyperedgeRendering, externalVertexCoordinateRules][layoutReferenceSide[in, out]][[1]]
 
 sharedRuleElements[in_ -> out_] := multisetIntersection @@ (Join[vertexList[#], #] & /@ {in, out})
 

--- a/SetReplace/RulePlot.wlt
+++ b/SetReplace/RulePlot.wlt
@@ -99,25 +99,25 @@ VerificationTest[
   {True, False, False, False, True}
 ]
 
-(** GraphLayout **)
+(** HyperedgeRendering **)
 
 VerificationTest[
   Not[
     Or @@ SameQ @@@ Subsets[
-      Rasterize[RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], GraphLayout -> #]] & /@
-        {"SpringElectricalEmbedding", "SpringElectricalPolygons"},
+      Rasterize[RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], "HyperedgeRendering" -> #]] & /@
+        {"Subgraphs", "Polygons"},
       {2}]]
 ]
 
 VerificationTest[
-  RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], GraphLayout -> "Invalid"],
-  RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], GraphLayout -> "Invalid"],
+  RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], "HyperedgeRendering" -> "Invalid"],
+  RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], "HyperedgeRendering" -> "Invalid"],
   {RulePlot::invalidFiniteOption}
 ]
 
 VerificationTest[
-  RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], GraphLayout -> 3],
-  RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], GraphLayout -> 3],
+  RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], "HyperedgeRendering" -> 3],
+  RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], "HyperedgeRendering" -> 3],
   {RulePlot::invalidFiniteOption}
 ]
 

--- a/SetReplace/performance.wlt
+++ b/SetReplace/performance.wlt
@@ -74,15 +74,15 @@ $largeSet = WolframModel[
   AbsoluteTiming[MaxMemoryUsed[GraphPlot[Rule @@@ Catenate[Partition[#, 2, 1] & /@ $largeSet]]]];
 
 $edgeTypes = {"Ordered", "Cyclic"};
-$layouts = {"SpringElectricalEmbedding", "SpringElectricalPolygons"};
+$hyperedgeRenderings = {"Subgraphs", "Polygons"};
 
 Table[
   VerificationTest[
-    Head[HypergraphPlot[$largeSet, edgeType, GraphLayout -> layout]],
+    Head[HypergraphPlot[$largeSet, edgeType, "HyperedgeRendering" -> hyperedgeRendering]],
     Graphics,
     TimeConstraint -> (4 $normalPlotTiming),
     MemoryConstraint -> (7 $normalPlotMemory)],
   {edgeType, $edgeTypes},
-  {layout, $layouts}]
+  {hyperedgeRendering, $hyperedgeRenderings}]
 
 EndTestSection[]


### PR DESCRIPTION
## Changes

* Closes #105.
* Renames `GraphLayout` option to `"HyperedgeRendering"` in `HypergraphPlot` and `RulePlot`.
* `"SpringElectricalEmbedding"` now became `"Subgraphs"`.
* `"SpringElectricalPolygons"` became just `"Polygons"`.

## Tests

* Run tests: `./build.wls && ./install.wls && ./test.wls`
* Use `"HyperedgeRendering"` to switch between *normal graph* and *polygons* layouts:
```
In[] := HypergraphPlot[{{1, 2, 3}, {3, 4, 5}, {3, 6, 7}}, 
 "HyperedgeRendering" -> "Subgraphs"]
```
![image](https://user-images.githubusercontent.com/1479325/68702021-035d6480-0556-11ea-98bd-4cead88c2190.png)
* All options for rendering are now:
```
In[] := Dataset@Association@
  Table[hyperedgeRendering -> 
    Association@
     Table[edgeType -> 
       HypergraphPlot[{{1, 2, 3}, {3, 4, 5}, {3, 6, 7}}, edgeType, 
        "HyperedgeRendering" -> 
         hyperedgeRendering], {edgeType, {"Ordered", 
        "Cyclic"}}], {hyperedgeRendering, {"Subgraphs", "Polygons"}}]
```
![image](https://user-images.githubusercontent.com/1479325/68701926-d0b36c00-0555-11ea-8974-d3cd27ea5a4e.png)