### PR TITLE
Descriptive test failures

### DIFF
--- a/SetReplace/HypergraphPlot.wlt
+++ b/SetReplace/HypergraphPlot.wlt
@@ -1,457 +1,431 @@
-BeginTestSection["HypergraphPlot"]
-
-(* Argument Checks *)
-
-(** Argument count **)
-
-VerificationTest[
-  HypergraphPlot[],
-  HypergraphPlot[],
-  {HypergraphPlot::argt}
-]
-
-VerificationTest[
-  HypergraphPlot[{{1, 2}}, {{1, 2}}, {{1, 2}}],
-  HypergraphPlot[{{1, 2}}, {{1, 2}}, {{1, 2}}],
-  {HypergraphPlot::argt}
-]
-
-(** Valid edges **)
-
-VerificationTest[
-  HypergraphPlot[1],
-  HypergraphPlot[1],
-  {HypergraphPlot::invalidEdges}
-]
-
-VerificationTest[
-  HypergraphPlot[{1, 2}],
-  HypergraphPlot[{1, 2}],
-  {HypergraphPlot::invalidEdges}
-]
-
-VerificationTest[
-  HypergraphPlot[{{1, 3}, 2}],
-  HypergraphPlot[{{1, 3}, 2}],
-  {HypergraphPlot::invalidEdges}
-]
-
-VerificationTest[
-  HypergraphPlot[{{1, 3}, 6, {2, 4}}],
-  HypergraphPlot[{{1, 3}, 6, {2, 4}}],
-  {HypergraphPlot::invalidEdges}
-]
-
-(** Valid EdgeType **)
-
-VerificationTest[
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, None],
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, None],
-  {HypergraphPlot::invalidEdgeType}
-]
-
-VerificationTest[
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "$$$Incorrect$$$"],
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "$$$Incorrect$$$"],
-  {HypergraphPlot::invalidEdgeType}
-]
-
-VerificationTest[
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, {"$$$Incorrect$$$"}],
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, {"$$$Incorrect$$$"}],
-  {HypergraphPlot::invalidEdgeType}
-]
-
-VerificationTest[
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, {{1, 2, 3} -> "$$$Incorrect$$$"}],
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, {{1, 2, 3} -> "$$$Incorrect$$$"}],
-  {HypergraphPlot::invalidEdgeType}
-]
-
-VerificationTest[
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, {None, {1, 2, 3} -> "Ordered"}],
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, {None, {1, 2, 3} -> "Ordered"}],
-  {HypergraphPlot::invalidEdgeType}
-]
-
-VerificationTest[
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, {"$$$Incorrect$$$", {1, 2, 3} -> "Ordered"}],
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, {"$$$Incorrect$$$", {1, 2, 3} -> "Ordered"}],
-  {HypergraphPlot::invalidEdgeType}
-]
-
-VerificationTest[
-  HypergraphPlot[
-    {{1, 2, 3}, {3, 4, 5}},
-    {{3, 4, 5} -> "Ordered", {1, 2, 3} -> "$$$Incorrect$$$"}],
-  HypergraphPlot[
-    {{1, 2, 3}, {3, 4, 5}},
-    {{3, 4, 5} -> "Ordered", {1, 2, 3} -> "$$$Incorrect$$$"}],
-  {HypergraphPlot::invalidEdgeType}
-]
-
-VerificationTest[
-  Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "Ordered"]],
-  Graphics
-]
-
-VerificationTest[
-  Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "Cyclic"]],
-  Graphics
-]
-
-(* Valid options *)
-
-VerificationTest[
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "$$$InvalidOption###" -> True],
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "$$$InvalidOption###" -> True],
-  {HypergraphPlot::optx}
-]
-
-VerificationTest[
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "Ordered", "$$$InvalidOption###" -> True],
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "Ordered", "$$$InvalidOption###" -> True],
-  {HypergraphPlot::optx}
-]
-
-VerificationTest[
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "$$$Incorrect$$$", "$$$InvalidOption###" -> True],
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "$$$Incorrect$$$", "$$$InvalidOption###" -> True],
-  {HypergraphPlot::invalidEdgeType}
-]
-
-(* Valid coordinates *)
-
-VerificationTest[
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, VertexCoordinateRules -> $$$invalid$$$],
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, VertexCoordinateRules -> $$$invalid$$$],
-  {HypergraphPlot::invalidCoordinates}
-]
-
-VerificationTest[
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, VertexCoordinateRules -> {{0, 0}}],
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, VertexCoordinateRules -> {{0, 0}}],
-  {HypergraphPlot::invalidCoordinates}
-]
-
-VerificationTest[
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, VertexCoordinateRules -> {1 -> {0}}],
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, VertexCoordinateRules -> {1 -> {0}}],
-  {HypergraphPlot::invalidCoordinates}
-]
-
-VerificationTest[
-  Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, VertexCoordinateRules -> {1 -> {0, 0}}]],
-  Graphics
-]
-
-VerificationTest[
-  Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "Ordered", VertexCoordinateRules -> {1 -> {0, 0}}]],
-  Graphics
-]
-
-(* Valid GraphHighlight *)
-
-VerificationTest[
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> $$$invalid$$$],
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> $$$invalid$$$],
-  {HypergraphPlot::invalidHighlight}
-]
-
-VerificationTest[
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {6}],
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {6}],
-  {HypergraphPlot::invalidHighlight}
-]
-
-VerificationTest[
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {1, 1}],
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {1, 1}],
-  {HypergraphPlot::invalidHighlight}
-]
-
-VerificationTest[
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {{1, 2}}],
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {{1, 2}}],
-  {HypergraphPlot::invalidHighlight}
-]
-
-VerificationTest[
-  Head[HypergraphPlot[{{1, 2, 3}, {1, 2, 3}}, GraphHighlight -> {{1, 2, 3}}]],
-  Graphics
-]
-
-VerificationTest[
-  Head[HypergraphPlot[{{1, 2, 3}, {1, 2, 3}}, GraphHighlight -> {{1, 2, 3}, {1, 2, 3}}]],
-  Graphics
-]
-
-VerificationTest[
-  Head[HypergraphPlot[{{1, 2, 3}, {1, 2, 3}}, GraphHighlight -> {{1, 2, 3}, {1, 2, 3}, {1, 2, 3}}]],
-  Head[HypergraphPlot[{{1, 2, 3}, {1, 2, 3}}, GraphHighlight -> {{1, 2, 3}, {1, 2, 3}, {1, 2, 3}}]],
-  {HypergraphPlot::invalidHighlight}
-]
-
-VerificationTest[
-  Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {1}]],
-  Graphics
-]
-
-VerificationTest[
-  Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {{1, 2, 3}}]],
-  Graphics
-]
-
-VerificationTest[
-  Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {4, {1, 2, 3}}]],
-  Graphics
-]
-
-(* Valid GraphHighlightStyle *)
-
-VerificationTest[
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {1}, GraphHighlightStyle -> None],
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {1}, GraphHighlightStyle -> None],
-  {HypergraphPlot::invalidHighlightStyle}
-]
-
-VerificationTest[
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {1}, GraphHighlightStyle -> 2],
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {1}, GraphHighlightStyle -> 2],
-  {HypergraphPlot::invalidHighlightStyle}
-]
-
-VerificationTest[
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {1}, GraphHighlightStyle -> "Dashed"],
-  HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {1}, GraphHighlightStyle -> "Dashed"],
-  {HypergraphPlot::invalidHighlightStyle}
-]
-
-VerificationTest[
-  Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {1}, GraphHighlightStyle -> Black]],
-  Graphics
-]
-
-(* Implementation *)
-
-(** Simple examples **)
-
-$edgeTypes = {"Ordered", "Cyclic"};
-
-$simpleHypergraphs = {
-  {{1, 3}, {2, 4}},
-  {},
-  {{}},
-  {{1}},
-  {{1}, {1}},
-  {{1}, {2}},
-  {{1}, {1}, {2}},
-  {{1, 2}, {1}},
-  {{1, 2}, {1}, {}}
-};
-
-Table[VerificationTest[
-  Head[HypergraphPlot[hypergraph, #]],
-  Graphics
-] & /@ $edgeTypes, {hypergraph, $simpleHypergraphs}]
-
-(** Large graphs **)
-
-VerificationTest[
-  Head @ HypergraphPlot @ SetReplace[
-    {{0, 1}, {0, 2}, {0, 3}},
-    ToPatternRules[
-      {{0, 1}, {0, 2}, {0, 3}} ->
-      {{4, 5}, {5, 4}, {4, 6}, {6, 4},
-        {5, 6}, {6, 5}, {4, 1}, {5, 2}, {6, 3}}],
-    #],
-  Graphics
-] & /@ {10, 5000}
-
-(* EdgeType *)
-
-diskCoordinates[graphics_] := Sort[Cases[graphics, Disk[i_, ___] :> i, All]]
-
-$layoutTestHypergraphs = {
-  {{1, 2, 3}, {3, 4, 5}},
-  {{1, 2, 3, 4, 5}, {5, 6, 7, 8, 9}},
-  {{1, 2, 3, 4, 5, 6, 7, 8, 9}, {1, 4, 7}},
-  {{1, 2, 3, 4, 5, 6}, {1, 2, 3, 4}},
-  {{1, 2, 3}, {3, 4, 5}, {1, 2, 3, 4}}
-};
-
-VerificationTest[
-  diskCoordinates[HypergraphPlot[#, "Ordered"]],
-  diskCoordinates[HypergraphPlot[#, "Cyclic"]],
-  SameTest -> (Not @* Equal)
-] & /@ $layoutTestHypergraphs
-
-VerificationTest[
-  Length[Union[Cases[
-    HypergraphPlot[#, "HyperedgeRendering" -> "Subgraphs"],
-    Polygon[___],
-    All]]],
-  1
-] & /@ $layoutTestHypergraphs
-
-VerificationTest[
-  Length[Union[Cases[
-    HypergraphPlot[#, "HyperedgeRendering" -> "Polygons"],
-    Polygon[___],
-    All]]],
-  1 + Length[#]
-] & /@ $layoutTestHypergraphs
-
-(* VertexLabels *)
-
-VerificationTest[
-  MissingQ[FirstCase[
-    HypergraphPlot[#, VertexLabels -> None],
-    Text[___],
-    Missing[],
-    All]]
-] & /@ $layoutTestHypergraphs
-
-VerificationTest[
-  !MissingQ[FirstCase[
-    HypergraphPlot[#, VertexLabels -> Automatic],
-    Text[___],
-    Missing[],
-    All]]
-] & /@ $layoutTestHypergraphs
-
-(* Single-vertex edges *)
-
-VerificationTest[
-  HypergraphPlot[{{1}, {1, 2}}],
-  HypergraphPlot[{{1, 2}}],
-  SameTest -> (Not @* SameQ)
-]
-
-VerificationTest[
-  MissingQ[FirstCase[
-    HypergraphPlot[{{1, 2}}, VertexLabels -> None],
-    Circle[___],
-    Missing[],
-    All]]
-]
-
-VerificationTest[
-  !MissingQ[FirstCase[
-    HypergraphPlot[{{1}, {1, 2}}, VertexLabels -> Automatic],
-    Circle[___],
-    Missing[],
-    All]]
-]
-
-(* VertexCoordinateRules *)
-
-VerificationTest[
-  And @@ (MemberQ[
-      diskCoordinates[HypergraphPlot[
-        {{1, 2, 3}, {3, 4, 5}, {3, 3}},
-        VertexCoordinateRules -> {1 -> {0, 0}, 2 -> {1, 0}}]],
-      #] & /@
-    {{0., 0.}, {1., 0.}})
-]
-
-VerificationTest[
-  Chop @ diskCoordinates[HypergraphPlot[
-    {{1, 2, 3}, {3, 4, 5}},
-    VertexCoordinateRules -> {3 -> {0, 0}}]],
-  Table[{0, 0}, 5],
-  SameTest -> (Not @* Equal)
-]
-
-VerificationTest[
-  Chop @ diskCoordinates[HypergraphPlot[
-    {{1, 2, 3}, {3, 4, 5}},
-    VertexCoordinateRules -> {3 -> {1, 0}, 3 -> {0, 0}}]],
-  Table[{0, 0}, 5],
-  SameTest -> (Not @* Equal)
-]
-
-(** Same coordinates should not produce any messages **)
-VerificationTest[
-  And @@ Cases[
-    HypergraphPlot[{{1, 2, 3}}, VertexCoordinateRules -> {1 -> {1, 0}, 2 -> {1, 0}}],
-    Rotate[_, {v1_, v2_}] :> v1 != {0, 0} && v2 != {0, 0},
-    All]
-]
-
-(* GraphHighlight *)
-
-VerificationTest[
-  Length[Union @ Cases[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {#}], _ ? ColorQ, All]] >
-    Length[Union @ Cases[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}], _ ? ColorQ, All]]
-] & /@ {4, {1, 2, 3}}
-
-(** Test multi-edge highlighting **)
-VerificationTest[
-  Differences[
-    Length[Union[Cases[#, _?ColorQ, All]]] & /@
-      (HypergraphPlot[{{1, 2}, {1, 2}}, "HyperedgeRendering" -> "Subgraphs", GraphHighlight -> #] &) /@
-      {{}, {{1, 2}}, {{1, 2}, {1, 2}}}],
-  {1, -1}
-]
-
-(* GraphHighlightStyle *)
-
-VerificationTest[
-  With[{
-      color = RGBColor[0.4, 0.6, 0.2]},
-    FreeQ[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> #, GraphHighlightStyle -> color], color] & /@
-      {{}, {4}, {{1, 2, 3}}}],
-  {True, False, False}
-]
-
-(* Scaling consistency *)
-(* Vertex sizes, arrow sizes, average edge lengths, and loop lengths should always be the same. *)
-
-VerificationTest[
-  SameQ @@ (
-    Union[Cases[HypergraphPlot[#], Disk[_, r_] :> r, All]] & /@
-      {{{1}}, {{1, 2, 3}}, {{1, 2, 3}, {3, 4, 5}}, RandomInteger[10, {5, 5}]})
-]
-
-VerificationTest[
-  SameQ @@ (
-    Union[Cases[HypergraphPlot[#, "HyperedgeRendering" -> "Subgraphs"], p : Polygon[___] :> Area[p], All]] & /@
-      {{{1, 2}}, {{1, 2, 3}}, {{1, 2, 3}, {3, 4, 5}}, RandomInteger[10, {5, 5}]})
-]
-
-VerificationTest[
-  Equal @@ (
-    Mean[Cases[
-        HypergraphPlot[#, "HyperedgeRendering" -> "Subgraphs"],
-        Line[pts_] :> EuclideanDistance @@ pts,
-        All]] & /@
-      {{{1, 2}}, {{1, 2, 3}}, {{1, 2, 3}, {3, 4, 5}}, {{1, 2, 3}, {3, 4, 5}, {5, 6, 1}}, {{1, 2, 3, 4, 5, 1}}})
-]
-
-$selfLoopLength = FirstCase[
-  HypergraphPlot[{{1, 1}}, "HyperedgeRendering" -> "Subgraphs"],
-  Line[pts_] :> RegionMeasure[Line[pts]],
-  Missing[],
-  All];
-
-VerificationTest[
-  And @@ (
-    Abs[
-          First[
-              Nearest[
-                Cases[
-                  HypergraphPlot[#, "HyperedgeRendering" -> "Subgraphs"],
-                  Line[pts_] :> RegionMeasure[Line[pts]],
-                  All],
-                $selfLoopLength]] -
+<|
+  "HypergraphPlot" -> <|
+    "init" -> (
+      $edgeTypes = {"Ordered", "Cyclic"};
+
+      $simpleHypergraphs = {
+        {{1, 3}, {2, 4}},
+        {},
+        {{}},
+        {{1}},
+        {{1}, {1}},
+        {{1}, {2}},
+        {{1}, {1}, {2}},
+        {{1, 2}, {1}},
+        {{1, 2}, {1}, {}}
+      };
+
+      diskCoordinates[graphics_] := Sort[Cases[graphics, Disk[i_, ___] :> i, All]];
+
+      $layoutTestHypergraphs = {
+        {{1, 2, 3}, {3, 4, 5}},
+        {{1, 2, 3, 4, 5}, {5, 6, 7, 8, 9}},
+        {{1, 2, 3, 4, 5, 6, 7, 8, 9}, {1, 4, 7}},
+        {{1, 2, 3, 4, 5, 6}, {1, 2, 3, 4}},
+        {{1, 2, 3}, {3, 4, 5}, {1, 2, 3, 4}}
+      };
+
+      $selfLoopLength = FirstCase[
+        HypergraphPlot[{{1, 1}}, "HyperedgeRendering" -> "Subgraphs"],
+        Line[pts_] :> RegionMeasure[Line[pts]],
+        Missing[],
+        All];
+
+      Attributes[testUnevaluated] = {HoldAll};
+      testUnevaluated[input_, messages_, opts___] :=
+        VerificationTest[
+          input,
+          HoldPattern[input],
+          messages,
+          SameTest -> MatchQ,
+          opts];
+    ),
+    "tests" -> Join[
+      (* Argument Checks *)
+
+      (** Argument count **)
+
+      {testUnevaluated[
+        HypergraphPlot[],
+        {HypergraphPlot::argt}
+      ]},
+
+      {testUnevaluated[
+        HypergraphPlot[{{1, 2}}, {{1, 2}}, {{1, 2}}],
+        {HypergraphPlot::argt}
+      ]},
+
+      (** Valid edges **)
+
+      {testUnevaluated[
+        HypergraphPlot[1],
+        {HypergraphPlot::invalidEdges}
+      ]},
+
+      {testUnevaluated[
+        HypergraphPlot[{1, 2}],
+        {HypergraphPlot::invalidEdges}
+      ]},
+
+      {testUnevaluated[
+        HypergraphPlot[{{1, 3}, 2}],
+        {HypergraphPlot::invalidEdges}
+      ]},
+
+      {testUnevaluated[
+        HypergraphPlot[{{1, 3}, 6, {2, 4}}],
+        {HypergraphPlot::invalidEdges}
+      ]},
+
+      (** Valid EdgeType **)
+
+      {testUnevaluated[
+        HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, None],
+        {HypergraphPlot::invalidEdgeType}
+      ]},
+
+      {testUnevaluated[
+        HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "$$$Incorrect$$$"],
+        {HypergraphPlot::invalidEdgeType}
+      ]},
+
+      {testUnevaluated[
+        HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, {"$$$Incorrect$$$"}],
+        {HypergraphPlot::invalidEdgeType}
+      ]},
+
+      {testUnevaluated[
+        HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, {{1, 2, 3} -> "$$$Incorrect$$$"}],
+        {HypergraphPlot::invalidEdgeType}
+      ]},
+
+      {testUnevaluated[
+        HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, {None, {1, 2, 3} -> "Ordered"}],
+        {HypergraphPlot::invalidEdgeType}
+      ]},
+
+      {testUnevaluated[
+        HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, {"$$$Incorrect$$$", {1, 2, 3} -> "Ordered"}],
+        {HypergraphPlot::invalidEdgeType}
+      ]},
+
+      {testUnevaluated[
+        HypergraphPlot[
+          {{1, 2, 3}, {3, 4, 5}},
+          {{3, 4, 5} -> "Ordered", {1, 2, 3} -> "$$$Incorrect$$$"}],
+        {HypergraphPlot::invalidEdgeType}
+      ]},
+
+      {VerificationTest[
+        Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "Ordered"]],
+        Graphics
+      ]},
+
+      {VerificationTest[
+        Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "Cyclic"]],
+        Graphics
+      ]},
+
+      (* Valid options *)
+
+      {testUnevaluated[
+        HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "$$$InvalidOption###" -> True],
+        {HypergraphPlot::optx}
+      ]},
+
+      {testUnevaluated[
+        HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "Ordered", "$$$InvalidOption###" -> True],
+        {HypergraphPlot::optx}
+      ]},
+
+      {testUnevaluated[
+        HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "$$$Incorrect$$$", "$$$InvalidOption###" -> True],
+        {HypergraphPlot::invalidEdgeType}
+      ]},
+
+      (* Valid coordinates *)
+
+      {testUnevaluated[
+        HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, VertexCoordinateRules -> $$$invalid$$$],
+        {HypergraphPlot::invalidCoordinates}
+      ]},
+
+      {testUnevaluated[
+        HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, VertexCoordinateRules -> {{0, 0}}],
+        {HypergraphPlot::invalidCoordinates}
+      ]},
+
+      {testUnevaluated[
+        HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, VertexCoordinateRules -> {1 -> {0}}],
+        {HypergraphPlot::invalidCoordinates}
+      ]},
+
+      {VerificationTest[
+        Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, VertexCoordinateRules -> {1 -> {0, 0}}]],
+        Graphics
+      ]},
+
+      {VerificationTest[
+        Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "Ordered", VertexCoordinateRules -> {1 -> {0, 0}}]],
+        Graphics
+      ]},
+
+      (* Valid GraphHighlight *)
+
+      {testUnevaluated[
+        HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> $$$invalid$$$],
+        {HypergraphPlot::invalidHighlight}
+      ]},
+
+      {testUnevaluated[
+        HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {6}],
+        {HypergraphPlot::invalidHighlight}
+      ]},
+
+      {testUnevaluated[
+        HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {1, 1}],
+        {HypergraphPlot::invalidHighlight}
+      ]},
+
+      {testUnevaluated[
+        HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {{1, 2}}],
+        {HypergraphPlot::invalidHighlight}
+      ]},
+
+      {VerificationTest[
+        Head[HypergraphPlot[{{1, 2, 3}, {1, 2, 3}}, GraphHighlight -> {{1, 2, 3}}]],
+        Graphics
+      ]},
+
+      {VerificationTest[
+        Head[HypergraphPlot[{{1, 2, 3}, {1, 2, 3}}, GraphHighlight -> {{1, 2, 3}, {1, 2, 3}}]],
+        Graphics
+      ]},
+
+      {testUnevaluated[
+        HypergraphPlot[{{1, 2, 3}, {1, 2, 3}}, GraphHighlight -> {{1, 2, 3}, {1, 2, 3}, {1, 2, 3}}],
+        {HypergraphPlot::invalidHighlight}
+      ]},
+
+      {VerificationTest[
+        Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {1}]],
+        Graphics
+      ]},
+
+      {VerificationTest[
+        Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {{1, 2, 3}}]],
+        Graphics
+      ]},
+
+      {VerificationTest[
+        Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {4, {1, 2, 3}}]],
+        Graphics
+      ]},
+
+      (* Valid GraphHighlightStyle *)
+
+      {testUnevaluated[
+        HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {1}, GraphHighlightStyle -> None],
+        {HypergraphPlot::invalidHighlightStyle}
+      ]},
+
+      {testUnevaluated[
+        HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {1}, GraphHighlightStyle -> 2],
+        {HypergraphPlot::invalidHighlightStyle}
+      ]},
+
+      {testUnevaluated[
+        HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {1}, GraphHighlightStyle -> "Dashed"],
+        {HypergraphPlot::invalidHighlightStyle}
+      ]},
+
+      {VerificationTest[
+        Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {1}, GraphHighlightStyle -> Black]],
+        Graphics
+      ]},
+
+      (* Implementation *)
+
+      (** Simple examples **)
+
+      Catenate[Table[With[{hypergraph = hypergraph}, VerificationTest[
+        Head[HypergraphPlot[hypergraph, #]],
+        Graphics
+      ]] & /@ $edgeTypes, {hypergraph, $simpleHypergraphs}]],
+
+      (** Large graphs **)
+
+      VerificationTest[
+        Head @ HypergraphPlot @ SetReplace[
+          {{0, 1}, {0, 2}, {0, 3}},
+          ToPatternRules[
+            {{0, 1}, {0, 2}, {0, 3}} ->
+            {{4, 5}, {5, 4}, {4, 6}, {6, 4},
+              {5, 6}, {6, 5}, {4, 1}, {5, 2}, {6, 3}}],
+          #],
+        Graphics
+      ] & /@ {10, 5000},
+
+      (* EdgeType *)
+
+      VerificationTest[
+        diskCoordinates[HypergraphPlot[#, "Ordered"]] != diskCoordinates[HypergraphPlot[#, "Cyclic"]]
+      ] & /@ $layoutTestHypergraphs,
+
+      VerificationTest[
+        Length[Union[Cases[
+          HypergraphPlot[#, "HyperedgeRendering" -> "Subgraphs"],
+          Polygon[___],
+          All]]],
+        1
+      ] & /@ $layoutTestHypergraphs,
+
+      VerificationTest[
+        Length[Union[Cases[
+          HypergraphPlot[#, "HyperedgeRendering" -> "Polygons"],
+          Polygon[___],
+          All]]],
+        1 + Length[#]
+      ] & /@ $layoutTestHypergraphs,
+
+      (* VertexLabels *)
+
+      VerificationTest[
+        MissingQ[FirstCase[
+          HypergraphPlot[#, VertexLabels -> None],
+          Text[___],
+          Missing[],
+          All]]
+      ] & /@ $layoutTestHypergraphs,
+
+      VerificationTest[
+        !MissingQ[FirstCase[
+          HypergraphPlot[#, VertexLabels -> Automatic],
+          Text[___],
+          Missing[],
+          All]]
+      ] & /@ $layoutTestHypergraphs,
+
+      (* Single-vertex edges *)
+
+      {VerificationTest[
+        HypergraphPlot[{{1}, {1, 2}}] =!= HypergraphPlot[{{1, 2}}]
+      ]},
+
+      {VerificationTest[
+        MissingQ[FirstCase[
+          HypergraphPlot[{{1, 2}}, VertexLabels -> None],
+          Circle[___],
+          Missing[],
+          All]]
+      ]},
+
+      {VerificationTest[
+        !MissingQ[FirstCase[
+          HypergraphPlot[{{1}, {1, 2}}, VertexLabels -> Automatic],
+          Circle[___],
+          Missing[],
+          All]]
+      ]},
+
+      (* VertexCoordinateRules *)
+
+      {VerificationTest[
+        And @@ (MemberQ[
+            diskCoordinates[HypergraphPlot[
+              {{1, 2, 3}, {3, 4, 5}, {3, 3}},
+              VertexCoordinateRules -> {1 -> {0, 0}, 2 -> {1, 0}}]],
+            #] & /@
+          {{0., 0.}, {1., 0.}})
+      ]},
+
+      {VerificationTest[
+        Chop @ diskCoordinates[HypergraphPlot[
+          {{1, 2, 3}, {3, 4, 5}},
+          VertexCoordinateRules -> {3 -> {0, 0}}]] != Table[{0, 0}, 5]
+      ]},
+
+      {VerificationTest[
+        Chop @ diskCoordinates[HypergraphPlot[
+          {{1, 2, 3}, {3, 4, 5}},
+          VertexCoordinateRules -> {3 -> {1, 0}, 3 -> {0, 0}}]] != Table[{0, 0}, 5]
+      ]},
+
+      (** Same coordinates should not produce any messages **)
+      {VerificationTest[
+        And @@ Cases[
+          HypergraphPlot[{{1, 2, 3}}, VertexCoordinateRules -> {1 -> {1, 0}, 2 -> {1, 0}}],
+          Rotate[_, {v1_, v2_}] :> v1 != {0, 0} && v2 != {0, 0},
+          All]
+      ]},
+
+      (* GraphHighlight *)
+
+      VerificationTest[
+        Length[Union @ Cases[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {#}], _ ? ColorQ, All]] >
+          Length[Union @ Cases[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}], _ ? ColorQ, All]]
+      ] & /@ {4, {1, 2, 3}},
+
+      (** Test multi-edge highlighting **)
+      {VerificationTest[
+        Differences[
+          Length[Union[Cases[#, _?ColorQ, All]]] & /@
+            (HypergraphPlot[{{1, 2}, {1, 2}}, "HyperedgeRendering" -> "Subgraphs", GraphHighlight -> #] &) /@
+            {{}, {{1, 2}}, {{1, 2}, {1, 2}}}],
+        {1, -1}
+      ]},
+
+      (* GraphHighlightStyle *)
+
+      {VerificationTest[
+        With[{
+            color = RGBColor[0.4, 0.6, 0.2]},
+          FreeQ[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> #, GraphHighlightStyle -> color], color] & /@
+            {{}, {4}, {{1, 2, 3}}}],
+        {True, False, False}
+      ]},
+
+      (* Scaling consistency *)
+      (* Vertex sizes, arrow sizes, average edge lengths, and loop lengths should always be the same. *)
+
+      {VerificationTest[
+        SameQ @@ (
+          Union[Cases[HypergraphPlot[#], Disk[_, r_] :> r, All]] & /@
+            {{{1}}, {{1, 2, 3}}, {{1, 2, 3}, {3, 4, 5}}, RandomInteger[10, {5, 5}]})
+      ]},
+
+      {VerificationTest[
+        SameQ @@ (
+          Union[Cases[HypergraphPlot[#, "HyperedgeRendering" -> "Subgraphs"], p : Polygon[___] :> Area[p], All]] & /@
+            {{{1, 2}}, {{1, 2, 3}}, {{1, 2, 3}, {3, 4, 5}}, RandomInteger[10, {5, 5}]})
+      ]},
+
+      {VerificationTest[
+        Equal @@ (
+          Mean[Cases[
+              HypergraphPlot[#, "HyperedgeRendering" -> "Subgraphs"],
+              Line[pts_] :> EuclideanDistance @@ pts,
+              All]] & /@
+            {{{1, 2}}, {{1, 2, 3}}, {{1, 2, 3}, {3, 4, 5}}, {{1, 2, 3}, {3, 4, 5}, {5, 6, 1}}, {{1, 2, 3, 4, 5, 1}}})
+      ]},
+
+      VerificationTest[
+        Abs[
+              First[
+                Nearest[
+                  Cases[
+                    HypergraphPlot[#, "HyperedgeRendering" -> "Subgraphs"],
+                    Line[pts_] :> RegionMeasure[Line[pts]],
+                    All],
+                  $selfLoopLength]] -
             $selfLoopLength] <
-        1.*^-10 & /@ {
-      {{1, 1}},
-      {{1, 2, 3}, {1, 1}},
-      {{1, 2, 3}, {3, 4, 5}, {5, 5}},
-      {{1, 2, 3}, {3, 4, 5}, {5, 6, 1, 1}},
-      {{1, 2, 3, 4, 5, 5, 1}}})
-]
-
-EndTestSection[]
+          1.*^-10
+      ] & /@ {
+        {{1, 1}},
+        {{1, 2, 3}, {1, 1}},
+        {{1, 2, 3}, {3, 4, 5}, {5, 5}},
+        {{1, 2, 3}, {3, 4, 5}, {5, 6, 1, 1}},
+        {{1, 2, 3, 4, 5, 5, 1}}}
+    ]
+  |>
+|>

--- a/SetReplace/HypergraphPlot.wlt
+++ b/SetReplace/HypergraphPlot.wlt
@@ -31,14 +31,7 @@
         Missing[],
         All];
 
-      Attributes[testUnevaluated] = {HoldAll};
-      testUnevaluated[input_, messages_, opts___] :=
-        VerificationTest[
-          input,
-          HoldPattern[input],
-          messages,
-          SameTest -> MatchQ,
-          opts];
+      Global`testUnevaluated = SetReplace`PackageScope`testUnevaluated;
     ),
     "tests" -> {
       (* Argument Checks *)

--- a/SetReplace/HypergraphPlot.wlt
+++ b/SetReplace/HypergraphPlot.wlt
@@ -40,218 +40,218 @@
           SameTest -> MatchQ,
           opts];
     ),
-    "tests" -> Join[
+    "tests" -> {
       (* Argument Checks *)
 
       (** Argument count **)
 
-      {testUnevaluated[
+      testUnevaluated[
         HypergraphPlot[],
         {HypergraphPlot::argt}
-      ]},
+      ],
 
-      {testUnevaluated[
+      testUnevaluated[
         HypergraphPlot[{{1, 2}}, {{1, 2}}, {{1, 2}}],
         {HypergraphPlot::argt}
-      ]},
+      ],
 
       (** Valid edges **)
 
-      {testUnevaluated[
+      testUnevaluated[
         HypergraphPlot[1],
         {HypergraphPlot::invalidEdges}
-      ]},
+      ],
 
-      {testUnevaluated[
+      testUnevaluated[
         HypergraphPlot[{1, 2}],
         {HypergraphPlot::invalidEdges}
-      ]},
+      ],
 
-      {testUnevaluated[
+      testUnevaluated[
         HypergraphPlot[{{1, 3}, 2}],
         {HypergraphPlot::invalidEdges}
-      ]},
+      ],
 
-      {testUnevaluated[
+      testUnevaluated[
         HypergraphPlot[{{1, 3}, 6, {2, 4}}],
         {HypergraphPlot::invalidEdges}
-      ]},
+      ],
 
       (** Valid EdgeType **)
 
-      {testUnevaluated[
+      testUnevaluated[
         HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, None],
         {HypergraphPlot::invalidEdgeType}
-      ]},
+      ],
 
-      {testUnevaluated[
+      testUnevaluated[
         HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "$$$Incorrect$$$"],
         {HypergraphPlot::invalidEdgeType}
-      ]},
+      ],
 
-      {testUnevaluated[
+      testUnevaluated[
         HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, {"$$$Incorrect$$$"}],
         {HypergraphPlot::invalidEdgeType}
-      ]},
+      ],
 
-      {testUnevaluated[
+      testUnevaluated[
         HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, {{1, 2, 3} -> "$$$Incorrect$$$"}],
         {HypergraphPlot::invalidEdgeType}
-      ]},
+      ],
 
-      {testUnevaluated[
+      testUnevaluated[
         HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, {None, {1, 2, 3} -> "Ordered"}],
         {HypergraphPlot::invalidEdgeType}
-      ]},
+      ],
 
-      {testUnevaluated[
+      testUnevaluated[
         HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, {"$$$Incorrect$$$", {1, 2, 3} -> "Ordered"}],
         {HypergraphPlot::invalidEdgeType}
-      ]},
+      ],
 
-      {testUnevaluated[
+      testUnevaluated[
         HypergraphPlot[
           {{1, 2, 3}, {3, 4, 5}},
           {{3, 4, 5} -> "Ordered", {1, 2, 3} -> "$$$Incorrect$$$"}],
         {HypergraphPlot::invalidEdgeType}
-      ]},
+      ],
 
-      {VerificationTest[
+      VerificationTest[
         Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "Ordered"]],
         Graphics
-      ]},
+      ],
 
-      {VerificationTest[
+      VerificationTest[
         Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "Cyclic"]],
         Graphics
-      ]},
+      ],
 
       (* Valid options *)
 
-      {testUnevaluated[
+      testUnevaluated[
         HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "$$$InvalidOption###" -> True],
         {HypergraphPlot::optx}
-      ]},
+      ],
 
-      {testUnevaluated[
+      testUnevaluated[
         HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "Ordered", "$$$InvalidOption###" -> True],
         {HypergraphPlot::optx}
-      ]},
+      ],
 
-      {testUnevaluated[
+      testUnevaluated[
         HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "$$$Incorrect$$$", "$$$InvalidOption###" -> True],
         {HypergraphPlot::invalidEdgeType}
-      ]},
+      ],
 
       (* Valid coordinates *)
 
-      {testUnevaluated[
+      testUnevaluated[
         HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, VertexCoordinateRules -> $$$invalid$$$],
         {HypergraphPlot::invalidCoordinates}
-      ]},
+      ],
 
-      {testUnevaluated[
+      testUnevaluated[
         HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, VertexCoordinateRules -> {{0, 0}}],
         {HypergraphPlot::invalidCoordinates}
-      ]},
+      ],
 
-      {testUnevaluated[
+      testUnevaluated[
         HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, VertexCoordinateRules -> {1 -> {0}}],
         {HypergraphPlot::invalidCoordinates}
-      ]},
+      ],
 
-      {VerificationTest[
+      VerificationTest[
         Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, VertexCoordinateRules -> {1 -> {0, 0}}]],
         Graphics
-      ]},
+      ],
 
-      {VerificationTest[
+      VerificationTest[
         Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "Ordered", VertexCoordinateRules -> {1 -> {0, 0}}]],
         Graphics
-      ]},
+      ],
 
       (* Valid GraphHighlight *)
 
-      {testUnevaluated[
+      testUnevaluated[
         HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> $$$invalid$$$],
         {HypergraphPlot::invalidHighlight}
-      ]},
+      ],
 
-      {testUnevaluated[
+      testUnevaluated[
         HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {6}],
         {HypergraphPlot::invalidHighlight}
-      ]},
+      ],
 
-      {testUnevaluated[
+      testUnevaluated[
         HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {1, 1}],
         {HypergraphPlot::invalidHighlight}
-      ]},
+      ],
 
-      {testUnevaluated[
+      testUnevaluated[
         HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {{1, 2}}],
         {HypergraphPlot::invalidHighlight}
-      ]},
+      ],
 
-      {VerificationTest[
+      VerificationTest[
         Head[HypergraphPlot[{{1, 2, 3}, {1, 2, 3}}, GraphHighlight -> {{1, 2, 3}}]],
         Graphics
-      ]},
+      ],
 
-      {VerificationTest[
+      VerificationTest[
         Head[HypergraphPlot[{{1, 2, 3}, {1, 2, 3}}, GraphHighlight -> {{1, 2, 3}, {1, 2, 3}}]],
         Graphics
-      ]},
+      ],
 
-      {testUnevaluated[
+      testUnevaluated[
         HypergraphPlot[{{1, 2, 3}, {1, 2, 3}}, GraphHighlight -> {{1, 2, 3}, {1, 2, 3}, {1, 2, 3}}],
         {HypergraphPlot::invalidHighlight}
-      ]},
+      ],
 
-      {VerificationTest[
+      VerificationTest[
         Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {1}]],
         Graphics
-      ]},
+      ],
 
-      {VerificationTest[
+      VerificationTest[
         Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {{1, 2, 3}}]],
         Graphics
-      ]},
+      ],
 
-      {VerificationTest[
+      VerificationTest[
         Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {4, {1, 2, 3}}]],
         Graphics
-      ]},
+      ],
 
       (* Valid GraphHighlightStyle *)
 
-      {testUnevaluated[
+      testUnevaluated[
         HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {1}, GraphHighlightStyle -> None],
         {HypergraphPlot::invalidHighlightStyle}
-      ]},
+      ],
 
-      {testUnevaluated[
+      testUnevaluated[
         HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {1}, GraphHighlightStyle -> 2],
         {HypergraphPlot::invalidHighlightStyle}
-      ]},
+      ],
 
-      {testUnevaluated[
+      testUnevaluated[
         HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {1}, GraphHighlightStyle -> "Dashed"],
         {HypergraphPlot::invalidHighlightStyle}
-      ]},
+      ],
 
-      {VerificationTest[
+      VerificationTest[
         Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {1}, GraphHighlightStyle -> Black]],
         Graphics
-      ]},
+      ],
 
       (* Implementation *)
 
       (** Simple examples **)
 
-      Catenate[Table[With[{hypergraph = hypergraph}, VerificationTest[
+      Table[With[{hypergraph = hypergraph}, VerificationTest[
         Head[HypergraphPlot[hypergraph, #]],
         Graphics
-      ]] & /@ $edgeTypes, {hypergraph, $simpleHypergraphs}]],
+      ]] & /@ $edgeTypes, {hypergraph, $simpleHypergraphs}],
 
       (** Large graphs **)
 
@@ -308,56 +308,56 @@
 
       (* Single-vertex edges *)
 
-      {VerificationTest[
+      VerificationTest[
         HypergraphPlot[{{1}, {1, 2}}] =!= HypergraphPlot[{{1, 2}}]
-      ]},
+      ],
 
-      {VerificationTest[
+      VerificationTest[
         MissingQ[FirstCase[
           HypergraphPlot[{{1, 2}}, VertexLabels -> None],
           Circle[___],
           Missing[],
           All]]
-      ]},
+      ],
 
-      {VerificationTest[
+      VerificationTest[
         !MissingQ[FirstCase[
           HypergraphPlot[{{1}, {1, 2}}, VertexLabels -> Automatic],
           Circle[___],
           Missing[],
           All]]
-      ]},
+      ],
 
       (* VertexCoordinateRules *)
 
-      {VerificationTest[
+      VerificationTest[
         And @@ (MemberQ[
             diskCoordinates[HypergraphPlot[
               {{1, 2, 3}, {3, 4, 5}, {3, 3}},
               VertexCoordinateRules -> {1 -> {0, 0}, 2 -> {1, 0}}]],
             #] & /@
           {{0., 0.}, {1., 0.}})
-      ]},
+      ],
 
-      {VerificationTest[
+      VerificationTest[
         Chop @ diskCoordinates[HypergraphPlot[
           {{1, 2, 3}, {3, 4, 5}},
           VertexCoordinateRules -> {3 -> {0, 0}}]] != Table[{0, 0}, 5]
-      ]},
+      ],
 
-      {VerificationTest[
+      VerificationTest[
         Chop @ diskCoordinates[HypergraphPlot[
           {{1, 2, 3}, {3, 4, 5}},
           VertexCoordinateRules -> {3 -> {1, 0}, 3 -> {0, 0}}]] != Table[{0, 0}, 5]
-      ]},
+      ],
 
       (** Same coordinates should not produce any messages **)
-      {VerificationTest[
+      VerificationTest[
         And @@ Cases[
           HypergraphPlot[{{1, 2, 3}}, VertexCoordinateRules -> {1 -> {1, 0}, 2 -> {1, 0}}],
           Rotate[_, {v1_, v2_}] :> v1 != {0, 0} && v2 != {0, 0},
           All]
-      ]},
+      ],
 
       (* GraphHighlight *)
 
@@ -367,47 +367,47 @@
       ] & /@ {4, {1, 2, 3}},
 
       (** Test multi-edge highlighting **)
-      {VerificationTest[
+      VerificationTest[
         Differences[
           Length[Union[Cases[#, _?ColorQ, All]]] & /@
             (HypergraphPlot[{{1, 2}, {1, 2}}, "HyperedgeRendering" -> "Subgraphs", GraphHighlight -> #] &) /@
             {{}, {{1, 2}}, {{1, 2}, {1, 2}}}],
         {1, -1}
-      ]},
+      ],
 
       (* GraphHighlightStyle *)
 
-      {VerificationTest[
+      VerificationTest[
         With[{
             color = RGBColor[0.4, 0.6, 0.2]},
           FreeQ[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> #, GraphHighlightStyle -> color], color] & /@
             {{}, {4}, {{1, 2, 3}}}],
         {True, False, False}
-      ]},
+      ],
 
       (* Scaling consistency *)
       (* Vertex sizes, arrow sizes, average edge lengths, and loop lengths should always be the same. *)
 
-      {VerificationTest[
+      VerificationTest[
         SameQ @@ (
           Union[Cases[HypergraphPlot[#], Disk[_, r_] :> r, All]] & /@
             {{{1}}, {{1, 2, 3}}, {{1, 2, 3}, {3, 4, 5}}, RandomInteger[10, {5, 5}]})
-      ]},
+      ],
 
-      {VerificationTest[
+      VerificationTest[
         SameQ @@ (
           Union[Cases[HypergraphPlot[#, "HyperedgeRendering" -> "Subgraphs"], p : Polygon[___] :> Area[p], All]] & /@
             {{{1, 2}}, {{1, 2, 3}}, {{1, 2, 3}, {3, 4, 5}}, RandomInteger[10, {5, 5}]})
-      ]},
+      ],
 
-      {VerificationTest[
+      VerificationTest[
         Equal @@ (
           Mean[Cases[
               HypergraphPlot[#, "HyperedgeRendering" -> "Subgraphs"],
               Line[pts_] :> EuclideanDistance @@ pts,
               All]] & /@
             {{{1, 2}}, {{1, 2, 3}}, {{1, 2, 3}, {3, 4, 5}}, {{1, 2, 3}, {3, 4, 5}, {5, 6, 1}}, {{1, 2, 3, 4, 5, 1}}})
-      ]},
+      ],
 
       VerificationTest[
         Abs[
@@ -426,6 +426,6 @@
         {{1, 2, 3}, {3, 4, 5}, {5, 5}},
         {{1, 2, 3}, {3, 4, 5}, {5, 6, 1, 1}},
         {{1, 2, 3, 4, 5, 5, 1}}}
-    ]
+    }
   |>
 |>

--- a/SetReplace/HypergraphPlot.wlt
+++ b/SetReplace/HypergraphPlot.wlt
@@ -31,7 +31,8 @@
         Missing[],
         All];
 
-      Global`testUnevaluated = SetReplace`PackageScope`testUnevaluated;
+      Attributes[Global`testUnevaluated] = {HoldAll};
+      Global`testUnevaluated[args___] := SetReplace`PackageScope`testUnevaluated[VerificationTest, args];
     ),
     "tests" -> {
       (* Argument Checks *)

--- a/SetReplace/RulePlot.wlt
+++ b/SetReplace/RulePlot.wlt
@@ -1,294 +1,284 @@
-BeginTestSection["RulePlot"]
+<|
+  "RulePlot" -> <|
+    "init" -> (
+      Attributes[Global`testUnevaluated] = {HoldAll};
+      Global`testUnevaluated[args___] := SetReplace`PackageScope`testUnevaluated[VerificationTest, args];
 
-(* Rule correctness checking *)
+      $rulesForVertexSizeConsistency = {
+        {{1}} -> {{1}},
+        {{1}} -> {{2}},
+        {{1, 2}} -> {{1}},
+        {{1, 2}} -> {{1, 2}},
+        {{1, 2, 3}} -> {{1}},
+        {{1, 2, 3}} -> {{1, 2}},
+        {{1}, {2}} -> {{2}, {3}},
+        {{1}, {2}, {3}} -> {{2}, {3}, {4}},
+        {{1, 2, 3}} -> {{3, 4, 5}},
+        {{1, 2, 3}} -> {{1, 2}, {2, 3}},
+        {{1, 2, 3}} -> {{2, 3}, {3, 4}}};
+    ),
+    "tests" -> {
+      (* Rule correctness checking *)
 
-VerificationTest[
-  RulePlot[WolframModel[1]],
-  RulePlot[WolframModel[1]],
-  {RulePlot::invalidRules}
-]
+      testUnevaluated[
+        RulePlot[WolframModel[1]],
+        {RulePlot::invalidRules}
+      ],
 
-VerificationTest[
-  RulePlot[WolframModel[1 -> 2]],
-  RulePlot[WolframModel[1 -> 2]],
-  {RulePlot::notHypergraphRule}
-]
+      testUnevaluated[
+        RulePlot[WolframModel[1 -> 2]],
+        {RulePlot::notHypergraphRule}
+      ],
 
-VerificationTest[
-  RulePlot[WolframModel[{1} -> {2}]],
-  RulePlot[WolframModel[{1} -> {2}]],
-  {RulePlot::notHypergraphRule}
-]
+      testUnevaluated[
+        RulePlot[WolframModel[{1} -> {2}]],
+        {RulePlot::notHypergraphRule}
+      ],
 
-VerificationTest[
-  RulePlot[WolframModel[{{1}} -> {2}]],
-  RulePlot[WolframModel[{{1}} -> {2}]],
-  {RulePlot::notHypergraphRule}
-]
+      testUnevaluated[
+        RulePlot[WolframModel[{{1}} -> {2}]],
+        {RulePlot::notHypergraphRule}
+      ],
 
-VerificationTest[
-  Head[RulePlot[WolframModel[{{1}} -> {{2}}]]],
-  Graphics
-]
+      VerificationTest[
+        Head[RulePlot[WolframModel[{{1}} -> {{2}}]]],
+        Graphics
+      ],
 
-VerificationTest[
-  RulePlot[WolframModel[<|"PatternRules" -> {{1}} -> {{2}}|>]],
-  RulePlot[WolframModel[<|"PatternRules" -> {{1}} -> {{2}}|>]],
-  {RulePlot::patternRules}
-]
+      testUnevaluated[
+        RulePlot[WolframModel[<|"PatternRules" -> {{1}} -> {{2}}|>]],
+        {RulePlot::patternRules}
+      ],
 
-VerificationTest[
-  Head[RulePlot[WolframModel[{{1}} -> {{2}}, Method -> "$$$AnyMethod$$$"]]],
-  Graphics
-]
+      VerificationTest[
+        Head[RulePlot[WolframModel[{{1}} -> {{2}}, Method -> "$$$AnyMethod$$$"]]],
+        Graphics
+      ],
 
-VerificationTest[
-  RulePlot[WolframModel[{{{1}} -> {{2}}, 1}]],
-  RulePlot[WolframModel[{{{1}} -> {{2}}, 1}]],
-  {RulePlot::invalidRules}
-]
+      testUnevaluated[
+        RulePlot[WolframModel[{{{1}} -> {{2}}, 1}]],
+        {RulePlot::invalidRules}
+      ],
 
-VerificationTest[
-  RulePlot[WolframModel[{{{1}} -> {{2}}, 1 -> 2}]],
-  RulePlot[WolframModel[{{{1}} -> {{2}}, 1 -> 2}]],
-  {RulePlot::notHypergraphRule}
-]
+      testUnevaluated[
+        RulePlot[WolframModel[{{{1}} -> {{2}}, 1 -> 2}]],
+        {RulePlot::notHypergraphRule}
+      ],
 
-VerificationTest[
-  Head[RulePlot[WolframModel[{{{1}} -> {{2}}, {{1}} -> {{2}}}]]],
-  Graphics
-]
+      VerificationTest[
+        Head[RulePlot[WolframModel[{{{1}} -> {{2}}, {{1}} -> {{2}}}]]],
+        Graphics
+      ],
 
-(* Options *)
+      (* Options *)
 
-(** EdgeType **)
+      (** EdgeType **)
 
-VerificationTest[
-  Not[
-    Or @@ SameQ @@@ Subsets[
-      Rasterize[RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], "EdgeType" -> #]] & /@
-        {"Ordered", "Cyclic"},
-      {2}]]
-]
+      VerificationTest[
+        Not[
+          Or @@ SameQ @@@ Subsets[
+            Rasterize[RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], "EdgeType" -> #]] & /@
+              {"Ordered", "Cyclic"},
+            {2}]]
+      ],
 
-VerificationTest[
-  RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], "EdgeType" -> "Invalid"],
-  RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], "EdgeType" -> "Invalid"],
-  {RulePlot::invalidEdgeType}
-]
+      testUnevaluated[
+        RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], "EdgeType" -> "Invalid"],
+        {RulePlot::invalidEdgeType}
+      ],
 
-VerificationTest[
-  RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], "EdgeType" -> 3],
-  RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], "EdgeType" -> 3],
-  {RulePlot::invalidEdgeType}
-]
+      testUnevaluated[
+        RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], "EdgeType" -> 3],
+        {RulePlot::invalidEdgeType}
+      ],
 
-(** GraphhighlightStyle **)
+      (** GraphhighlightStyle **)
 
-VerificationTest[
-  RulePlot[WolframModel[{{1, 2, 3}, {3, 4, 5}} -> {{3, 4, 5}, {5, 6, 7}}], GraphHighlightStyle -> 1],
-  RulePlot[WolframModel[{{1, 2, 3}, {3, 4, 5}} -> {{3, 4, 5}, {5, 6, 7}}], GraphHighlightStyle -> 1],
-  {RulePlot::invalidHighlightStyle}
-]
+      testUnevaluated[
+        RulePlot[WolframModel[{{1, 2, 3}, {3, 4, 5}} -> {{3, 4, 5}, {5, 6, 7}}], GraphHighlightStyle -> 1],
+        {RulePlot::invalidHighlightStyle}
+      ],
 
-VerificationTest[
-  With[{
-      color = RGBColor[0.4, 0.6, 0.2]},
-    FreeQ[RulePlot[WolframModel[#], GraphHighlightStyle -> color], color] & /@
-      {{{1}} -> {{2}}, {{1}} -> {{1}}, {{1, 2}} -> {{1, 2}}, {{1, 2}} -> {{2, 3}}, {{1, 2}} -> {{3, 4}}}],
-  {True, False, False, False, True}
-]
+      VerificationTest[
+        With[{
+            color = RGBColor[0.4, 0.6, 0.2]},
+          FreeQ[RulePlot[WolframModel[#], GraphHighlightStyle -> color], color] & /@
+            {{{1}} -> {{2}}, {{1}} -> {{1}}, {{1, 2}} -> {{1, 2}}, {{1, 2}} -> {{2, 3}}, {{1, 2}} -> {{3, 4}}}],
+        {True, False, False, False, True}
+      ],
 
-(** HyperedgeRendering **)
+      (** HyperedgeRendering **)
 
-VerificationTest[
-  Not[
-    Or @@ SameQ @@@ Subsets[
-      Rasterize[RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], "HyperedgeRendering" -> #]] & /@
-        {"Subgraphs", "Polygons"},
-      {2}]]
-]
+      VerificationTest[
+        Not[
+          Or @@ SameQ @@@ Subsets[
+            Rasterize[RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], "HyperedgeRendering" -> #]] & /@
+              {"Subgraphs", "Polygons"},
+            {2}]]
+      ],
 
-VerificationTest[
-  RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], "HyperedgeRendering" -> "Invalid"],
-  RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], "HyperedgeRendering" -> "Invalid"],
-  {RulePlot::invalidFiniteOption}
-]
+      testUnevaluated[
+        RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], "HyperedgeRendering" -> "Invalid"],
+        {RulePlot::invalidFiniteOption}
+      ],
 
-VerificationTest[
-  RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], "HyperedgeRendering" -> 3],
-  RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], "HyperedgeRendering" -> 3],
-  {RulePlot::invalidFiniteOption}
-]
+      testUnevaluated[
+        RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], "HyperedgeRendering" -> 3],
+        {RulePlot::invalidFiniteOption}
+      ],
 
-(** VertexCoordinateRules **)
+      (** VertexCoordinateRules **)
 
-VerificationTest[
-  SameQ @@
-    Cases[
-      RulePlot[
-        WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}],
-        VertexCoordinateRules -> {1 -> {0, 0}, 2 -> {1, 0}, 3 -> {2, 0}, 4 -> {3, 0}, 5 -> {4, 0}}],
-      Disk[p_, _] :> p,
-      All][[All, 2]]
-]
+      VerificationTest[
+        SameQ @@
+          Cases[
+            RulePlot[
+              WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}],
+              VertexCoordinateRules -> {1 -> {0, 0}, 2 -> {1, 0}, 3 -> {2, 0}, 4 -> {3, 0}, 5 -> {4, 0}}],
+            Disk[p_, _] :> p,
+            All][[All, 2]]
+      ],
 
-(*** Due to scaling and translation being computed in the frontend instead of ahead of time,
-      coordinates on both sides of the rule might be the same. ***)
-VerificationTest[
-  Length[
-      Union[
-        Cases[
-          RulePlot[
-            WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}],
-            VertexCoordinateRules -> {1 -> {0, 0}, 2 -> {0, 0}, 3 -> {0, 0}, 4 -> {0, 0}, 5 -> {0, 0}}],
-          Disk[p_, _] :> p,
-          All]]]
-    <= 2
-]
+      (*** Due to scaling and translation being computed in the frontend instead of ahead of time,
+            coordinates on both sides of the rule might be the same. ***)
+      VerificationTest[
+        Length[
+            Union[
+              Cases[
+                RulePlot[
+                  WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}],
+                  VertexCoordinateRules -> {1 -> {0, 0}, 2 -> {0, 0}, 3 -> {0, 0}, 4 -> {0, 0}, 5 -> {0, 0}}],
+                Disk[p_, _] :> p,
+                All]]]
+          <= 2
+      ],
 
-VerificationTest[
-  Head[RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], VertexCoordinateRules -> {}]],
-  Graphics
-]
+      VerificationTest[
+        Head[RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], VertexCoordinateRules -> {}]],
+        Graphics
+      ],
 
-VerificationTest[
-  RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], VertexCoordinateRules -> {1}],
-  RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], VertexCoordinateRules -> {1}],
-  {RulePlot::invalidCoordinates}
-]
+      testUnevaluated[
+        RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], VertexCoordinateRules -> {1}],
+        {RulePlot::invalidCoordinates}
+      ],
 
-(** VertexLabels **)
+      (** VertexLabels **)
 
-VerificationTest[
-  Sort[Cases[RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], VertexLabels -> Automatic], Text[i_, ___] :> i, All]],
-  {1, 2, 3, 3, 4, 5}
-]
+      VerificationTest[
+        Sort[Cases[RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], VertexLabels -> Automatic], Text[i_, ___] :> i, All]],
+        {1, 2, 3, 3, 4, 5}
+      ],
 
-VerificationTest[
-  Length[Cases[RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], VertexLabels -> x], Text[x, ___], All]],
-  6
-]
+      VerificationTest[
+        Length[Cases[RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], VertexLabels -> x], Text[x, ___], All]],
+        6
+      ],
 
-(** Graphics **)
+      (** Graphics **)
 
-VerificationTest[
-  Background /. AbsoluteOptions[RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], Background -> Black], Background],
-  Black,
-  SameTest -> Equal
-]
+      VerificationTest[
+        Background /. AbsoluteOptions[RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], Background -> Black], Background],
+        Black,
+        SameTest -> Equal
+      ],
 
-(** Frame **)
+      (** Frame **)
 
-VerificationTest[
-  Not[
-    Or @@ SameQ @@@ Subsets[
-      Rasterize[RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], Frame -> #]] & /@ {False, True}, {2}]]
-]
+      VerificationTest[
+        Not[
+          Or @@ SameQ @@@ Subsets[
+            Rasterize[RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], Frame -> #]] & /@ {False, True}, {2}]]
+      ],
 
-VerificationTest[
-  RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], Frame -> "Invalid"],
-  RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], Frame -> "Invalid"],
-  {RulePlot::invalidFiniteOption}
-]
+      testUnevaluated[
+        RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], Frame -> "Invalid"],
+        {RulePlot::invalidFiniteOption}
+      ],
 
-(** FrameStyle **)
+      (** FrameStyle **)
 
-VerificationTest[
-  MemberQ[
-    Cases[
-      RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], FrameStyle -> RGBColor[0.33, 0.66, 0.77]][[1]],
-      _ ? ColorQ,
-      All],
-    RGBColor[0.33, 0.66, 0.77]]
-]
+      VerificationTest[
+        MemberQ[
+          Cases[
+            RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], FrameStyle -> RGBColor[0.33, 0.66, 0.77]][[1]],
+            _ ? ColorQ,
+            All],
+          RGBColor[0.33, 0.66, 0.77]]
+      ],
 
-VerificationTest[
-  Not @ MemberQ[
-    Cases[
-      RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], FrameStyle -> RGBColor[0.33, 0.66, 0.77], Frame -> False][[1]],
-      _ ? ColorQ,
-      All],
-    RGBColor[0.33, 0.66, 0.77]]
-]
+      VerificationTest[
+        Not @ MemberQ[
+          Cases[
+            RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], FrameStyle -> RGBColor[0.33, 0.66, 0.77], Frame -> False][[1]],
+            _ ? ColorQ,
+            All],
+          RGBColor[0.33, 0.66, 0.77]]
+      ],
 
-(** PlotLegends **)
+      (** PlotLegends **)
 
-VerificationTest[
-  MatchQ[
-    RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], PlotLegends -> "Text"],
-    Legended[_, Placed[StandardForm[{{1, 2, 3}} -> {{3, 4, 5}}], Below]]]
-]
+      VerificationTest[
+        MatchQ[
+          RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], PlotLegends -> "Text"],
+          Legended[_, Placed[StandardForm[{{1, 2, 3}} -> {{3, 4, 5}}], Below]]]
+      ],
 
-VerificationTest[
-  MatchQ[RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], PlotLegends -> "test"], Legended[_, "test"]]
-]
+      VerificationTest[
+        MatchQ[RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], PlotLegends -> "test"], Legended[_, "test"]]
+      ],
 
-VerificationTest[
-  Not @ MatchQ[RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}]], Legended[___]]
-]
+      VerificationTest[
+        Not @ MatchQ[RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}]], Legended[___]]
+      ],
 
-(** Spacings **)
+      (** Spacings **)
 
-VerificationTest[
-  Not[Or @@ SameQ @@@ Subsets[
-    Rasterize[RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], Spacings -> #]] & /@
-      {0, 1, {{1, 0}, {0, 0}}, {{0, 1}, {0, 0}}, {{0, 0}, {1, 0}}, {{0, 0}, {0, 1}}},
-    {2}]]
-]
+      VerificationTest[
+        Not[Or @@ SameQ @@@ Subsets[
+          Rasterize[RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], Spacings -> #]] & /@
+            {0, 1, {{1, 0}, {0, 0}}, {{0, 1}, {0, 0}}, {{0, 0}, {1, 0}}, {{0, 0}, {0, 1}}},
+          {2}]]
+      ],
 
-VerificationTest[
-  And @@ SameQ @@
-    (Rasterize[RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], Spacings -> #]] & /@ {1, {{1, 1}, {1, 1}}})
-]
+      VerificationTest[
+        SameQ @@
+          (Rasterize[RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], Spacings -> #]] & /@ {1, {{1, 1}, {1, 1}}})
+      ],
 
-VerificationTest[
-  RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], Spacings -> #],
-  RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], Spacings -> #],
-  {RulePlot::invalidSpacings}
-] & /@ {
-  "Incorrect",
-  {1, 1},
-  {{1, 2}, 1},
-  {1, {1, 2}},
-  {{1, 2, 3}, {1, 2}},
-  {{1, {2, 3}}, {1, 2}}
-}
+      testUnevaluated[
+        RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], Spacings -> #],
+        {RulePlot::invalidSpacings}
+      ] & /@ {
+        "Incorrect",
+        {1, 1},
+        {{1, 2}, 1},
+        {1, {1, 2}},
+        {{1, 2, 3}, {1, 2}},
+        {{1, {2, 3}}, {1, 2}}
+      },
 
-(* Scaling consistency *)
+      (* Scaling consistency *)
 
-(** Vertex amplification **)
+      (** Vertex amplification **)
 
-VerificationTest[
-  First[Cases[RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}]], Disk[_, r_] :> r, All]] > 
-    First[Cases[HypergraphPlot[{{1, 2, 3}}], Disk[_, r_] :> r, All]]
-]
+      VerificationTest[
+        First[Cases[RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}]], Disk[_, r_] :> r, All]] > 
+          First[Cases[HypergraphPlot[{{1, 2, 3}}], Disk[_, r_] :> r, All]]
+      ],
 
-(** Consistent vertex sizes **)
+      (** Consistent vertex sizes **)
 
-$rules = {
-  {{1}} -> {{1}},
-  {{1}} -> {{2}},
-  {{1, 2}} -> {{1}},
-  {{1, 2}} -> {{1, 2}},
-  {{1, 2, 3}} -> {{1}},
-  {{1, 2, 3}} -> {{1, 2}},
-  {{1}, {2}} -> {{2}, {3}},
-  {{1}, {2}, {3}} -> {{2}, {3}, {4}},
-  {{1, 2, 3}} -> {{3, 4, 5}},
-  {{1, 2, 3}} -> {{1, 2}, {2, 3}},
-  {{1, 2, 3}} -> {{2, 3}, {3, 4}}};
+      VerificationTest[
+        SameQ @@ Cases[RulePlot[WolframModel[#]], Disk[_, r_] :> r, All]
+      ] & /@ $rulesForVertexSizeConsistency,
 
-VerificationTest[
-  And @@ (SameQ @@ Cases[RulePlot[WolframModel[#]], Disk[_, r_] :> r, All] & /@ $rules)
-]
+      (** Shared vertices are colored **)
 
-(** Shared vertices are colored **)
-
-VerificationTest[
-  Cases[RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}]], _ ? ColorQ, All],
-  Cases[RulePlot[WolframModel[{{1, 2, 3}} -> {{4, 5, 6}}]], _ ? ColorQ, All],
-  SameTest -> Not @* SameQ
-]
-
-EndTestSection[]
+      VerificationTest[
+        Cases[RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}]], _ ? ColorQ, All] =!=
+          Cases[RulePlot[WolframModel[{{1, 2, 3}} -> {{4, 5, 6}}]], _ ? ColorQ, All]
+      ]
+    }
+  |>
+|>

--- a/SetReplace/SetReplace.wlt
+++ b/SetReplace/SetReplace.wlt
@@ -1,229 +1,220 @@
-BeginTestSection["SetReplace"]
+<|
+	"SetReplace" -> <|
+		"init" -> (
+			Attributes[Global`testUnevaluated] = {HoldAll};
+      Global`testUnevaluated[args___] := SetReplace`PackageScope`testUnevaluated[VerificationTest, args];
+		),
+		"tests" -> {
+			(* Argument checks *)
 
-(* Argument checks *)
+			(** Argument count **)
 
-(** Argument count **)
+			testUnevaluated[
+				SetReplace[],
+				{SetReplace::argt}
+			],
 
-VerificationTest[
-	SetReplace[],
-	SetReplace[],
-	{SetReplace::argt}
-]
+			testUnevaluated[
+				SetReplace[Method -> "LowLevel"],
+				{SetReplace::argt}
+			],
 
-VerificationTest[
-	SetReplace[Method -> "LowLevel"],
-	SetReplace[Method -> "LowLevel"],
-	{SetReplace::argt}
-]
+			(** Set is a list **)
 
-(** Set is a list **)
+			testUnevaluated[
+				SetReplace[1, 1 -> 2],
+				{SetReplace::setNotList}
+			],
 
-VerificationTest[
-	SetReplace[1, 1 -> 2],
-	SetReplace[1, 1 -> 2],
-	{SetReplace::setNotList}
-]
+			testUnevaluated[
+				SetReplace[1, 1 -> 2, Method -> "LowLevel"],
+				{SetReplace::setNotList}
+			],
 
-VerificationTest[
-	SetReplace[1, 1 -> 2, Method -> "LowLevel"],
-	SetReplace[1, 1 -> 2, Method -> "LowLevel"],
-	{SetReplace::setNotList}
-]
+			(** Rules are valid **)
 
-(** Rules are valid **)
+			testUnevaluated[
+				SetReplace[{1}, 1],
+				{SetReplace::invalidRules}
+			],
 
-VerificationTest[
-	SetReplace[{1}, 1],
-	SetReplace[{1}, 1],
-	{SetReplace::invalidRules}
-]
+			testUnevaluated[
+				SetReplace[{1}, 1, Method -> "LowLevel"],
+				{SetReplace::invalidRules}
+			],
 
-VerificationTest[
-	SetReplace[{1}, 1, Method -> "LowLevel"],
-	SetReplace[{1}, 1, Method -> "LowLevel"],
-	{SetReplace::invalidRules}
-]
+			testUnevaluated[
+				SetReplace[{1}, {1}],
+				{SetReplace::invalidRules}
+			],
 
-VerificationTest[
-	SetReplace[{1}, {1}],
-	SetReplace[{1}, {1}],
-	{SetReplace::invalidRules}
-]
+			(** Step count is valid **)
 
-(** Step count is valid **)
+			testUnevaluated[
+				SetReplace[{1}, {1 -> 2}, -1],
+				{SetReplace::nonIntegerIterations}
+			],
 
-VerificationTest[
-	SetReplace[{1}, {1 -> 2}, -1],
-	SetReplace[{1}, {1 -> 2}, -1],
-	{SetReplace::nonIntegerIterations}
-]
+			testUnevaluated[
+				SetReplace[{1}, {1 -> 2}, -1, Method -> "LowLevel"],
+				{SetReplace::nonIntegerIterations}
+			],
 
-VerificationTest[
-	SetReplace[{1}, {1 -> 2}, -1, Method -> "LowLevel"],
-	SetReplace[{1}, {1 -> 2}, -1, Method -> "LowLevel"],
-	{SetReplace::nonIntegerIterations}
-]
+			testUnevaluated[
+				SetReplace[{1}, {1 -> 2}, 1.5],
+				{SetReplace::nonIntegerIterations}
+			],
 
-VerificationTest[
-	SetReplace[{1}, {1 -> 2}, 1.5],
-	SetReplace[{1}, {1 -> 2}, 1.5],
-	{SetReplace::nonIntegerIterations}
-]
+			(** Method is valid **)
 
-(** Method is valid **)
+			testUnevaluated[
+				SetReplace[{{0}}, {{0}} -> {{1}}, Method -> "$$$InvalidMethod###"],
+				{SetReplace::invalidMethod}
+			],
 
-VerificationTest[
-	SetReplace[{{0}}, {{0}} -> {{1}}, Method -> StringJoin[ToString /@ $SetReplaceMethods]],
-	SetReplace[{{0}}, {{0}} -> {{1}}, Method -> StringJoin[ToString /@ $SetReplaceMethods]],
-	{SetReplace::invalidMethod}
-]
+			(** TimeConstraint is valid **)
 
-(** TimeConstraint is valid **)
+			With[{rule = ToPatternRules[{{1, 2}} -> {{1, 3}, {3, 2}}]}, testUnevaluated[
+			  SetReplace[{{0, 0}}, rule, 100, TimeConstraint -> #],
+			  {SetReplace::timc}
+			] & /@ {0, -1, "x"}],
 
-VerificationTest[
-  SetReplace[{{0, 0}}, ToPatternRules[{{1, 2}} -> {{1, 3}, {3, 2}}], 100, TimeConstraint -> #],
-  SetReplace[{{0, 0}}, ToPatternRules[{{1, 2}} -> {{1, 3}, {3, 2}}], 100, TimeConstraint -> #],
-  {SetReplace::timc}
-] & /@ {0, -1, "x"}
+			(* Implementation *)
 
-(* Implementation *)
+			(** Simple examples **)
 
-(** Simple examples **)
+			VerificationTest[
+				SetReplace[{}, {} :> {}],
+				{}
+			],
 
-VerificationTest[
-	SetReplace[{}, {} :> {}],
-	{}
-]
+			VerificationTest[
+				SetReplace[{1, 2, 3}, 2 -> 5],
+				{1, 3, 5}
+			],
 
-VerificationTest[
-	SetReplace[{1, 2, 3}, 2 -> 5],
-	{1, 3, 5}
-]
+			VerificationTest[
+				SetReplace[{1, 2, 3}, 2 :> 5],
+				{1, 3, 5}
+			],
 
-VerificationTest[
-	SetReplace[{1, 2, 3}, 2 :> 5],
-	{1, 3, 5}
-]
+			VerificationTest[
+				SetReplace[{1, 2, 3}, {2 :> 5, 3 :> 6}, 2],
+				{1, 5, 6}
+			],
 
-VerificationTest[
-	SetReplace[{1, 2, 3}, {2 :> 5, 3 :> 6}, 2],
-	{1, 5, 6}
-]
+			VerificationTest[
+				SetReplace[{1, 2, 3}, {2 -> 5, 3 :> 6}, 2],
+				{1, 5, 6}
+			],
 
-VerificationTest[
-	SetReplace[{1, 2, 3}, {2 -> 5, 3 :> 6}, 2],
-	{1, 5, 6}
-]
+			VerificationTest[
+				SetReplace[{1, 2, 3}, {2 -> 5, 3 :> 6}, 10],
+				{1, 5, 6}
+			],
 
-VerificationTest[
-	SetReplace[{1, 2, 3}, {2 -> 5, 3 :> 6}, 10],
-	{1, 5, 6}
-]
+			VerificationTest[
+				SetReplace[{1, 2, 3}, {3, 2} -> 5],
+				{1, 5}
+			],
 
-VerificationTest[
-	SetReplace[{1, 2, 3}, {3, 2} -> 5],
-	{1, 5}
-]
+			VerificationTest[
+				SetReplace[{1, 2, 3}, 4 -> 5],
+				{1, 2, 3}
+			],
 
-VerificationTest[
-	SetReplace[{1, 2, 3}, 4 -> 5],
-	{1, 2, 3}
-]
+			VerificationTest[
+				SetReplace[{{1}}, {{1}} :> {}],
+				{}
+			],
 
-VerificationTest[
-	SetReplace[{{1}}, {{1}} :> {}],
-	{}
-]
+			VerificationTest[
+				SetReplace[{{1}}, {{1}} :> {}, Method -> "LowLevel"],
+				{}
+			],
 
-VerificationTest[
-	SetReplace[{{1}}, {{1}} :> {}, Method -> "LowLevel"],
-	{}
-]
+			VerificationTest[
+				SetReplace[{{1}}, {{1}} :> {}, Method -> "Symbolic"],
+				{}
+			],
 
-VerificationTest[
-	SetReplace[{{1}}, {{1}} :> {}, Method -> "Symbolic"],
-	{}
-]
+			VerificationTest[
+				SetReplace[{{1}}, {{1}} :> {}, Method -> Automatic],
+				{}
+			],
 
-VerificationTest[
-	SetReplace[{{1}}, {{1}} :> {}, Method -> Automatic],
-	{}
-]
+			VerificationTest[
+				SetReplace[{{1}, {2}}, {{1}, {2}} :> {{3}}],
+				{{3}}
+			],
 
-VerificationTest[
-	SetReplace[{{1}, {2}}, {{1}, {2}} :> {{3}}],
-	{{3}}
-]
+			VerificationTest[
+				SetReplace[{{2}, {1}}, {{1}, {2}} :> {{3}}],
+				{{3}}
+			],
 
-VerificationTest[
-	SetReplace[{{2}, {1}}, {{1}, {2}} :> {{3}}],
-	{{3}}
-]
+			VerificationTest[
+				Module[{extraEdge},
+			 		extraEdge =
+			 			SetReplace[{{0, 1}}, {{a_, b_}} :> Module[{$0}, {{a, $0}, {$0, b}}]];
+			 		SetReplace[extraEdge, {{a_, b_}, {b_, c_}} :> {{a, c}}]
+			 	],
+				{{0, 1}}
+			],
 
-VerificationTest[
-	Module[{extraEdge},
- 		extraEdge =
- 			SetReplace[{{0, 1}}, {{a_, b_}} :> Module[{$0}, {{a, $0}, {$0, b}}]];
- 		SetReplace[extraEdge, {{a_, b_}, {b_, c_}} :> {{a, c}}]
- 	],
-	{{0, 1}}
-]
+			VerificationTest[
+				SetReplace[{0}, 0 :> Module[{v}, v]],
+				{Unique[]},
+				SameTest -> (Dimensions[#1] == Dimensions[#2] &)
+			],
 
-VerificationTest[
-	SetReplace[{0}, 0 :> Module[{v}, v]],
-	{Unique[]},
-	SameTest -> (Dimensions[#1] == Dimensions[#2] &)
-]
+			VerificationTest[
+				SetReplace[{{2, 2}, 1}, ToPatternRules[{{{3, 3}, 1} -> {3, 1, 3}}]],
+				{2, 1, 2}
+			],
 
-VerificationTest[
-	SetReplace[{{2, 2}, 1}, ToPatternRules[{{{3, 3}, 1} -> {3, 1, 3}}]],
-	{2, 1, 2}
-]
+			VerificationTest[
+				SetReplace[{{{2, 2}, 1}}, ToPatternRules[{{{3, 3}, 1} -> {3, 1, 3}}]],
+				{{{2, 2}, 1}}
+			],
 
-VerificationTest[
-	SetReplace[{{{2, 2}, 1}}, ToPatternRules[{{{3, 3}, 1} -> {3, 1, 3}}]],
-	{{{2, 2}, 1}}
-]
+			(*** infinite number of steps is supported ***)
+			VerificationTest[
+				SetReplace[{{1, 2}, {2, 3}}, {{a_, b_}, {b_, c_}} :> {{a, c}}, Infinity, Method -> "LowLevel"],
+				{{1, 3}}
+			],
 
-(*** infinite number of steps is supported ***)
-VerificationTest[
-	SetReplace[{{1, 2}, {2, 3}}, {{a_, b_}, {b_, c_}} :> {{a, c}}, Infinity, Method -> "LowLevel"],
-	{{1, 3}}
-]
+			(** Examples not supported by LowLevel implementation **)
 
-(** Examples not supported by LowLevel implementation **)
+			(*** not a hypergraph ***)
+			testUnevaluated[
+				SetReplace[{1}, {1 -> 2}, Method -> "LowLevel"],
+				{SetReplace::lowLevelNotImplemented}
+			],
 
-(*** not a hypergraph ***)
-VerificationTest[
-	SetReplace[{1}, {1 -> 2}, Method -> "LowLevel"],
-	SetReplace[{1}, {1 -> 2}, Method -> "LowLevel"],
-	{SetReplace::lowLevelNotImplemented}
-]
+			(*** rule is not local ***)
+			testUnevaluated[
+				SetReplace[{{1, 2}, {3, 4}}, {{1, 2}, {3, 4}} -> {{1, 3}, {2, 4}}, Method -> "LowLevel"],
+				{SetReplace::lowLevelNotImplemented}
+			],
 
-(*** rule is not local ***)
-VerificationTest[
-	SetReplace[{{1, 2}, {3, 4}}, {{1, 2}, {3, 4}} -> {{1, 3}, {2, 4}}, Method -> "LowLevel"],
-	SetReplace[{{1, 2}, {3, 4}}, {{1, 2}, {3, 4}} -> {{1, 3}, {2, 4}}, Method -> "LowLevel"],
-	{SetReplace::lowLevelNotImplemented}
-]
+			(*** nothing -> something ***)
+			testUnevaluated[
+				SetReplace[{{1, 2}, {3, 4}}, {} -> {{1, 3}, {2, 4}}, Method -> "LowLevel"],
+				{SetReplace::lowLevelNotImplemented}
+			],
 
-(*** nothing -> something ***)
-VerificationTest[
-	SetReplace[{{1, 2}, {3, 4}}, {} -> {{1, 3}, {2, 4}}, Method -> "LowLevel"],
-	SetReplace[{{1, 2}, {3, 4}}, {} -> {{1, 3}, {2, 4}}, Method -> "LowLevel"],
-	{SetReplace::lowLevelNotImplemented}
-]
+			(* TimeConstraint *)
 
-(* TimeConstraint *)
+			VerificationTest[
+				SetReplace[{{0, 0}}, ToPatternRules[{{1, 2}} -> {{1, 3}, {3, 2}}], 100000, Method -> #, TimeConstraint -> 0.1],
+				$Aborted
+			] & /@ $SetReplaceMethods,
 
-VerificationTest[
-	SetReplace[{{0, 0}}, ToPatternRules[{{1, 2}} -> {{1, 3}, {3, 2}}], 100000, Method -> #, TimeConstraint -> 0.1],
-	$Aborted
-] & /@ $SetReplaceMethods
-
-VerificationTest[
-	TimeConstrained[SetReplace[{{0, 0}}, ToPatternRules[{{1, 2}} -> {{1, 3}, {3, 2}}], 100000, Method -> #], 0.1],
-	$Aborted
-] & /@ $SetReplaceMethods
-
-EndTestSection[]
+			VerificationTest[
+				TimeConstrained[SetReplace[{{0, 0}}, ToPatternRules[{{1, 2}} -> {{1, 3}, {3, 2}}], 100000, Method -> #], 0.1],
+				$Aborted
+			] & /@ $SetReplaceMethods
+		}
+	|>
+|>

--- a/SetReplace/SetReplaceAll.wlt
+++ b/SetReplace/SetReplaceAll.wlt
@@ -1,162 +1,161 @@
-BeginTestSection["SetReplaceAll"]
+<|
+  "SetReplaceAll" -> <|
+    "init" -> (
+      Attributes[Global`testUnevaluated] = {HoldAll};
+      Global`testUnevaluated[args___] := SetReplace`PackageScope`testUnevaluated[VerificationTest, args];
+    ),
+    "tests" -> {
+      (* Argument Checks *)
 
-(* Argument Checks *)
+      (** Argument count **)
 
-(** Argument count **)
+      testUnevaluated[
+        SetReplaceAll[],
+        {SetReplaceAll::argt}
+      ],
 
-VerificationTest[
-  SetReplaceAll[],
-  SetReplaceAll[],
-  {SetReplaceAll::argt}
-]
+      testUnevaluated[
+        SetReplaceAll[1, 2, 3, 4],
+        {SetReplaceAll::argt}
+      ],
 
-VerificationTest[
-  SetReplaceAll[1, 2, 3, 4],
-  SetReplaceAll[1, 2, 3, 4],
-  {SetReplaceAll::argt}
-]
+      (** Set is a list **)
 
-(** Set is a list **)
+      testUnevaluated[
+        SetReplaceAll[1, 1 -> 2],
+        {SetReplaceAll::setNotList}
+      ],
 
-VerificationTest[
-  SetReplaceAll[1, 1 -> 2],
-  SetReplaceAll[1, 1 -> 2],
-  {SetReplaceAll::setNotList}
-]
+      (** Rules are valid **)
 
-(** Rules are valid **)
+      testUnevaluated[
+        SetReplaceAll[{1}, 1],
+        {SetReplaceAll::invalidRules}
+      ],
 
-VerificationTest[
-  SetReplaceAll[{1}, 1],
-  SetReplaceAll[{1}, 1],
-  {SetReplaceAll::invalidRules}
-]
+      testUnevaluated[
+        SetReplaceAll[{1}, {1}],
+        {SetReplaceAll::invalidRules}
+      ],
 
-VerificationTest[
-  SetReplaceAll[{1}, {1}],
-  SetReplaceAll[{1}, {1}],
-  {SetReplaceAll::invalidRules}
-]
+      (** Step count is valid **)
 
-(** Step count is valid **)
+      testUnevaluated[
+        SetReplaceAll[{1}, {1 -> 2}, -1],
+        {SetReplaceAll::nonIntegerIterations}
+      ],
 
-VerificationTest[
-  SetReplaceAll[{1}, {1 -> 2}, -1],
-  SetReplaceAll[{1}, {1 -> 2}, -1],
-  {SetReplaceAll::nonIntegerIterations}
-]
+      testUnevaluated[
+        SetReplaceAll[{1}, {1 -> 2}, 1.5],
+        {SetReplaceAll::nonIntegerIterations}
+      ],
 
-VerificationTest[
-  SetReplaceAll[{1}, {1 -> 2}, 1.5],
-  SetReplaceAll[{1}, {1 -> 2}, 1.5],
-  {SetReplaceAll::nonIntegerIterations}
-]
+      (* Implementation *)
 
-(* Implementation *)
+      VerificationTest[ 
+        SetReplaceAll[{1, 2, 3}, n_ :> -n],
+        {-1, -2, -3}
+      ],
 
-VerificationTest[ 
-  SetReplaceAll[{1, 2, 3}, n_ :> -n],
-  {-1, -2, -3}
-]
+      VerificationTest[
+        SetReplaceAll[{1, 2, 3}, n_ :> -n, 2],
+        {1, 2, 3}
+      ],
 
-VerificationTest[
-  SetReplaceAll[{1, 2, 3}, n_ :> -n, 2],
-  {1, 2, 3}
-]
+      VerificationTest[
+        SetReplaceAll[{1, 2, 3}, {n_, m_} :> {-m, -n}],
+        {3, -2, -1}
+      ],
 
-VerificationTest[
-  SetReplaceAll[{1, 2, 3}, {n_, m_} :> {-m, -n}],
-  {3, -2, -1}
-]
+      VerificationTest[
+        SetReplaceAll[{1, 2, 3}, {n_, m_} :> {-m, -n}, 2],
+        {-1, 2, -3}
+      ],
 
-VerificationTest[
-  SetReplaceAll[{1, 2, 3}, {n_, m_} :> {-m, -n}, 2],
-  {-1, 2, -3}
-]
+      VerificationTest[
+        Most @ SetReplaceAll[
+            {1, 2, 3, 4}, {2 -> {3, 4}, {v1_, v2_} :> Module[{x}, {v1, v2, x}]}],
+        {4, 3, 4, 1, 3}
+      ],
 
-VerificationTest[
-  Most @ SetReplaceAll[
-      {1, 2, 3, 4}, {2 -> {3, 4}, {v1_, v2_} :> Module[{x}, {v1, v2, x}]}],
-  {4, 3, 4, 1, 3}
-]
+      VerificationTest[
+        MatchQ[SetReplaceAll[
+            {1, 2, 3, 4},
+            {2 -> {3, 4}, {v1_, v2_} :> Module[{x}, {v1, v2, x}]},
+            2], {4, 3, _, 4, 1, _, 3, _, _}],
+        True
+      ],
 
-VerificationTest[
-  MatchQ[SetReplaceAll[
-      {1, 2, 3, 4},
-      {2 -> {3, 4}, {v1_, v2_} :> Module[{x}, {v1, v2, x}]},
-      2], {4, 3, _, 4, 1, _, 3, _, _}],
-  True
-]
+      VerificationTest[
+        Length @ SetReplaceAll[
+          {{0, 1}, {0, 2}, {0, 3}}, 
+          ToPatternRules[
+            {{0, 1}, {0, 2}, {0, 3}} ->
+            {{4, 5}, {5, 4}, {4, 6}, {6, 4}, {5, 6}, {6, 5}, {4, 1}, {5, 2}, {6, 3}}],
+          4],
+        3^5
+      ],
 
-VerificationTest[
-  Length @ SetReplaceAll[
-    {{0, 1}, {0, 2}, {0, 3}}, 
-    ToPatternRules[
-      {{0, 1}, {0, 2}, {0, 3}} ->
-      {{4, 5}, {5, 4}, {4, 6}, {6, 4}, {5, 6}, {6, 5}, {4, 1}, {5, 2}, {6, 3}}],
-    4],
-  3^5
-]
+      VerificationTest[
+        Length @ SetReplaceAll[
+          {{0, 0}, {0, 0}, {0, 0}}, 
+          ToPatternRules[
+            {{0, 1}, {0, 2}, {0, 3}} ->
+            {{4, 5}, {5, 4}, {4, 6}, {6, 4}, {5, 6}, {6, 5}, {4, 1}, {5, 2}, {6, 3}}],
+          4],
+        3^5
+      ],
 
-VerificationTest[
-  Length @ SetReplaceAll[
-    {{0, 0}, {0, 0}, {0, 0}}, 
-    ToPatternRules[
-      {{0, 1}, {0, 2}, {0, 3}} ->
-      {{4, 5}, {5, 4}, {4, 6}, {6, 4}, {5, 6}, {6, 5}, {4, 1}, {5, 2}, {6, 3}}],
-    4],
-  3^5
-]
+      VerificationTest[
+        Length @ SetReplaceAll[
+          {{0, 1}, {0, 2}, {0, 3}}, 
+          ToPatternRules[
+            {{0, 1}, {0, 2}, {0, 3}} ->
+            {{4, 5}, {5, 4}, {4, 6}, {6, 4}, {5, 6}, {6, 5},
+             {4, 1}, {5, 2}, {6, 3}, {1, 6}, {3, 4}}],
+          3],
+        107
+      ],
 
-VerificationTest[
-  Length @ SetReplaceAll[
-    {{0, 1}, {0, 2}, {0, 3}}, 
-    ToPatternRules[
-      {{0, 1}, {0, 2}, {0, 3}} ->
-      {{4, 5}, {5, 4}, {4, 6}, {6, 4}, {5, 6}, {6, 5},
-       {4, 1}, {5, 2}, {6, 3}, {1, 6}, {3, 4}}],
-    3],
-  107
-]
+      VerificationTest[
+        Length @ SetReplaceAll[
+          {{0, 1}, {0, 2}, {0, 3}},
+          ToPatternRules[
+            {{0, 1}, {0, 2}, {0, 3}} ->
+            {{4, 5}, {5, 4}, {4, 6}, {6, 4}, {5, 6}, {6, 5},
+             {4, 1}, {5, 2}, {6, 3}, {1, 6}, {3, 4}}],
+          3,
+          Method -> "LowLevel"],
+        Length @ SetReplaceAll[
+          {{0, 1}, {0, 2}, {0, 3}},
+          ToPatternRules[
+            {{0, 1}, {0, 2}, {0, 3}} ->
+            {{4, 5}, {5, 4}, {4, 6}, {6, 4}, {5, 6}, {6, 5},
+             {4, 1}, {5, 2}, {6, 3}, {1, 6}, {3, 4}}],
+          3,
+          Method -> "Symbolic"]
+      ],
 
-VerificationTest[
-  Length @ SetReplaceAll[
-    {{0, 1}, {0, 2}, {0, 3}},
-    ToPatternRules[
-      {{0, 1}, {0, 2}, {0, 3}} ->
-      {{4, 5}, {5, 4}, {4, 6}, {6, 4}, {5, 6}, {6, 5},
-       {4, 1}, {5, 2}, {6, 3}, {1, 6}, {3, 4}}],
-    3,
-    Method -> "LowLevel"],
-  Length @ SetReplaceAll[
-    {{0, 1}, {0, 2}, {0, 3}},
-    ToPatternRules[
-      {{0, 1}, {0, 2}, {0, 3}} ->
-      {{4, 5}, {5, 4}, {4, 6}, {6, 4}, {5, 6}, {6, 5},
-       {4, 1}, {5, 2}, {6, 3}, {1, 6}, {3, 4}}],
-    3,
-    Method -> "Symbolic"]
-]
+      VerificationTest[
+        SetReplaceAll[
+          {{0, 1}, {1, 2}, {2, 3}, {3, 4}},
+          {{a_, b_}, {b_, c_}} :> {{a, c}},
+          2,
+          Method -> "LowLevel"],
+        {{0, 4}}
+      ],
 
-VerificationTest[
-  SetReplaceAll[
-    {{0, 1}, {1, 2}, {2, 3}, {3, 4}},
-    {{a_, b_}, {b_, c_}} :> {{a, c}},
-    2,
-    Method -> "LowLevel"],
-  {{0, 4}}
-]
+      (* TimeConstraint *)
 
-(* TimeConstraint *)
+      VerificationTest[
+        SetReplaceAll[{{0, 0}}, ToPatternRules[{{1, 2}} -> {{1, 3}, {3, 2}}], 100, Method -> #, TimeConstraint -> 0.1],
+        $Aborted
+      ] & /@ $SetReplaceMethods,
 
-VerificationTest[
-  SetReplaceAll[{{0, 0}}, ToPatternRules[{{1, 2}} -> {{1, 3}, {3, 2}}], 100, Method -> #, TimeConstraint -> 0.1],
-  $Aborted
-] & /@ $SetReplaceMethods
-
-VerificationTest[
-  TimeConstrained[SetReplaceAll[{{0, 0}}, ToPatternRules[{{1, 2}} -> {{1, 3}, {3, 2}}], 100, Method -> #], 0.1],
-  $Aborted
-] & /@ $SetReplaceMethods
-
-EndTestSection[]
+      VerificationTest[
+        TimeConstrained[SetReplaceAll[{{0, 0}}, ToPatternRules[{{1, 2}} -> {{1, 3}, {3, 2}}], 100, Method -> #], 0.1],
+        $Aborted
+      ] & /@ $SetReplaceMethods
+    }
+  |>
+|>

--- a/SetReplace/SetReplaceFixedPoint.wlt
+++ b/SetReplace/SetReplaceFixedPoint.wlt
@@ -1,84 +1,86 @@
-BeginTestSection["SetReplaceFixedPoint"]
+<|
+  "SetReplaceFixedPoint" -> <|
+    "init" -> (
+      Attributes[Global`testUnevaluated] = {HoldAll};
+      Global`testUnevaluated[args___] := SetReplace`PackageScope`testUnevaluated[VerificationTest, args];
+    ),
+    "tests" -> {
+      (* Argument Checks *)
 
-(* Argument Checks *)
+      (** Argument count **)
 
-(** Argument count **)
+      testUnevaluated[
+        SetReplaceFixedPoint[{1}],
+        {SetReplaceFixedPoint::argr}
+      ],
 
-VerificationTest[
-  SetReplaceFixedPoint[{1}],
-  SetReplaceFixedPoint[{1}],
-  {SetReplaceFixedPoint::argr}
-]
+      testUnevaluated[
+        SetReplaceFixedPoint[{1}, {1 -> 2}, 3],
+        {SetReplaceFixedPoint::argrx}
+      ],
 
-VerificationTest[
-  SetReplaceFixedPoint[{1}, {1 -> 2}, 3],
-  SetReplaceFixedPoint[{1}, {1 -> 2}, 3],
-  {SetReplaceFixedPoint::argrx}
-]
+      (** Set is a list **)
 
-(** Set is a list **)
+      testUnevaluated[
+        SetReplaceFixedPoint[1, 1 -> 2],
+        {SetReplaceFixedPoint::setNotList}
+      ],
 
-VerificationTest[
-  SetReplaceFixedPoint[1, 1 -> 2],
-  SetReplaceFixedPoint[1, 1 -> 2],
-  {SetReplaceFixedPoint::setNotList}
-]
+      (** Rules are valid **)
 
-(** Rules are valid **)
+      testUnevaluated[
+        SetReplaceFixedPoint[{1}, {1}],
+        {SetReplaceFixedPoint::invalidRules}
+      ],
 
-VerificationTest[
-  SetReplaceFixedPoint[{1}, {1}],
-  SetReplaceFixedPoint[{1}, {1}],
-  {SetReplaceFixedPoint::invalidRules}
-]
+      (* Implementation *)
 
-(* Implementation *)
+      VerificationTest[
+        SetReplaceFixedPoint[{1, 1, 1}, {1 -> 2}],
+        {2, 2, 2}
+      ],
 
-VerificationTest[
-  SetReplaceFixedPoint[{1, 1, 1}, {1 -> 2}],
-  {2, 2, 2}
-]
+      VerificationTest[
+        SetReplaceFixedPoint[{{1, 2}, {2, 3}, {3, 4}}, {{a_, b_}, {b_, c_}} :> {{a, c}}],
+        {{1, 4}}
+      ],
 
-VerificationTest[
-  SetReplaceFixedPoint[{{1, 2}, {2, 3}, {3, 4}}, {{a_, b_}, {b_, c_}} :> {{a, c}}],
-  {{1, 4}}
-]
+      VerificationTest[
+        SetReplaceFixedPoint[{{1, 2}, {2, 3}, {3, 1}}, {{a_, b_}, {b_, c_}} :> {{a, c}}, Method -> "Symbolic"],
+        {{3, 3}}
+      ],
 
-VerificationTest[
-  SetReplaceFixedPoint[{{1, 2}, {2, 3}, {3, 1}}, {{a_, b_}, {b_, c_}} :> {{a, c}}, Method -> "Symbolic"],
-  {{3, 3}}
-]
+      VerificationTest[
+        SetReplaceFixedPoint[{{1, 2}, {2, 3}, {3, 1}}, {{a_, b_}, {b_, c_}} :> {{a, c}}, Method -> "LowLevel"],
+        {{3, 3}}
+      ],
 
-VerificationTest[
-  SetReplaceFixedPoint[{{1, 2}, {2, 3}, {3, 1}}, {{a_, b_}, {b_, c_}} :> {{a, c}}, Method -> "LowLevel"],
-  {{3, 3}}
-]
+      VerificationTest[
+        SetReplaceFixedPoint[{{1, 2}, {2, 3}, {3, 4}}, {{a_, b_}} :> {}],
+        {}
+      ],
 
-VerificationTest[
-  SetReplaceFixedPoint[{{1, 2}, {2, 3}, {3, 4}}, {{a_, b_}} :> {}],
-  {}
-]
+      VerificationTest[
+        TimeConstrained[SetReplaceFixedPoint[{}, {} :> {{1, 2}}], 1],
+        $Aborted
+      ],
 
-VerificationTest[
-  TimeConstrained[SetReplaceFixedPoint[{}, {} :> {{1, 2}}], 1],
-  $Aborted
-]
+      VerificationTest[
+        TimeConstrained[SetReplaceFixedPoint[{{1, 2}}, {{1, 2}} :> {{1, 2}}], 1],
+        $Aborted
+      ],
 
-VerificationTest[
-  TimeConstrained[SetReplaceFixedPoint[{{1, 2}}, {{1, 2}} :> {{1, 2}}], 1],
-  $Aborted
-]
+      (* TimeConstraint *)
 
-(* TimeConstraint *)
+      VerificationTest[
+        SetReplaceFixedPoint[{{0, 0}}, ToPatternRules[{{1, 2}} -> {{1, 3}, {3, 2}}], Method -> #, TimeConstraint -> 0.1],
+        $Aborted
+      ] & /@ $SetReplaceMethods,
 
-VerificationTest[
-  SetReplaceFixedPoint[{{0, 0}}, ToPatternRules[{{1, 2}} -> {{1, 3}, {3, 2}}], Method -> #, TimeConstraint -> 0.1],
-  $Aborted
-] & /@ $SetReplaceMethods
-
-VerificationTest[
-  TimeConstrained[SetReplaceFixedPoint[{{0, 0}}, ToPatternRules[{{1, 2}} -> {{1, 3}, {3, 2}}], Method -> #], 0.1],
-  $Aborted
-] & /@ $SetReplaceMethods
-
-EndTestSection[]
+      VerificationTest[
+        TimeConstrained[SetReplaceFixedPoint[{{0, 0}}, ToPatternRules[{{1, 2}} -> {{1, 3}, {3, 2}}], Method -> #], 0.1],
+        $Aborted
+      ] & /@ $SetReplaceMethods
+    }
+  |>
+|>

--- a/SetReplace/SetReplaceFixedPointList.wlt
+++ b/SetReplace/SetReplaceFixedPointList.wlt
@@ -1,84 +1,86 @@
-BeginTestSection["SetReplaceFixedPointList"]
+<|
+  "SetReplaceFixedPointList" -> <|
+    "init" -> (
+      Attributes[Global`testUnevaluated] = {HoldAll};
+      Global`testUnevaluated[args___] := SetReplace`PackageScope`testUnevaluated[VerificationTest, args];
+    ),
+    "tests" -> {
+      (* Argument Checks *)
 
-(* Argument Checks *)
+      (** Argument count **)
 
-(** Argument count **)
+      testUnevaluated[
+        SetReplaceFixedPointList[{1}],
+        {SetReplaceFixedPointList::argr}
+      ],
 
-VerificationTest[
-  SetReplaceFixedPointList[{1}],
-  SetReplaceFixedPointList[{1}],
-  {SetReplaceFixedPointList::argr}
-]
+      testUnevaluated[
+        SetReplaceFixedPointList[{1}, {1 -> 2}, 3],
+        {SetReplaceFixedPointList::argrx}
+      ],
 
-VerificationTest[
-  SetReplaceFixedPointList[{1}, {1 -> 2}, 3],
-  SetReplaceFixedPointList[{1}, {1 -> 2}, 3],
-  {SetReplaceFixedPointList::argrx}
-]
+      (** Set is a list **)
 
-(** Set is a list **)
+      testUnevaluated[
+        SetReplaceFixedPointList[1, 1 -> 2],
+        {SetReplaceFixedPointList::setNotList}
+      ],
 
-VerificationTest[
-  SetReplaceFixedPointList[1, 1 -> 2],
-  SetReplaceFixedPointList[1, 1 -> 2],
-  {SetReplaceFixedPointList::setNotList}
-]
+      (** Rules are valid **)
 
-(** Rules are valid **)
+      testUnevaluated[
+        SetReplaceFixedPointList[{1}, {1}],
+        {SetReplaceFixedPointList::invalidRules}
+      ],
 
-VerificationTest[
-  SetReplaceFixedPointList[{1}, {1}],
-  SetReplaceFixedPointList[{1}, {1}],
-  {SetReplaceFixedPointList::invalidRules}
-]
+      (* Implementation *)
 
-(* Implementation *)
+      VerificationTest[
+        SetReplaceFixedPointList[{1, 1, 1}, {1 -> 2}],
+        {{1, 1, 1}, {1, 1, 2}, {1, 2, 2}, {2, 2, 2}}
+      ],
 
-VerificationTest[
-  SetReplaceFixedPointList[{1, 1, 1}, {1 -> 2}],
-  {{1, 1, 1}, {1, 1, 2}, {1, 2, 2}, {2, 2, 2}}
-]
+      VerificationTest[
+        SetReplaceFixedPointList[{{1, 2}, {2, 3}, {3, 4}}, {{a_, b_}, {b_, c_}} :> {{a, c}}],
+        {{{1, 2}, {2, 3}, {3, 4}}, {{3, 4}, {1, 3}}, {{1, 4}}}
+      ],
 
-VerificationTest[
-  SetReplaceFixedPointList[{{1, 2}, {2, 3}, {3, 4}}, {{a_, b_}, {b_, c_}} :> {{a, c}}],
-  {{{1, 2}, {2, 3}, {3, 4}}, {{3, 4}, {1, 3}}, {{1, 4}}}
-]
+      VerificationTest[
+        SetReplaceFixedPointList[{{1, 2}, {2, 3}, {3, 1}}, {{a_, b_}, {b_, c_}} :> {{a, c}}, Method -> "LowLevel"],
+        {{{1, 2}, {2, 3}, {3, 1}}, {{3, 1}, {1, 3}}, {{3, 3}}}
+      ],
 
-VerificationTest[
-  SetReplaceFixedPointList[{{1, 2}, {2, 3}, {3, 1}}, {{a_, b_}, {b_, c_}} :> {{a, c}}, Method -> "LowLevel"],
-  {{{1, 2}, {2, 3}, {3, 1}}, {{3, 1}, {1, 3}}, {{3, 3}}}
-]
+      VerificationTest[
+        SetReplaceFixedPointList[{{1, 2}, {2, 3}, {3, 1}}, {{a_, b_}, {b_, c_}} :> {{a, c}}, Method -> "Symbolic"],
+        {{{1, 2}, {2, 3}, {3, 1}}, {{3, 1}, {1, 3}}, {{3, 3}}}
+      ],
 
-VerificationTest[
-  SetReplaceFixedPointList[{{1, 2}, {2, 3}, {3, 1}}, {{a_, b_}, {b_, c_}} :> {{a, c}}, Method -> "Symbolic"],
-  {{{1, 2}, {2, 3}, {3, 1}}, {{3, 1}, {1, 3}}, {{3, 3}}}
-]
+      VerificationTest[
+        SetReplaceFixedPointList[{{1, 2}, {2, 3}, {3, 4}}, {{a_, b_}} :> {}],
+        {{{1, 2}, {2, 3}, {3, 4}}, {{2, 3}, {3, 4}}, {{3, 4}}, {}}
+      ],
 
-VerificationTest[
-  SetReplaceFixedPointList[{{1, 2}, {2, 3}, {3, 4}}, {{a_, b_}} :> {}],
-  {{{1, 2}, {2, 3}, {3, 4}}, {{2, 3}, {3, 4}}, {{3, 4}}, {}}
-]
+      VerificationTest[
+        TimeConstrained[SetReplaceFixedPointList[{}, {} :> {{1, 2}}], 1],
+        $Aborted
+      ],
 
-VerificationTest[
-  TimeConstrained[SetReplaceFixedPointList[{}, {} :> {{1, 2}}], 1],
-  $Aborted
-]
+      VerificationTest[
+        TimeConstrained[SetReplaceFixedPointList[{{1, 2}}, {{1, 2}} :> {{1, 2}}], 1],
+        $Aborted
+      ],
 
-VerificationTest[
-  TimeConstrained[SetReplaceFixedPointList[{{1, 2}}, {{1, 2}} :> {{1, 2}}], 1],
-  $Aborted
-]
+      (* TimeConstraint *)
 
-(* TimeConstraint *)
+      VerificationTest[
+        SetReplaceFixedPointList[{{0, 0}}, ToPatternRules[{{1, 2}} -> {{1, 3}, {3, 2}}], Method -> #, TimeConstraint -> 0.1],
+        $Aborted
+      ] & /@ $SetReplaceMethods,
 
-VerificationTest[
-  SetReplaceFixedPointList[{{0, 0}}, ToPatternRules[{{1, 2}} -> {{1, 3}, {3, 2}}], Method -> #, TimeConstraint -> 0.1],
-  $Aborted
-] & /@ $SetReplaceMethods
-
-VerificationTest[
-  TimeConstrained[SetReplaceFixedPointList[{{0, 0}}, ToPatternRules[{{1, 2}} -> {{1, 3}, {3, 2}}], Method -> #], 0.1],
-  $Aborted
-] & /@ $SetReplaceMethods
-
-EndTestSection[]
+      VerificationTest[
+        TimeConstrained[SetReplaceFixedPointList[{{0, 0}}, ToPatternRules[{{1, 2}} -> {{1, 3}, {3, 2}}], Method -> #], 0.1],
+        $Aborted
+      ] & /@ $SetReplaceMethods
+    }
+  |>
+|>

--- a/SetReplace/SetReplaceList.wlt
+++ b/SetReplace/SetReplaceList.wlt
@@ -1,97 +1,98 @@
-BeginTestSection["SetReplaceList"]
+<|
+  "SetReplaceList" -> <|
+    "init" -> (
+      Attributes[Global`testUnevaluated] = {HoldAll};
+      Global`testUnevaluated[args___] := SetReplace`PackageScope`testUnevaluated[VerificationTest, args];
+    ),
+    "tests" -> {
+      (* Argument Checks *)
 
-(* Argument Checks *)
+      (** Argument count **)
 
-(** Argument count **)
+      testUnevaluated[
+        SetReplaceList[{1}],
+        {SetReplaceList::argr}
+      ],
 
-VerificationTest[
-  SetReplaceList[{1}],
-  SetReplaceList[{1}],
-  {SetReplaceList::argr}
-]
+      testUnevaluated[
+        SetReplaceList[{1}, {2 -> 5, 3 :> 6}, 10, 10],
+        {SetReplaceList::argrx}
+      ],
 
-VerificationTest[
-  SetReplaceList[{1}, {2 -> 5, 3 :> 6}, 10, 10],
-  SetReplaceList[{1}, {2 -> 5, 3 :> 6}, 10, 10],
-  {SetReplaceList::argrx}
-]
+      (** Set is a list **)
 
-(** Set is a list **)
+      testUnevaluated[
+        SetReplaceList[1, 1 -> 2, 2],
+        {SetReplaceList::setNotList}
+      ],
 
-VerificationTest[
-  SetReplaceList[1, 1 -> 2, 2],
-  SetReplaceList[1, 1 -> 2, 2],
-  {SetReplaceList::setNotList}
-]
+      (** Rules are valid **)
 
-(** Rules are valid **)
+      testUnevaluated[
+        SetReplaceList[{1}, {1}, 1],
+        {SetReplaceList::invalidRules}
+      ],
 
-VerificationTest[
-  SetReplaceList[{1}, {1}, 1],
-  SetReplaceList[{1}, {1}, 1],
-  {SetReplaceList::invalidRules}
-]
+      (** Step count is valid **)
 
-(** Step count is valid **)
+      testUnevaluated[
+        SetReplaceList[{1}, {1 -> 2}, -1],
+        {SetReplaceList::nonIntegerIterations}
+      ],
 
-VerificationTest[
-  SetReplaceList[{1}, {1 -> 2}, -1],
-  SetReplaceList[{1}, {1 -> 2}, -1],
-  {SetReplaceList::nonIntegerIterations}
-]
+      (* Implementation *)
 
-(* Implementation *)
+      VerificationTest[
+        SetReplaceList[{1, 2, 3}, {2 -> 5, 3 :> 6, 5 :> 9}, 10],
+        {{1, 2, 3}, {1, 3, 5}, {1, 5, 6}, {1, 6, 9}}
+      ],
 
-VerificationTest[
-  SetReplaceList[{1, 2, 3}, {2 -> 5, 3 :> 6, 5 :> 9}, 10],
-  {{1, 2, 3}, {1, 3, 5}, {1, 5, 6}, {1, 6, 9}}
-]
+      VerificationTest[
+        SetReplaceList[{1, 2, 3}, {2 -> 5, 3 :> 6, 5 :> 9}, Infinity],
+        {{1, 2, 3}, {1, 3, 5}, {1, 5, 6}, {1, 6, 9}}
+      ],
 
-VerificationTest[
-  SetReplaceList[{1, 2, 3}, {2 -> 5, 3 :> 6, 5 :> 9}, Infinity],
-  {{1, 2, 3}, {1, 3, 5}, {1, 5, 6}, {1, 6, 9}}
-]
+      VerificationTest[
+        SetReplaceList[{1, 2, 3}, {2 -> 5, 3 :> 6, 5 :> 9}, 1],
+        {{1, 2, 3}, {1, 3, 5}}
+      ],
 
-VerificationTest[
-  SetReplaceList[{1, 2, 3}, {2 -> 5, 3 :> 6, 5 :> 9}, 1],
-  {{1, 2, 3}, {1, 3, 5}}
-]
+      VerificationTest[
+        SetReplaceList[{{1}, {2}, {3}}, {{{2}} -> {{5}}, {{3}} :> {{6}}, {{5}} :> {{9}}}, 2, Method -> "LowLevel"],
+        {{{1}, {2}, {3}}, {{1}, {3}, {5}}, {{1}, {5}, {6}}}
+      ],
 
-VerificationTest[
-  SetReplaceList[{{1}, {2}, {3}}, {{{2}} -> {{5}}, {{3}} :> {{6}}, {{5}} :> {{9}}}, 2, Method -> "LowLevel"],
-  {{{1}, {2}, {3}}, {{1}, {3}, {5}}, {{1}, {5}, {6}}}
-]
+      VerificationTest[
+        SetReplaceList[{{1}, {2}, {3}}, {{{2}} -> {{5}}, {{3}} :> {{6}}, {{5}} :> {{9}}}, 2, Method -> "Symbolic"],
+        {{{1}, {2}, {3}}, {{1}, {3}, {5}}, {{1}, {5}, {6}}}
+      ],
 
-VerificationTest[
-  SetReplaceList[{{1}, {2}, {3}}, {{{2}} -> {{5}}, {{3}} :> {{6}}, {{5}} :> {{9}}}, 2, Method -> "Symbolic"],
-  {{{1}, {2}, {3}}, {{1}, {3}, {5}}, {{1}, {5}, {6}}}
-]
+      VerificationTest[
+        SetReplaceList[{{1, 2}, {2, 3}, {3, 1}}, {{a_, b_}, {b_, c_}} :> {{a, c}}, 2],
+        {{{1, 2}, {2, 3}, {3, 1}}, {{3, 1}, {1, 3}}, {{3, 3}}}
+      ],
 
-VerificationTest[
-  SetReplaceList[{{1, 2}, {2, 3}, {3, 1}}, {{a_, b_}, {b_, c_}} :> {{a, c}}, 2],
-  {{{1, 2}, {2, 3}, {3, 1}}, {{3, 1}, {1, 3}}, {{3, 3}}}
-]
+      VerificationTest[
+        SetReplaceList[{}, {} :> {{1, 2}}, 2],
+        {{}, {{1, 2}}, {{1, 2}, {1, 2}}}
+      ],
 
-VerificationTest[
-  SetReplaceList[{}, {} :> {{1, 2}}, 2],
-  {{}, {{1, 2}}, {{1, 2}, {1, 2}}}
-]
+      VerificationTest[
+        SetReplaceList[{{1, 2}}, {{1, 2}} :> {{1, 2}}, 2],
+        {{{1, 2}}, {{1, 2}}, {{1, 2}}}
+      ],
 
-VerificationTest[
-  SetReplaceList[{{1, 2}}, {{1, 2}} :> {{1, 2}}, 2],
-  {{{1, 2}}, {{1, 2}}, {{1, 2}}}
-]
+      (* TimeConstraint *)
 
-(* TimeConstraint *)
+      VerificationTest[
+        SetReplaceList[{{0, 0}}, ToPatternRules[{{1, 2}} -> {{1, 3}, {3, 2}}], 100000, Method -> #, TimeConstraint -> 0.1],
+        $Aborted
+      ] & /@ $SetReplaceMethods,
 
-VerificationTest[
-  SetReplaceList[{{0, 0}}, ToPatternRules[{{1, 2}} -> {{1, 3}, {3, 2}}], 100000, Method -> #, TimeConstraint -> 0.1],
-  $Aborted
-] & /@ $SetReplaceMethods
-
-VerificationTest[
-  TimeConstrained[SetReplaceList[{{0, 0}}, ToPatternRules[{{1, 2}} -> {{1, 3}, {3, 2}}], 100000, Method -> #], 0.1],
-  $Aborted
-] & /@ $SetReplaceMethods
-
-EndTestSection[]
+      VerificationTest[
+        TimeConstrained[SetReplaceList[{{0, 0}}, ToPatternRules[{{1, 2}} -> {{1, 3}, {3, 2}}], 100000, Method -> #], 0.1],
+        $Aborted
+      ] & /@ $SetReplaceMethods
+    }
+  |>
+|>

--- a/SetReplace/ToPatternRules.wlt
+++ b/SetReplace/ToPatternRules.wlt
@@ -1,124 +1,121 @@
-BeginTestSection["ToPatternRules"]
+<|
+  "ToPatternRules" -> <|
+    "init" -> (
+      Attributes[Global`testUnevaluated] = {HoldAll};
+      Global`testUnevaluated[args___] := SetReplace`PackageScope`testUnevaluated[VerificationTest, args];
+    ),
+    "tests" -> {
+      (* Argument Checks *)
 
-(* Argument Checks *)
+      (** Argument count **)
 
-(** Argument count **)
+      testUnevaluated[
+        ToPatternRules[],
+        {ToPatternRules::argx}
+      ],
 
-VerificationTest[
-  ToPatternRules[],
-  ToPatternRules[],
-  {ToPatternRules::argx}
-]
+      testUnevaluated[
+        ToPatternRules[1, 2],
+        {ToPatternRules::argx}
+      ],
 
-VerificationTest[
-  ToPatternRules[1, 2],
-  ToPatternRules[1, 2],
-  {ToPatternRules::argx}
-]
+      (** Argument is a list of rules or a single rule **)
 
-(** Argument is a list of rules or a single rule **)
+      testUnevaluated[
+        ToPatternRules[1],
+        {ToPatternRules::notRules}
+      ],
 
-VerificationTest[
-  ToPatternRules[1],
-  ToPatternRules[1],
-  {ToPatternRules::notRules}
-]
+      (* Implementation *)
 
-(* Implementation *)
+      (** Simple examples **)
 
-(** Simple examples **)
+      VerificationTest[
+        SetReplace[{1}, ToPatternRules[4 -> 5]] =!= {1}
+      ],
 
-VerificationTest[
-  SetReplace[{1}, ToPatternRules[4 -> 5]],
-  {1},
-  SameTest -> Not @* SameQ
-]
+      VerificationTest[
+        SetReplace[{1}, ToPatternRules[4 -> {5, 5}]] =!= {1}
+      ],
 
-VerificationTest[
-  SetReplace[{1}, ToPatternRules[4 -> {5, 5}]],
-  {1},
-  SameTest -> Not @* SameQ
-]
+      VerificationTest[
+        SetReplace[{1}, ToPatternRules[{4} -> 9]] =!= {9}
+      ],
 
-VerificationTest[
-  SetReplace[{1}, ToPatternRules[{4} -> 9]],
-  {9},
-  SameTest -> Not @* SameQ
-]
+      VerificationTest[
+        ToPatternRules[{{} -> {}}],
+        {{} :> {}}
+      ],
 
-VerificationTest[
-  ToPatternRules[{{} -> {}}],
-  {{} :> {}}
-]
+      VerificationTest[
+        SetReplace[{{1, 2}, {2, 3}}, ToPatternRules[{{} -> {}}], 3],
+        {{1, 2}, {2, 3}}
+      ],
 
-VerificationTest[
-  SetReplace[{{1, 2}, {2, 3}}, ToPatternRules[{{} -> {}}], 3],
-  {{1, 2}, {2, 3}}
-]
+      VerificationTest[
+        SetReplace[{{"v1", "v2"}}, ToPatternRules[{{1, 2}} -> {{1}}]],
+        {{"v1"}}
+      ],
 
-VerificationTest[
-  SetReplace[{{"v1", "v2"}}, ToPatternRules[{{1, 2}} -> {{1}}]],
-  {{"v1"}}
-]
+      VerificationTest[
+        SetReplace[
+          {{"v1", "v2"}, {"v2", "v3"}},
+          ToPatternRules[{{1, 2}, {2, 3}} -> {{1, 3}}]],
+        {{"v1", "v3"}}
+      ],
 
-VerificationTest[
-  SetReplace[
-    {{"v1", "v2"}, {"v2", "v3"}},
-    ToPatternRules[{{1, 2}, {2, 3}} -> {{1, 3}}]],
-  {{"v1", "v3"}}
-]
+      (** Multiple rules **)
 
-(** Multiple rules **)
+      VerificationTest[
+        SetReplace[
+          {{"v1", "v2"}, {"v2", "v3"}},
+          ToPatternRules[{
+            {{1, 2}, {2, 3}} -> {{1, 3}},
+            {{1, 2}} -> {{1, 1, 2, 2}}}], 2],
+        {{"v1", "v1", "v2", "v2"}, {"v2", "v2", "v3", "v3"}}
+      ],
 
-VerificationTest[
-  SetReplace[
-    {{"v1", "v2"}, {"v2", "v3"}},
-    ToPatternRules[{
-      {{1, 2}, {2, 3}} -> {{1, 3}},
-      {{1, 2}} -> {{1, 1, 2, 2}}}], 2],
-  {{"v1", "v1", "v2", "v2"}, {"v2", "v2", "v3", "v3"}}
-]
+      (** Creating vertices **)
 
-(** Creating vertices **)
+      VerificationTest[
+        SetReplace[
+          SetReplace[{{"v1", "v2"}}, ToPatternRules[{{1, 2}} -> {{1, 2, 3}}]],
+          {{"v1", "v2", z_}} :> {{"v1", "v2"}}],
+        {{"v1", "v2"}}
+      ],
 
-VerificationTest[
-  SetReplace[
-    SetReplace[{{"v1", "v2"}}, ToPatternRules[{{1, 2}} -> {{1, 2, 3}}]],
-    {{"v1", "v2", z_}} :> {{"v1", "v2"}}],
-  {{"v1", "v2"}}
-]
+      (** Check new vertices are being held **)
 
-(** Check new vertices are being held **)
+      VerificationTest[
+        Module[{v1 = v2 = v3 = v4 = v5 = 1},
+          SetReplace[{z + z^z, y + y^y}, ToPatternRules[x + x^x -> x]]
+        ],
+        {y + y^y, z}
+      ],
 
-VerificationTest[
-  Module[{v1 = v2 = v3 = v4 = v5 = 1},
-    SetReplace[{z + z^z, y + y^y}, ToPatternRules[x + x^x -> x]]
-  ],
-  {y + y^y, z}
-]
+      (** Non-list rule structures **)
 
-(** Non-list rule structures **)
+      VerificationTest[
+        SetReplace[
+          {10 -> 20, {30, 40}},
+          ToPatternRules[{1 -> 2, {3, 4}} -> {{1, 2, 3}, {3, 4, 5}}]][[1]],
+        {10, 20, 30}
+      ],
 
-VerificationTest[
-  SetReplace[
-    {10 -> 20, {30, 40}},
-    ToPatternRules[{1 -> 2, {3, 4}} -> {{1, 2, 3}, {3, 4, 5}}]][[1]],
-  {10, 20, 30}
-]
+      VerificationTest[
+        SetReplace[{{2, 2}, 1},
+          ToPatternRules[{
+            {{Graph[{3 -> 4}], Graph[{3 -> 4}]}, Graph[{1 -> 2}]} ->
+            {Graph[{3 -> 4}], Graph[{1 -> 2}], Graph[{3 -> 4}]}}]],
+        {2, 1, 2}
+      ],
 
-VerificationTest[
-  SetReplace[{{2, 2}, 1},
-    ToPatternRules[{
-      {{Graph[{3 -> 4}], Graph[{3 -> 4}]}, Graph[{1 -> 2}]} ->
-      {Graph[{3 -> 4}], Graph[{1 -> 2}], Graph[{3 -> 4}]}}]],
-  {2, 1, 2}
-]
-
-VerificationTest[
-  SetReplace[
-    {{v[1], v[2]}, {v[2], v[3]}},
-    ToPatternRules[{{v[1], v[2]}, {v[2], v[3]}} -> {{v[1], v[3]}}]],
-  {{v[1], v[3]}}
-]
-
-EndTestSection[]
+      VerificationTest[
+        SetReplace[
+          {{v[1], v[2]}, {v[2], v[3]}},
+          ToPatternRules[{{v[1], v[2]}, {v[2], v[3]}} -> {{v[1], v[3]}}]],
+        {{v[1], v[3]}}
+      ]
+    }
+  |>
+|>

--- a/SetReplace/WolframModel.wlt
+++ b/SetReplace/WolframModel.wlt
@@ -804,8 +804,7 @@
                 output =
                   WolframModel[timeConstraintRule, timeConstraintInit, 100, Method -> method, TimeConstraint -> time]},
               WolframModel[timeConstraintRule, timeConstraintInit, <|"Events" -> output["EventsCount"]|>] === output],
-            100],
-          TimeConstraint -> 60
+            100]
         ]], {method, $SetReplaceMethods}, {time, {1.*^-100, 0.1}}],
 
         (*** This does not work with TimeConstrained though, $Aborted is returned in that case. ***)

--- a/SetReplace/WolframModel.wlt
+++ b/SetReplace/WolframModel.wlt
@@ -1,902 +1,853 @@
-BeginTestSection["WolframModel"]
-
-(* Argument checks *)
-
-(** Argument counts, simple rule and inits **)
-
-VerificationTest[
-  WolframModel,
-  WolframModel
-]
-
-VerificationTest[
-  WolframModel[],
-  WolframModel[],
-  {WolframModel::argb}
-]
-
-VerificationTest[
-  WolframModel[x],
-  WolframModel[x],
-  {}
-]
-
-VerificationTest[
-  WolframModel[x, y],
-  WolframModel[x, y],
-  {WolframModel::invalidRules}
-]
-
-VerificationTest[
-  WolframModel[x, y, z],
-  WolframModel[x, y, z],
-  {WolframModel::invalidRules}
-]
-
-VerificationTest[
-  WolframModel[x, y, z, w],
-  WolframModel[x, y, z, w],
-  {WolframModel::invalidRules}
-]
-
-VerificationTest[
-  WolframModel[x, y, z, w, a],
-  WolframModel[x, y, z, w, a],
-  {WolframModel::argb}
-]
-
-VerificationTest[
-  WolframModel[x, y, z, w, a, b],
-  WolframModel[x, y, z, w, a, b],
-  {WolframModel::argb}
-]
-
-VerificationTest[
-  WolframModel[f -> 3],
-  WolframModel[f -> 3],
-  {WolframModel::argb}
-]
-
-VerificationTest[
-  WolframModel[x, f -> 3],
-  WolframModel[x, f -> 3],
-  {}
-]
-
-VerificationTest[
-  WolframModel[x, y, f -> 3],
-  WolframModel[x, y, f -> 3],
-  {WolframModel::invalidRules}
-]
-
-VerificationTest[
-  WolframModel[x, y, z, f -> 3],
-  WolframModel[x, y, z, f -> 3],
-  {WolframModel::invalidRules}
-]
-
-VerificationTest[
-  WolframModel[x, y, z, w, f -> 3],
-  WolframModel[x, y, z, w, f -> 3],
-  {WolframModel::invalidRules}
-]
-
-VerificationTest[
-  WolframModel[x, y, z, w, a, f -> 3],
-  WolframModel[x, y, z, w, a, f -> 3],
-  {WolframModel::argb}
-]
-
-VerificationTest[
-  WolframModel[x, y, z, w, a, b, f -> 3],
-  WolframModel[x, y, z, w, a, b, f -> 3],
-  {WolframModel::argb}
-]
-
-VerificationTest[
-  WolframModel[1 -> 2],
-  WolframModel[1 -> 2]
-]
-
-VerificationTest[
-  WolframModel[1 -> 2, f -> 2],
-  WolframModel[1 -> 2, f -> 2],
-  {WolframModel::optx}
-]
-
-VerificationTest[
-  WolframModel[1 -> 2, f -> 2][1],
-  WolframModel[1 -> 2, f -> 2][1],
-  {WolframModel::optx}
-]
-
-VerificationTest[
-  WolframModel[1 -> 2, f -> 2][{1}],
-  WolframModel[1 -> 2, f -> 2][{1}],
-  {WolframModel::optx}
-]
-
-VerificationTest[
-  WolframModel[1 -> 2, Method -> "LowLevel"][{1}],
-  WolframModel[1 -> 2, Method -> "LowLevel"][{1}],
-  {WolframModel::lowLevelNotImplemented}
-]
-
-VerificationTest[
-  WolframModel[1 -> 2, Method -> "$$$InvalidMethod$$$"][{1}],
-  WolframModel[1 -> 2, Method -> "$$$InvalidMethod$$$"][{1}],
-  {WolframModel::invalidMethod}
-]
-
-VerificationTest[
-  WolframModel[1 -> 2, 4],
-  WolframModel[1 -> 2, 4],
-  {WolframModel::invalidState}
-]
-
-VerificationTest[
-  WolframModel[1 -> 2, 4, g -> 2],
-  WolframModel[1 -> 2, 4, g -> 2],
-  {WolframModel::invalidState}
-]
-
-VerificationTest[
-  WolframModel[1 -> 2][4],
-  WolframModel[1 -> 2][4],
-  {WolframModel::invalidState}
-]
-
-VerificationTest[
-  WolframModel[1 -> 2, g -> 2][4],
-  WolframModel[1 -> 2, g -> 2][4],
-  {WolframModel::optx}
-]
-
-VerificationTest[
-  WolframModel[1 -> 2][4, g -> 2],
-  WolframModel[1 -> 2][4, g -> 2],
-  {WolframModel::argx}
-]
-
-VerificationTest[
-  WolframModel[1 -> 2][{1}],
-  {_ ? AtomQ},
-  SameTest -> MatchQ
-]
-
-VerificationTest[
-  WolframModel[1 -> 2, {1}],
-  _WolframModelEvolutionObject,
-  SameTest -> MatchQ
-]
-
-VerificationTest[
-  WolframModel[1 -> 2, f -> 2][{1}],
-  WolframModel[1 -> 2, f -> 2][{1}],
-  {WolframModel::optx}
-]
-
-VerificationTest[
-  WolframModel[1 -> 2][{1}, f -> 2],
-  WolframModel[1 -> 2][{1}, f -> 2],
-  {WolframModel::argx}
-]
-
-VerificationTest[
-  WolframModel[1 -> 2][{1}, x],
-  WolframModel[1 -> 2][{1}, x],
-  {WolframModel::argx}
-]
-
-VerificationTest[
-  WolframModel[1 -> 2, x][{1}],
-  WolframModel[1 -> 2, x][{1}],
-  {WolframModel::invalidState}
-]
-
-VerificationTest[
-  WolframModel[1 -> 2, Method -> "$$$InvalidMethod$$$"][{1}],
-  WolframModel[1 -> 2, Method -> "$$$InvalidMethod$$$"][{1}],
-  {WolframModel::invalidMethod}
-]
-
-VerificationTest[
-  WolframModel[1 -> 2, Method -> "Symbolic"][{1}],
-  {_ ? AtomQ},
-  SameTest -> MatchQ
-]
-
-VerificationTest[
-  WolframModel[1 -> 2][{1}, Method -> "Symbolic"],
-  WolframModel[1 -> 2][{1}, Method -> "Symbolic"],
-  {WolframModel::argx}
-]
-
-VerificationTest[
-  WolframModel[{{1, 2}} -> {{1, 3}, {3, 2}}, {{0, 0}}, 100, TimeConstraint -> #],
-  WolframModel[{{1, 2}} -> {{1, 3}, {3, 2}}, {{0, 0}}, 100, TimeConstraint -> #],
-  {WolframModel::timc}
-] & /@ {0, -1, "x"}
-
-(** PatternRules **)
-
-VerificationTest[
-  WolframModel[<|"PatternRules" -> 1 -> 2|>][{1}],
-  {2}
-]
-
-VerificationTest[
-  WolframModel[<|"PatternRule" -> 1 -> 2|>],
-  WolframModel[<|"PatternRule" -> 1 -> 2|>],
-  {}
-]
-
-VerificationTest[
-  WolframModel[<|"PatternRule" -> 1 -> 2|>][{1}],
-  WolframModel[<|"PatternRule" -> 1 -> 2|>][{1}],
-  {}
-]
-
-VerificationTest[
-  WolframModel[<|"PatternRules" -> 1 -> 2, "f" -> 2|>],
-  WolframModel[<|"PatternRules" -> 1 -> 2, "f" -> 2|>],
-  {}
-]
-
-VerificationTest[
-  WolframModel[<|"PatternRules" -> 1 -> 2, "f" -> 2|>][{1}],
-  WolframModel[<|"PatternRules" -> 1 -> 2, "f" -> 2|>][{1}],
-  {}
-]
-
-VerificationTest[
-  WolframModel[<|"PatternRules" -> 1 -> 2|>],
-  WolframModel[<|"PatternRules" -> 1 -> 2|>]
-]
-
-VerificationTest[
-  WolframModel[<|"PatternRules" -> {1 -> 2, a_ :> Module[{b}, b]}|>][{1}],
-  {2}
-]
-
-VerificationTest[
-  WolframModel[<|"PatternRules" -> {1 -> 2, a_ :> Module[{b}, b]}|>][{2}],
-  {_ ? AtomQ},
-  SameTest -> MatchQ
-]
-
-VerificationTest[
-  WolframModel[<|"PatternRules" -> {1 -> 2, a_ :> Module[{b}, b]}|>, {1}],
-  _WolframModelEvolutionObject,
-  SameTest -> MatchQ
-]
-
-VerificationTest[
-  WolframModel[<|"PatternRules" -> {1 -> 2, a_ :> Module[{b}, b]}|>, {1}, x],
-  WolframModel[<|"PatternRules" -> {1 -> 2, a_ :> Module[{b}, b]}|>, {1}, x],
-  {WolframModel::invalidSteps}
-]
-
-(** Steps **)
-
-VerificationTest[
-  WolframModel[1 -> 2, {1}, 2]["GenerationsCount"],
-  2
-]
-
-VerificationTest[
-  WolframModel[1 -> 2, {1}, 2, x],
-  WolframModel[1 -> 2, {1}, 2, x],
-  {WolframModel::invalidProperty}
-]
-
-VerificationTest[
-  WolframModel[1 -> 2, {1}, 2.2],
-  WolframModel[1 -> 2, {1}, 2.2],
-  {WolframModel::invalidSteps}
-]
-
-VerificationTest[
-  WolframModel[1 -> 2, {1}, "sdfsdf"],
-  WolframModel[1 -> 2, {1}, "sdfsdf"],
-  {WolframModel::invalidSteps}
-]
-
-VerificationTest[
-  WolframModel[1 -> 2, {1}, 0]["EventsCount"],
-  0
-]
-
-VerificationTest[
-  WolframModel[1 -> 2, {1}, -1],
-  WolframModel[1 -> 2, {1}, -1],
-  {WolframModel::invalidSteps}
-]
-
-VerificationTest[
-  WolframModel[{{0, 1}} -> {{0, 2}, {2, 1}}, {{0, 1}}, 3] /@ {"GenerationsCount", "EventsCount"},
-  {3, 7}
-]
-
-VerificationTest[
-  WolframModel[{{0, 1}} -> {{0, 2}, {2, 1}}, {{0, 1}}, <|"Generations" -> 3|>] /@ {"GenerationsCount", "EventsCount"},
-  {3, 7}
-]
-
-VerificationTest[
-  WolframModel[{{0, 1}} -> {{0, 2}, {2, 1}}, {{0, 1}}, <|"Events" -> 6|>] /@ {"GenerationsCount", "EventsCount"},
-  {3, 6}
-]
-
-VerificationTest[
-  WolframModel[{{0, 1}} -> {{0, 2}, {2, 1}}, {{0, 1}}, <|"Generations" -> 3, "Events" -> 6|>] /@ {"GenerationsCount", "EventsCount"},
-  {3, 6}
-]
-
-VerificationTest[
-  WolframModel[{{0, 1}} -> {{0, 2}, {2, 1}}, {{0, 1}}, <|"Generations" -> 2, "Events" -> 6|>] /@ {"GenerationsCount", "EventsCount"},
-  {2, 3}
-]
-
-VerificationTest[
-  WolframModel[{{0, 1}, {1, 2}} -> {{0, 2}}, {{0, 1}, {1, 2}, {2, 3}, {3, 4}}, <||>] /@ {"GenerationsCount", "EventsCount"},
-  {2, 3}
-]
-
-VerificationTest[
-  WolframModel[{{0, 1}, {1, 2}} -> {{0, 2}}, {{0, 1}, {1, 2}, {2, 3}, {3, 4}}, <|"x" -> 2|>],
-  WolframModel[{{0, 1}, {1, 2}} -> {{0, 2}}, {{0, 1}, {1, 2}, {2, 3}, {3, 4}}, <|"x" -> 2|>],
-  {WolframModel::invalidSteps}
-]
-
-VerificationTest[
-  WolframModel[{{0, 1}, {1, 2}} -> {{0, 2}}, {{0, 1}, {1, 2}, {2, 3}, {3, 4}}, <|"x" -> 2, "Generations" -> 2|>],
-  WolframModel[{{0, 1}, {1, 2}} -> {{0, 2}}, {{0, 1}, {1, 2}, {2, 3}, {3, 4}}, <|"x" -> 2, "Generations" -> 2|>],
-  {WolframModel::invalidSteps}
-]
-
-VerificationTest[
-  WolframModel[{{0, 1}} -> {{0, 2}, {2, 1}}, {{0, 1}}, <|"Generations" -> \[Infinity], "Events" -> 12|>] /@ {"GenerationsCount", "EventsCount"},
-  {4, 12}
-]
-
-(** Properties **)
-
-VerificationTest[
-  WolframModel[1 -> 2, {1}, 2, "CausalGraph"],
-  Graph[{1, 2}, {1 -> 2}]
-]
-
-VerificationTest[
-  WolframModel[1 -> 2, {1}, 2, "123"],
-  WolframModel[1 -> 2, {1}, 2, "123"],
-  {WolframModel::invalidProperty}
-]
-
-VerificationTest[
-  WolframModel[1 -> 2, {1}, 2, "Generation"],
-  WolframModel[1 -> 2, {1}, 2, "Generation"],
-  {WolframModel::invalidProperty}
-]
-
-VerificationTest[
-  WolframModel[1 -> 2, {1}, 2, #] & /@ $WolframModelProperties // Length,
-  Length[$WolframModelProperties]
-]
-
-VerificationTest[
-  WolframModel[1 -> 2, {1}, 2, $WolframModelProperties] // Length,
-  WolframModel[1 -> 2, {1}, 2, #] & /@ $WolframModelProperties // Length
-]
-
-VerificationTest[
-  WolframModel[1 -> 2, {1}, 2, 2],
-  WolframModel[1 -> 2, {1}, 2, 2],
-  {WolframModel::invalidProperty}
-]
-
-VerificationTest[
-  WolframModel[1 -> 2, {1}, 2, {2, 3}],
-  WolframModel[1 -> 2, {1}, 2, {2, 3}],
-  {WolframModel::invalidProperty}
-]
-
-VerificationTest[
-  WolframModel[1 -> 2, {1}, 2, {"CausalGraph", 3}],
-  WolframModel[1 -> 2, {1}, 2, {"CausalGraph", 3}],
-  {WolframModel::invalidProperty}
-]
-
-VerificationTest[
-  WolframModel[1 -> 2, {1}, 2, {3, "CausalGraph"}],
-  WolframModel[1 -> 2, {1}, 2, {3, "CausalGraph"}],
-  {WolframModel::invalidProperty}
-]
-
-VerificationTest[
-  WolframModel[1 -> 2, {1}, 2, {"CausalGraph", "CausalGraph"}],
-  ConstantArray[Graph[{1, 2}, {1 -> 2}], 2]
-]
-
-VerificationTest[
-  WolframModel[1 -> 2, {1}, 2, "Rules"],
-  WolframModel[1 -> 2, {1}, 2, "Rules"],
-  {WolframModel::invalidProperty}
-]
-
-VerificationTest[
-  WolframModel[1 -> 2, {1}, 2, "Properties"],
-  WolframModel[1 -> 2, {1}, 2, "Properties"],
-  {WolframModel::invalidProperty}
-]
-
-(** Missing arguments **)
-
-VerificationTest[
-  WolframModel[1 -> 2, {1}, 1 -> 2, 2 -> 3],
-  WolframModel[1 -> 2, {1}, 1 -> 2, 2 -> 3],
-  {WolframModel::invalidSteps}
-]
-
-VerificationTest[
-  WolframModel[1 -> 2, {1}, "sdfds" -> 2, "xcvxcv" -> 3],
-  WolframModel[1 -> 2, {1}, "sdfds" -> 2, "xcvxcv" -> 3],
-  {WolframModel::optx}
-]
-
-VerificationTest[
-  WolframModel[{1}, 1 -> 2],
-  WolframModel[{1}, 1 -> 2],
-  {WolframModel::invalidRules}
-]
-
-VerificationTest[
-  WolframModel[1, 1 -> 2],
-  WolframModel[1, 1 -> 2],
-  {WolframModel::invalidRules}
-]
-
-VerificationTest[
-  WolframModel[1 -> 2, "CausalGraph"],
-  WolframModel[1 -> 2, "CausalGraph"],
-  {WolframModel::invalidState}
-]
-
-VerificationTest[
-  WolframModel[1 -> 2, {1}, "CausalGraph"],
-  Graph[{1}, {}]
-]
-
-VerificationTest[
-  WolframModel[1 -> 2, {1}, "CausalGraph", 1],
-  WolframModel[1 -> 2, {1}, "CausalGraph", 1],
-  {WolframModel::invalidSteps}
-]
-
-VerificationTest[
-  WolframModel[1 -> 2, 1, "CausalGraph"],
-  WolframModel[1 -> 2, 1, "CausalGraph"],
-  {WolframModel::invalidState}
-]
-
-(* Implementation *)
-
-(** Simple examples **)
-
-VerificationTest[
-  WolframModel[{1} -> {1}, {1}]["EventsCount"],
-  1
-]
-
-VerificationTest[
-  WolframModel[<|"PatternRules" -> (1 -> 2)|>, {1, 2, 3}][-1],
-  {2, 3, 2}
-]
-
-VerificationTest[
-  WolframModel[<|"PatternRules" -> (2 -> 5)|>, {1, 2, 3}][-1],
-  {1, 3, 5}
-]
-
-VerificationTest[
-  WolframModel[<|"PatternRules" -> (2 :> 5)|>, {1, 2, 3}][-1],
-  {1, 3, 5}
-]
-
-VerificationTest[
-  WolframModel[<|"PatternRules" -> {2 :> 5, 3 :> 6}|>, {1, 2, 3}][-1],
-  {1, 5, 6}
-]
-
-VerificationTest[
-  WolframModel[<|"PatternRules" -> {2 -> 5, 3 :> 6}|>, {1, 2, 3}][-1],
-  {1, 5, 6}
-]
-
-VerificationTest[
-  WolframModel[<|"PatternRules" -> {2 -> 5, 3 :> 6}|>, {1, 2, 3}, 2]["GenerationsCount"],
-  1
-]
-
-VerificationTest[
-  WolframModel[<|"PatternRules" -> {2 -> 5, 3 :> 6}|>, {1, 2, 3}, 2][-1],
-  {1, 5, 6}
-]
-
-VerificationTest[
-  WolframModel[<|"PatternRules" -> ({3, 2} -> 5)|>, {1, 2, 3}][-1],
-  {1, 5}
-]
-
-VerificationTest[
-  WolframModel[<|"PatternRules" -> (4 -> 5)|>, {1, 2, 3}]["EventsCount"],
-  0
-]
-
-VerificationTest[
-  WolframModel[<|"PatternRules" -> ({{1}} :> {})|>, {{1}}][-1],
-  {}
-]
-
-VerificationTest[
-  WolframModel[<|"PatternRules" -> ({{1}} :> {})|>, {{1}}, Method -> "LowLevel"][-1],
-  {}
-]
-
-VerificationTest[
-  WolframModel[<|"PatternRules" -> ({{1}} :> {})|>, {{1}}, Method -> "Symbolic"][-1],
-  {}
-]
-
-VerificationTest[
-  WolframModel[<|"PatternRules" -> ({{1}} :> {})|>, {{1}}, Method -> Automatic][-1],
-  {}
-]
-
-VerificationTest[
-  WolframModel[<|"PatternRules" -> ({{1}, {2}} :> {{3}})|>, {{1}, {2}}][-1],
-  {{3}}
-]
-
-VerificationTest[
-  WolframModel[<|"PatternRules" -> ({{1}, {2}} :> {{3}})|>, {{2}, {1}}][-1],
-  {{3}}
-]
-
-VerificationTest[
-  WolframModel[
-    <|"PatternRules" -> ({x_List ? (Length[#] == 3 &), y_List ? (Length[#] == 6 &)} :> {x, y, Join[x, y]})|>,
-    {"This" -> "that", {2, 3, 4}, {2, 5}, {1, 2, 3, 4, 5, 6}},
-    2][0],
-  {"This" -> "that", {2, 3, 4}, {2, 5}, {1, 2, 3, 4, 5, 6}}
-]
-
-VerificationTest[
-  WolframModel[
-    <|"PatternRules" -> ({x_List ? (Length[#] == 3 &), y_List ? (Length[#] == 6 &)} :> {x, y, Join[x, y]})|>,
-    {"This" -> "that", {2, 3, 4}, {2, 5}, {1, 2, 3, 4, 5, 6}},
-    2][-1],
-  {"This" -> "that", {2, 5}, {2, 3, 4, 1, 2, 3, 4, 5, 6}, {2, 3, 4}, {1, 2, 3, 4, 5, 6}, {2, 3, 4, 1, 2, 3, 4, 5, 6}}
-]
-
-VerificationTest[
-  WolframModel[
-    <|"PatternRules" -> ({x_List /; (Length[x] == 3), y_List /; (Length[y] == 6)} :> {x, y, Join[x, y]})|>,
-    {"This" -> "that", {2, 3, 4}, {2, 5}, {1, 2, 3, 4, 5, 6}},
-    2][0],
-  {"This" -> "that", {2, 3, 4}, {2, 5}, {1, 2, 3, 4, 5, 6}}
-]
-
-VerificationTest[
-  WolframModel[
-    <|"PatternRules" -> ({x_List /; (Length[x] == 3), y_List /; (Length[y] == 6)} :> {x, y, Join[x, y]})|>,
-    {"This" -> "that", {2, 3, 4}, {2, 5}, {1, 2, 3, 4, 5, 6}},
-    2][-1],
-  {"This" -> "that", {2, 5}, {2, 3, 4, 1, 2, 3, 4, 5, 6}, {2, 3, 4}, {1, 2, 3, 4, 5, 6}, {2, 3, 4, 1, 2, 3, 4, 5, 6}}
-]
-
-VerificationTest[
-  WolframModel[<|"PatternRules" -> ({{a_, b_}, {b_, c_}} :> {{a, c}})|>, {{1, 2}, {2, 3}, {3, 4}, {4, 5}}, 2][1],
-  {{1, 3}, {3, 5}}
-]
-
-VerificationTest[
-  WolframModel[<|"PatternRules" -> ({{a_, b_}, {b_, c_}} :> {{a, c}})|>, {{1, 2}, {2, 3}, {3, 4}, {4, 5}}, 2][1],
-  WolframModel[<|"PatternRules" -> ({{a_, b_}, {b_, c_}} :> {{a, c}})|>, {{1, 2}, {2, 3}, {3, 4}, {4, 5}}, 1][-1]
-]
-
-VerificationTest[
-  WolframModel[<|"PatternRules" -> ({{a_, b_}, {b_, c_}} :> {{a, c}})|>, {{1, 2}, {2, 3}, {3, 4}, {4, 5}}, 2][-1],
-  {{1, 5}}
-]
-
-VerificationTest[
-  WolframModel[{{1, 2}} -> {{1, 3}, {3, 2}}, {{1, 2}}, 10]["GenerationsCount"],
-  10
-]
-
-VerificationTest[
-  WolframModel[{{1, 2}} -> {{1, 3}, {3, 2}}, {{1, 2}}, 10]["EventsCount"],
-  1023
-]
-
-VerificationTest[
-  WolframModel[{{1}} -> {}, {{1}, {2}, {3}, {4}, {5}}, Infinity]["GenerationsCount"],
-  1
-]
-
-VerificationTest[
-  WolframModel[{{1}} -> {}, {{1}, {2}, {3}, {4}, {5}}, Infinity]["EventsCount"],
-  5
-]
-
-VerificationTest[
-  WolframModel[{{1}} -> {}, {{1}, {2}, {3}, {4}, {5}}, Infinity][-1],
-  {}
-]
-
-VerificationTest[
-  WolframModel[{{1}} -> {{1}}, {{1}, {2}, {3}, {4}, {5}}, 0]["GenerationsCount"],
-  0
-]
-
-VerificationTest[
-  WolframModel[{{1}} -> {{1}}, {{1}, {2}, {3}, {4}, {5}}, 0]["EventsCount"],
-  0
-]
-
-VerificationTest[
-  WolframModel[
-    {{{1}} -> {}, {{1, 2}} -> {{1}}},
-    {{1, 2}, {2}, {3}, {4}, {5}},
-    2]["GenerationsCount"],
-  2
-]
-
-VerificationTest[
-  WolframModel[
-    {{{1}} -> {}, {{1, 2}} -> {{1}}},
-    {{1, 2}, {2}, {3}, {4}, {5}},
-    2]["EventsCount"],
-  6
-]
-
-VerificationTest[
-  WolframModel[
-    <|"PatternRules" -> {{{1}} -> {{2}}}|>,
-    {{1}, {1}, {1}},
-    1,
-    Method -> "LowLevel"],
-  WolframModel[
-    <|"PatternRules" -> {{{1}} -> {{2}}}|>,
-    {{1}, {1}, {1}},
-    1,
-    Method -> "Symbolic"]
-]
-
-VerificationTest[
-  WolframModel[
-    {{v[1], v[2]}, {v[2], v[3]}} -> {{v[1], v[3]}},
-    {{v[1], v[2]}, {v[2], v[3]}},
-    "FinalState",
-    Method -> "Symbolic"],
-  {{v[1], v[3]}}
-]
-
-VerificationTest[
-  WolframModel[
-    {{v[1], v[2]}, {v[2], v[3]}} -> {{v[1], v[3]}},
-    {{v[1], v[2]}, {v[2], v[3]}},
-    "FinalState",
-    Method -> "LowLevel"],
-  {{v[1], v[3]}}
-]
-
-(** Nested lists as vertices **)
-
-VerificationTest[
-  Head[
-    WolframModel[{{{2, 2, 1}, {2, 2, 2}} -> {{1, 1, 3}, {1, 1, 1}, {2, 1, 2}, {3, 3, 2}}}, {Table[{0, 0, 0}, 3]}, 2]],
-  WolframModelEvolutionObject
-]
-
-VerificationTest[
-  WolframModel[
-    {{{2, 2, 1}, {2, 2, 2}} -> {{1, 1, 3}, {1, 1, 1}, {2, 1, 2}, {3, 3, 2}}},
-    {{{2}, {2}, 1}, {{2}, {2}, {2}}},
-    1,
-    "FinalState",
-    Method -> #],
-  {{1, 1, 2}, {1, 1, 1}, {{2}, 1, {2}}, {2, 2, {2}}}
-] & /@ $SetReplaceMethods
-
-VerificationTest[
-  WolframModel[{{{1, 1, 1}} -> {{1, 1, 1, 1}}}, {Table[{0, 0, 0}, 3]}, 2, "FinalState", Method -> #],
-  {ConstantArray[{0, 0, 0}, 4]}
-] & /@ $SetReplaceMethods
-
-(** NodeNamingFunction **)
-
-VerificationTest[
-  WolframModel[
-    {{1, 3}} -> {{1, 2}, {2, 3}},
-    {{0, 0}},
-    2,
-    "FinalState"],
-  WolframModel[
-    {{1, 3}} -> {{1, 2}, {2, 3}},
-    {{0, 0}},
-    2,
-    "FinalState",
-    "NodeNamingFunction" -> Automatic]
-]
-
-VerificationTest[
-  WolframModel[
-    {{1, 3}} -> {{1, 2}, {2, 3}},
-    {{0, 0}},
-    2,
-    "FinalState",
-    "NodeNamingFunction" -> Automatic],
-  {{0, 2}, {2, 1}, {1, 3}, {3, 0}}
-]
-
-VerificationTest[
-  WolframModel[
-    {{1, 3}} -> {{1, 2}, {2, 3}},
-    {{2, 2}},
-    2,
-    "FinalState",
-    "NodeNamingFunction" -> Automatic],
-  {{2, 3}, {3, 1}, {1, 4}, {4, 2}}
-]
-
-VerificationTest[
-  WolframModel[
-    {{1, 3}} -> {{1, 2}, {2, 3}},
-    {{0, 0}},
-    2,
-    "FinalState",
-    "NodeNamingFunction" -> All],
-  {{1, 3}, {3, 2}, {2, 4}, {4, 1}}
-]
-
-VerificationTest[
-  WolframModel[
-    {{1, 3}} -> {{1, 2}, {2, 3}},
-    {{0, 0}},
-    2,
-    "FinalState",
-    "NodeNamingFunction" -> None],
-  {{0, x_Symbol}, {x_Symbol, y_Symbol}, {y_Symbol, z_Symbol}, {z_Symbol, 0}},
-  SameTest -> MatchQ
-]
-
-VerificationTest[
-  WolframModel[
-    <|"PatternRules" -> {{a_, b_}} :> Module[{c}, {{a, c}, {c, b}}]|>,
-    {{0, 0}},
-    2,
-    "FinalState",
-    "NodeNamingFunction" -> All],
-  {{1, 3}, {3, 2}, {2, 4}, {4, 1}}
-]
-
-VerificationTest[
-  WolframModel[
-    <|"PatternRules" -> {{a_, b_}} :> Module[{c}, {{a, c}, {c, b}}]|>,
-    {{0, 0}},
-    2,
-    "FinalState",
-    "NodeNamingFunction" -> #],
-  {{0, x_Symbol}, {x_Symbol, y_Symbol}, {y_Symbol, z_Symbol}, {z_Symbol, 0}},
-  SameTest -> MatchQ
-] & /@ {Automatic, None}
-
-VerificationTest[
-  WolframModel[
-    <|"PatternRules" -> {{a_, b_}} :> Module[{c}, {{a, c}, {c, b}}]|>,
-    {{0, 0}},
-    2,
-    "FinalState"],
-  {{0, x_Symbol}, {x_Symbol, y_Symbol}, {y_Symbol, z_Symbol}, {z_Symbol, 0}},
-  SameTest -> MatchQ
-]
-
-$namingTestModel = {
-  {{0, 1}, {0, 2}, {0, 3}} ->
-    {{4, 5}, {5, 4}, {4, 6}, {6, 4}, {5, 6},
-      {6, 5}, {4, 1}, {5, 2}, {6, 3}, {1, 6}, {3, 4}},
-  {{0, 0},
-  {0, 0}, {0, 0}},
-  5,
-  "FinalState"};
-
-VerificationTest[
-  # == Range[Length[#]] & @ Union @ Flatten[
-    WolframModel[##, "NodeNamingFunction" -> All] & @@
-      $namingTestModel]
-]
-
-VerificationTest[
-  # == Range[0, Length[#] - 1] & @ Union @ Flatten[
-    WolframModel[##, "NodeNamingFunction" -> Automatic] & @@
-      $namingTestModel]
-]
-
-VerificationTest[
-  (#[[1]] /. Thread[Rule @@ Flatten /@ #]) == #[[2]] & @ (Table[
-    WolframModel[##, "NodeNamingFunction" -> namingFunction] & @@ $namingTestModel,
-    {namingFunction, {All, None}}])
-]
-
-(*** For anonymous rules, all level-2 expressions must be atomized, similar to ToPatternRules behavior ***)
-VerificationTest[
-  WolframModel[
-    {{s[1], s[2]}} -> {{s[1], s[3]}, {s[3], s[2]}},
-    {{s[1], s[2]}},
-    1,
-    "FinalState",
-    "NodeNamingFunction" -> All],
-  {{1, 3}, {3, 2}}
-]
-
-(** TimeConstraint **)
-
-$timeConstraintRule = {{1, 2}} -> {{1, 3}, {3, 2}};
-$timeConstraintInit = {{0, 0}};
-
-(*** Check that aborted evaluation still produces correct evolutions. ***)
-Table[VerificationTest[
-  And @@ Table[
-    With[{
-        output =
-          WolframModel[$timeConstraintRule, $timeConstraintInit, 100, Method -> method, TimeConstraint -> time]},
-      WolframModel[$timeConstraintRule, $timeConstraintInit, <|"Events" -> output["EventsCount"]|>] === output],
-    100],
-  TimeConstraint -> 60
-], {method, $SetReplaceMethods}, {time, {1.*^-100, 0.1}}]
-
-(*** This does not work with TimeConstrained though, $Aborted is returned in that case. ***)
-VerificationTest[
-  TimeConstrained[WolframModel[$timeConstraintRule, $timeConstraintInit, 100, Method -> #], 0.1],
-  $Aborted
-] & /@ $SetReplaceMethods
-
-(*** $Aborted should be returned if not an evolution object is asked for. ***)
-VerificationTest[
-  WolframModel[$timeConstraintRule, $timeConstraintInit, 100, "FinalState", Method -> #, TimeConstraint -> 0.1],
-  $Aborted
-] & /@ $SetReplaceMethods
-
-EndTestSection[]
-
-
-BeginTestSection["$SetReplaceMethods"]
-
-VerificationTest[
-  ListQ[$SetReplaceMethods]
-]
-
-VerificationTest[
-  AllTrue[
-    $SetReplaceMethods,
-    SetReplace[{{0}}, {{0}} -> {{1}}, Method -> #] === {{1}} &]
-]
-
-EndTestSection[]
-
-
-BeginTestSection["$WolframModelProperties"]
-
-VerificationTest[
-  ListQ[$WolframModelProperties]
-]
-
-VerificationTest[
-  AllTrue[
-    $WolframModelProperties,
-    Head[WolframModel[{{0}} -> {{1}}, {{0}}, 1, #]] =!= WolframModel &]
-]
-
-EndTestSection[]
+<|
+  "WolframModel" -> <|
+    "init" -> (
+      Attributes[Global`testUnevaluated] = {HoldAll};
+      Global`testUnevaluated[args___] := SetReplace`PackageScope`testUnevaluated[VerificationTest, args];
+
+      $namingTestModel = {
+        {{0, 1}, {0, 2}, {0, 3}} ->
+          {{4, 5}, {5, 4}, {4, 6}, {6, 4}, {5, 6},
+            {6, 5}, {4, 1}, {5, 2}, {6, 3}, {1, 6}, {3, 4}},
+        {{0, 0},
+        {0, 0}, {0, 0}},
+        5,
+        "FinalState"};
+
+      $timeConstraintRule = {{1, 2}} -> {{1, 3}, {3, 2}};
+      $timeConstraintInit = {{0, 0}};
+    ),
+    "tests" -> {
+      (* Argument checks *)
+
+      (** Argument counts, simple rule and inits **)
+
+      testUnevaluated[
+        WolframModel,
+        {}
+      ],
+
+      testUnevaluated[
+        WolframModel[],
+        {WolframModel::argb}
+      ],
+
+      testUnevaluated[
+        WolframModel[x],
+        {}
+      ],
+
+      testUnevaluated[
+        WolframModel[x, y],
+        {WolframModel::invalidRules}
+      ],
+
+      testUnevaluated[
+        WolframModel[x, y, z],
+        {WolframModel::invalidRules}
+      ],
+
+      testUnevaluated[
+        WolframModel[x, y, z, w],
+        {WolframModel::invalidRules}
+      ],
+
+      testUnevaluated[
+        WolframModel[x, y, z, w, a],
+        {WolframModel::argb}
+      ],
+
+      testUnevaluated[
+        WolframModel[x, y, z, w, a, b],
+        {WolframModel::argb}
+      ],
+
+      testUnevaluated[
+        WolframModel[f -> 3],
+        {WolframModel::argb}
+      ],
+
+      testUnevaluated[
+        WolframModel[x, f -> 3],
+        {}
+      ],
+
+      testUnevaluated[
+        WolframModel[x, y, f -> 3],
+        {WolframModel::invalidRules}
+      ],
+
+      testUnevaluated[
+        WolframModel[x, y, z, f -> 3],
+        {WolframModel::invalidRules}
+      ],
+
+      testUnevaluated[
+        WolframModel[x, y, z, w, f -> 3],
+        {WolframModel::invalidRules}
+      ],
+
+      testUnevaluated[
+        WolframModel[x, y, z, w, a, f -> 3],
+        {WolframModel::argb}
+      ],
+
+      testUnevaluated[
+        WolframModel[x, y, z, w, a, b, f -> 3],
+        {WolframModel::argb}
+      ],
+
+      testUnevaluated[
+        WolframModel[1 -> 2],
+        {}
+      ],
+
+      testUnevaluated[
+        WolframModel[1 -> 2, f -> 2],
+        {WolframModel::optx}
+      ],
+
+      testUnevaluated[
+        WolframModel[1 -> 2, f -> 2][1],
+        {WolframModel::optx}
+      ],
+
+      testUnevaluated[
+        WolframModel[1 -> 2, f -> 2][{1}],
+        {WolframModel::optx}
+      ],
+
+      testUnevaluated[
+        WolframModel[1 -> 2, Method -> "LowLevel"][{1}],
+        {WolframModel::lowLevelNotImplemented}
+      ],
+
+      testUnevaluated[
+        WolframModel[1 -> 2, Method -> "$$$InvalidMethod$$$"][{1}],
+        {WolframModel::invalidMethod}
+      ],
+
+      testUnevaluated[
+        WolframModel[1 -> 2, 4],
+        {WolframModel::invalidState}
+      ],
+
+      testUnevaluated[
+        WolframModel[1 -> 2, 4, g -> 2],
+        {WolframModel::invalidState}
+      ],
+
+      testUnevaluated[
+        WolframModel[1 -> 2][4],
+        {WolframModel::invalidState}
+      ],
+
+      testUnevaluated[
+        WolframModel[1 -> 2, g -> 2][4],
+        {WolframModel::optx}
+      ],
+
+      testUnevaluated[
+        WolframModel[1 -> 2][4, g -> 2],
+        {WolframModel::argx}
+      ],
+
+      VerificationTest[
+        WolframModel[1 -> 2][{1}],
+        {_ ? AtomQ},
+        SameTest -> MatchQ
+      ],
+
+      VerificationTest[
+        WolframModel[1 -> 2, {1}],
+        _WolframModelEvolutionObject,
+        SameTest -> MatchQ
+      ],
+
+      testUnevaluated[
+        WolframModel[1 -> 2, f -> 2][{1}],
+        {WolframModel::optx}
+      ],
+
+      testUnevaluated[
+        WolframModel[1 -> 2][{1}, f -> 2],
+        {WolframModel::argx}
+      ],
+
+      testUnevaluated[
+        WolframModel[1 -> 2][{1}, x],
+        {WolframModel::argx}
+      ],
+
+      testUnevaluated[
+        WolframModel[1 -> 2, x][{1}],
+        {WolframModel::invalidState}
+      ],
+
+      testUnevaluated[
+        WolframModel[1 -> 2, Method -> "$$$InvalidMethod$$$"][{1}],
+        {WolframModel::invalidMethod}
+      ],
+
+      VerificationTest[
+        WolframModel[1 -> 2, Method -> "Symbolic"][{1}],
+        {_ ? AtomQ},
+        SameTest -> MatchQ
+      ],
+
+      testUnevaluated[
+        WolframModel[1 -> 2][{1}, Method -> "Symbolic"],
+        {WolframModel::argx}
+      ],
+
+      testUnevaluated[
+        WolframModel[{{1, 2}} -> {{1, 3}, {3, 2}}, {{0, 0}}, 100, TimeConstraint -> #],
+        {WolframModel::timc}
+      ] & /@ {0, -1, "x"},
+
+      (** PatternRules **)
+
+      VerificationTest[
+        WolframModel[<|"PatternRules" -> 1 -> 2|>][{1}],
+        {2}
+      ],
+
+      testUnevaluated[
+        WolframModel[<|"PatternRule" -> 1 -> 2|>],
+        {}
+      ],
+
+      testUnevaluated[
+        WolframModel[<|"PatternRule" -> 1 -> 2|>][{1}],
+        {}
+      ],
+
+      testUnevaluated[
+        WolframModel[<|"PatternRules" -> 1 -> 2, "f" -> 2|>],
+        {}
+      ],
+
+      testUnevaluated[
+        WolframModel[<|"PatternRules" -> 1 -> 2, "f" -> 2|>][{1}],
+        {}
+      ],
+
+      testUnevaluated[
+        WolframModel[<|"PatternRules" -> 1 -> 2|>],
+        {}
+      ],
+
+      VerificationTest[
+        WolframModel[<|"PatternRules" -> {1 -> 2, a_ :> Module[{b}, b]}|>][{1}],
+        {2}
+      ],
+
+      VerificationTest[
+        WolframModel[<|"PatternRules" -> {1 -> 2, a_ :> Module[{b}, b]}|>][{2}],
+        {_ ? AtomQ},
+        SameTest -> MatchQ
+      ],
+
+      VerificationTest[
+        WolframModel[<|"PatternRules" -> {1 -> 2, a_ :> Module[{b}, b]}|>, {1}],
+        _WolframModelEvolutionObject,
+        SameTest -> MatchQ
+      ],
+
+      testUnevaluated[
+        WolframModel[<|"PatternRules" -> {1 -> 2, a_ :> Module[{b}, b]}|>, {1}, x],
+        {WolframModel::invalidSteps}
+      ],
+
+      (** Steps **)
+
+      VerificationTest[
+        WolframModel[1 -> 2, {1}, 2]["GenerationsCount"],
+        2
+      ],
+
+      testUnevaluated[
+        WolframModel[1 -> 2, {1}, 2, x],
+        {WolframModel::invalidProperty}
+      ],
+
+      testUnevaluated[
+        WolframModel[1 -> 2, {1}, 2.2],
+        {WolframModel::invalidSteps}
+      ],
+
+      testUnevaluated[
+        WolframModel[1 -> 2, {1}, "sdfsdf"],
+        {WolframModel::invalidSteps}
+      ],
+
+      VerificationTest[
+        WolframModel[1 -> 2, {1}, 0]["EventsCount"],
+        0
+      ],
+
+      testUnevaluated[
+        WolframModel[1 -> 2, {1}, -1],
+        {WolframModel::invalidSteps}
+      ],
+
+      VerificationTest[
+        WolframModel[{{0, 1}} -> {{0, 2}, {2, 1}}, {{0, 1}}, 3] /@ {"GenerationsCount", "EventsCount"},
+        {3, 7}
+      ],
+
+      VerificationTest[
+        WolframModel[{{0, 1}} -> {{0, 2}, {2, 1}}, {{0, 1}}, <|"Generations" -> 3|>] /@ {"GenerationsCount", "EventsCount"},
+        {3, 7}
+      ],
+
+      VerificationTest[
+        WolframModel[{{0, 1}} -> {{0, 2}, {2, 1}}, {{0, 1}}, <|"Events" -> 6|>] /@ {"GenerationsCount", "EventsCount"},
+        {3, 6}
+      ],
+
+      VerificationTest[
+        WolframModel[{{0, 1}} -> {{0, 2}, {2, 1}}, {{0, 1}}, <|"Generations" -> 3, "Events" -> 6|>] /@ {"GenerationsCount", "EventsCount"},
+        {3, 6}
+      ],
+
+      VerificationTest[
+        WolframModel[{{0, 1}} -> {{0, 2}, {2, 1}}, {{0, 1}}, <|"Generations" -> 2, "Events" -> 6|>] /@ {"GenerationsCount", "EventsCount"},
+        {2, 3}
+      ],
+
+      VerificationTest[
+        WolframModel[{{0, 1}, {1, 2}} -> {{0, 2}}, {{0, 1}, {1, 2}, {2, 3}, {3, 4}}, <||>] /@ {"GenerationsCount", "EventsCount"},
+        {2, 3}
+      ],
+
+      testUnevaluated[
+        WolframModel[{{0, 1}, {1, 2}} -> {{0, 2}}, {{0, 1}, {1, 2}, {2, 3}, {3, 4}}, <|"x" -> 2|>],
+        {WolframModel::invalidSteps}
+      ],
+
+      testUnevaluated[
+        WolframModel[{{0, 1}, {1, 2}} -> {{0, 2}}, {{0, 1}, {1, 2}, {2, 3}, {3, 4}}, <|"x" -> 2, "Generations" -> 2|>],
+        {WolframModel::invalidSteps}
+      ],
+
+      VerificationTest[
+        WolframModel[{{0, 1}} -> {{0, 2}, {2, 1}}, {{0, 1}}, <|"Generations" -> \[Infinity], "Events" -> 12|>] /@ {"GenerationsCount", "EventsCount"},
+        {4, 12}
+      ],
+
+      (** Properties **)
+
+      VerificationTest[
+        WolframModel[1 -> 2, {1}, 2, "CausalGraph"],
+        Graph[{1, 2}, {1 -> 2}]
+      ],
+
+      testUnevaluated[
+        WolframModel[1 -> 2, {1}, 2, "123"],
+        {WolframModel::invalidProperty}
+      ],
+
+      testUnevaluated[
+        WolframModel[1 -> 2, {1}, 2, "Generation"],
+        {WolframModel::invalidProperty}
+      ],
+
+      VerificationTest[
+        WolframModel[1 -> 2, {1}, 2, #] & /@ $WolframModelProperties // Length,
+        Length[$WolframModelProperties]
+      ],
+
+      VerificationTest[
+        WolframModel[1 -> 2, {1}, 2, $WolframModelProperties] // Length,
+        WolframModel[1 -> 2, {1}, 2, #] & /@ $WolframModelProperties // Length
+      ],
+
+      testUnevaluated[
+        WolframModel[1 -> 2, {1}, 2, 2],
+        {WolframModel::invalidProperty}
+      ],
+
+      testUnevaluated[
+        WolframModel[1 -> 2, {1}, 2, {2, 3}],
+        {WolframModel::invalidProperty}
+      ],
+
+      testUnevaluated[
+        WolframModel[1 -> 2, {1}, 2, {"CausalGraph", 3}],
+        {WolframModel::invalidProperty}
+      ],
+
+      testUnevaluated[
+        WolframModel[1 -> 2, {1}, 2, {3, "CausalGraph"}],
+        {WolframModel::invalidProperty}
+      ],
+
+      VerificationTest[
+        WolframModel[1 -> 2, {1}, 2, {"CausalGraph", "CausalGraph"}],
+        ConstantArray[Graph[{1, 2}, {1 -> 2}], 2]
+      ],
+
+      testUnevaluated[
+        WolframModel[1 -> 2, {1}, 2, "Rules"],
+        {WolframModel::invalidProperty}
+      ],
+
+      testUnevaluated[
+        WolframModel[1 -> 2, {1}, 2, "Properties"],
+        {WolframModel::invalidProperty}
+      ],
+
+      (** Missing arguments **)
+
+      testUnevaluated[
+        WolframModel[1 -> 2, {1}, 1 -> 2, 2 -> 3],
+        {WolframModel::invalidSteps}
+      ],
+
+      testUnevaluated[
+        WolframModel[1 -> 2, {1}, "sdfds" -> 2, "xcvxcv" -> 3],
+        {WolframModel::optx}
+      ],
+
+      testUnevaluated[
+        WolframModel[{1}, 1 -> 2],
+        {WolframModel::invalidRules}
+      ],
+
+      testUnevaluated[
+        WolframModel[1, 1 -> 2],
+        {WolframModel::invalidRules}
+      ],
+
+      testUnevaluated[
+        WolframModel[1 -> 2, "CausalGraph"],
+        {WolframModel::invalidState}
+      ],
+
+      VerificationTest[
+        WolframModel[1 -> 2, {1}, "CausalGraph"],
+        Graph[{1}, {}]
+      ],
+
+      testUnevaluated[
+        WolframModel[1 -> 2, {1}, "CausalGraph", 1],
+        {WolframModel::invalidSteps}
+      ],
+
+      testUnevaluated[
+        WolframModel[1 -> 2, 1, "CausalGraph"],
+        {WolframModel::invalidState}
+      ],
+
+      (* Implementation *)
+
+      (** Simple examples **)
+
+      VerificationTest[
+        WolframModel[{1} -> {1}, {1}]["EventsCount"],
+        1
+      ],
+
+      VerificationTest[
+        WolframModel[<|"PatternRules" -> (1 -> 2)|>, {1, 2, 3}][-1],
+        {2, 3, 2}
+      ],
+
+      VerificationTest[
+        WolframModel[<|"PatternRules" -> (2 -> 5)|>, {1, 2, 3}][-1],
+        {1, 3, 5}
+      ],
+
+      VerificationTest[
+        WolframModel[<|"PatternRules" -> (2 :> 5)|>, {1, 2, 3}][-1],
+        {1, 3, 5}
+      ],
+
+      VerificationTest[
+        WolframModel[<|"PatternRules" -> {2 :> 5, 3 :> 6}|>, {1, 2, 3}][-1],
+        {1, 5, 6}
+      ],
+
+      VerificationTest[
+        WolframModel[<|"PatternRules" -> {2 -> 5, 3 :> 6}|>, {1, 2, 3}][-1],
+        {1, 5, 6}
+      ],
+
+      VerificationTest[
+        WolframModel[<|"PatternRules" -> {2 -> 5, 3 :> 6}|>, {1, 2, 3}, 2]["GenerationsCount"],
+        1
+      ],
+
+      VerificationTest[
+        WolframModel[<|"PatternRules" -> {2 -> 5, 3 :> 6}|>, {1, 2, 3}, 2][-1],
+        {1, 5, 6}
+      ],
+
+      VerificationTest[
+        WolframModel[<|"PatternRules" -> ({3, 2} -> 5)|>, {1, 2, 3}][-1],
+        {1, 5}
+      ],
+
+      VerificationTest[
+        WolframModel[<|"PatternRules" -> (4 -> 5)|>, {1, 2, 3}]["EventsCount"],
+        0
+      ],
+
+      VerificationTest[
+        WolframModel[<|"PatternRules" -> ({{1}} :> {})|>, {{1}}][-1],
+        {}
+      ],
+
+      VerificationTest[
+        WolframModel[<|"PatternRules" -> ({{1}} :> {})|>, {{1}}, Method -> "LowLevel"][-1],
+        {}
+      ],
+
+      VerificationTest[
+        WolframModel[<|"PatternRules" -> ({{1}} :> {})|>, {{1}}, Method -> "Symbolic"][-1],
+        {}
+      ],
+
+      VerificationTest[
+        WolframModel[<|"PatternRules" -> ({{1}} :> {})|>, {{1}}, Method -> Automatic][-1],
+        {}
+      ],
+
+      VerificationTest[
+        WolframModel[<|"PatternRules" -> ({{1}, {2}} :> {{3}})|>, {{1}, {2}}][-1],
+        {{3}}
+      ],
+
+      VerificationTest[
+        WolframModel[<|"PatternRules" -> ({{1}, {2}} :> {{3}})|>, {{2}, {1}}][-1],
+        {{3}}
+      ],
+
+      VerificationTest[
+        WolframModel[
+          <|"PatternRules" -> ({x_List ? (Length[#] == 3 &), y_List ? (Length[#] == 6 &)} :> {x, y, Join[x, y]})|>,
+          {"This" -> "that", {2, 3, 4}, {2, 5}, {1, 2, 3, 4, 5, 6}},
+          2][0],
+        {"This" -> "that", {2, 3, 4}, {2, 5}, {1, 2, 3, 4, 5, 6}}
+      ],
+
+      VerificationTest[
+        WolframModel[
+          <|"PatternRules" -> ({x_List ? (Length[#] == 3 &), y_List ? (Length[#] == 6 &)} :> {x, y, Join[x, y]})|>,
+          {"This" -> "that", {2, 3, 4}, {2, 5}, {1, 2, 3, 4, 5, 6}},
+          2][-1],
+        {"This" -> "that", {2, 5}, {2, 3, 4, 1, 2, 3, 4, 5, 6}, {2, 3, 4}, {1, 2, 3, 4, 5, 6}, {2, 3, 4, 1, 2, 3, 4, 5, 6}}
+      ],
+
+      VerificationTest[
+        WolframModel[
+          <|"PatternRules" -> ({x_List /; (Length[x] == 3), y_List /; (Length[y] == 6)} :> {x, y, Join[x, y]})|>,
+          {"This" -> "that", {2, 3, 4}, {2, 5}, {1, 2, 3, 4, 5, 6}},
+          2][0],
+        {"This" -> "that", {2, 3, 4}, {2, 5}, {1, 2, 3, 4, 5, 6}}
+      ],
+
+      VerificationTest[
+        WolframModel[
+          <|"PatternRules" -> ({x_List /; (Length[x] == 3), y_List /; (Length[y] == 6)} :> {x, y, Join[x, y]})|>,
+          {"This" -> "that", {2, 3, 4}, {2, 5}, {1, 2, 3, 4, 5, 6}},
+          2][-1],
+        {"This" -> "that", {2, 5}, {2, 3, 4, 1, 2, 3, 4, 5, 6}, {2, 3, 4}, {1, 2, 3, 4, 5, 6}, {2, 3, 4, 1, 2, 3, 4, 5, 6}}
+      ],
+
+      VerificationTest[
+        WolframModel[<|"PatternRules" -> ({{a_, b_}, {b_, c_}} :> {{a, c}})|>, {{1, 2}, {2, 3}, {3, 4}, {4, 5}}, 2][1],
+        {{1, 3}, {3, 5}}
+      ],
+
+      VerificationTest[
+        WolframModel[<|"PatternRules" -> ({{a_, b_}, {b_, c_}} :> {{a, c}})|>, {{1, 2}, {2, 3}, {3, 4}, {4, 5}}, 2][1],
+        WolframModel[<|"PatternRules" -> ({{a_, b_}, {b_, c_}} :> {{a, c}})|>, {{1, 2}, {2, 3}, {3, 4}, {4, 5}}, 1][-1]
+      ],
+
+      VerificationTest[
+        WolframModel[<|"PatternRules" -> ({{a_, b_}, {b_, c_}} :> {{a, c}})|>, {{1, 2}, {2, 3}, {3, 4}, {4, 5}}, 2][-1],
+        {{1, 5}}
+      ],
+
+      VerificationTest[
+        WolframModel[{{1, 2}} -> {{1, 3}, {3, 2}}, {{1, 2}}, 10]["GenerationsCount"],
+        10
+      ],
+
+      VerificationTest[
+        WolframModel[{{1, 2}} -> {{1, 3}, {3, 2}}, {{1, 2}}, 10]["EventsCount"],
+        1023
+      ],
+
+      VerificationTest[
+        WolframModel[{{1}} -> {}, {{1}, {2}, {3}, {4}, {5}}, Infinity]["GenerationsCount"],
+        1
+      ],
+
+      VerificationTest[
+        WolframModel[{{1}} -> {}, {{1}, {2}, {3}, {4}, {5}}, Infinity]["EventsCount"],
+        5
+      ],
+
+      VerificationTest[
+        WolframModel[{{1}} -> {}, {{1}, {2}, {3}, {4}, {5}}, Infinity][-1],
+        {}
+      ],
+
+      VerificationTest[
+        WolframModel[{{1}} -> {{1}}, {{1}, {2}, {3}, {4}, {5}}, 0]["GenerationsCount"],
+        0
+      ],
+
+      VerificationTest[
+        WolframModel[{{1}} -> {{1}}, {{1}, {2}, {3}, {4}, {5}}, 0]["EventsCount"],
+        0
+      ],
+
+      VerificationTest[
+        WolframModel[
+          {{{1}} -> {}, {{1, 2}} -> {{1}}},
+          {{1, 2}, {2}, {3}, {4}, {5}},
+          2]["GenerationsCount"],
+        2
+      ],
+
+      VerificationTest[
+        WolframModel[
+          {{{1}} -> {}, {{1, 2}} -> {{1}}},
+          {{1, 2}, {2}, {3}, {4}, {5}},
+          2]["EventsCount"],
+        6
+      ],
+
+      VerificationTest[
+        WolframModel[
+          <|"PatternRules" -> {{{1}} -> {{2}}}|>,
+          {{1}, {1}, {1}},
+          1,
+          Method -> "LowLevel"],
+        WolframModel[
+          <|"PatternRules" -> {{{1}} -> {{2}}}|>,
+          {{1}, {1}, {1}},
+          1,
+          Method -> "Symbolic"]
+      ],
+
+      VerificationTest[
+        WolframModel[
+          {{v[1], v[2]}, {v[2], v[3]}} -> {{v[1], v[3]}},
+          {{v[1], v[2]}, {v[2], v[3]}},
+          "FinalState",
+          Method -> "Symbolic"],
+        {{v[1], v[3]}}
+      ],
+
+      VerificationTest[
+        WolframModel[
+          {{v[1], v[2]}, {v[2], v[3]}} -> {{v[1], v[3]}},
+          {{v[1], v[2]}, {v[2], v[3]}},
+          "FinalState",
+          Method -> "LowLevel"],
+        {{v[1], v[3]}}
+      ],
+
+      (** Nested lists as vertices **)
+
+      VerificationTest[
+        Head[
+          WolframModel[{{{2, 2, 1}, {2, 2, 2}} -> {{1, 1, 3}, {1, 1, 1}, {2, 1, 2}, {3, 3, 2}}}, {Table[{0, 0, 0}, 3]}, 2]],
+        WolframModelEvolutionObject
+      ],
+
+      VerificationTest[
+        WolframModel[
+          {{{2, 2, 1}, {2, 2, 2}} -> {{1, 1, 3}, {1, 1, 1}, {2, 1, 2}, {3, 3, 2}}},
+          {{{2}, {2}, 1}, {{2}, {2}, {2}}},
+          1,
+          "FinalState",
+          Method -> #],
+        {{1, 1, 2}, {1, 1, 1}, {{2}, 1, {2}}, {2, 2, {2}}}
+      ] & /@ $SetReplaceMethods,
+
+      VerificationTest[
+        WolframModel[{{{1, 1, 1}} -> {{1, 1, 1, 1}}}, {Table[{0, 0, 0}, 3]}, 2, "FinalState", Method -> #],
+        {ConstantArray[{0, 0, 0}, 4]}
+      ] & /@ $SetReplaceMethods,
+
+      (** NodeNamingFunction **)
+
+      VerificationTest[
+        WolframModel[
+          {{1, 3}} -> {{1, 2}, {2, 3}},
+          {{0, 0}},
+          2,
+          "FinalState"],
+        WolframModel[
+          {{1, 3}} -> {{1, 2}, {2, 3}},
+          {{0, 0}},
+          2,
+          "FinalState",
+          "NodeNamingFunction" -> Automatic]
+      ],
+
+      VerificationTest[
+        WolframModel[
+          {{1, 3}} -> {{1, 2}, {2, 3}},
+          {{0, 0}},
+          2,
+          "FinalState",
+          "NodeNamingFunction" -> Automatic],
+        {{0, 2}, {2, 1}, {1, 3}, {3, 0}}
+      ],
+
+      VerificationTest[
+        WolframModel[
+          {{1, 3}} -> {{1, 2}, {2, 3}},
+          {{2, 2}},
+          2,
+          "FinalState",
+          "NodeNamingFunction" -> Automatic],
+        {{2, 3}, {3, 1}, {1, 4}, {4, 2}}
+      ],
+
+      VerificationTest[
+        WolframModel[
+          {{1, 3}} -> {{1, 2}, {2, 3}},
+          {{0, 0}},
+          2,
+          "FinalState",
+          "NodeNamingFunction" -> All],
+        {{1, 3}, {3, 2}, {2, 4}, {4, 1}}
+      ],
+
+      VerificationTest[
+        WolframModel[
+          {{1, 3}} -> {{1, 2}, {2, 3}},
+          {{0, 0}},
+          2,
+          "FinalState",
+          "NodeNamingFunction" -> None],
+        {{0, x_Symbol}, {x_Symbol, y_Symbol}, {y_Symbol, z_Symbol}, {z_Symbol, 0}},
+        SameTest -> MatchQ
+      ],
+
+      VerificationTest[
+        WolframModel[
+          <|"PatternRules" -> {{a_, b_}} :> Module[{c}, {{a, c}, {c, b}}]|>,
+          {{0, 0}},
+          2,
+          "FinalState",
+          "NodeNamingFunction" -> All],
+        {{1, 3}, {3, 2}, {2, 4}, {4, 1}}
+      ],
+
+      VerificationTest[
+        WolframModel[
+          <|"PatternRules" -> {{a_, b_}} :> Module[{c}, {{a, c}, {c, b}}]|>,
+          {{0, 0}},
+          2,
+          "FinalState",
+          "NodeNamingFunction" -> #],
+        {{0, x_Symbol}, {x_Symbol, y_Symbol}, {y_Symbol, z_Symbol}, {z_Symbol, 0}},
+        SameTest -> MatchQ
+      ] & /@ {Automatic, None},
+
+      VerificationTest[
+        WolframModel[
+          <|"PatternRules" -> {{a_, b_}} :> Module[{c}, {{a, c}, {c, b}}]|>,
+          {{0, 0}},
+          2,
+          "FinalState"],
+        {{0, x_Symbol}, {x_Symbol, y_Symbol}, {y_Symbol, z_Symbol}, {z_Symbol, 0}},
+        SameTest -> MatchQ
+      ],
+
+      With[{namingTestModel = $namingTestModel}, {
+        VerificationTest[
+          # == Range[Length[#]] & @ Union @ Flatten[
+            WolframModel[##, "NodeNamingFunction" -> All] & @@
+              namingTestModel]
+        ],
+
+        VerificationTest[
+          # == Range[0, Length[#] - 1] & @ Union @ Flatten[
+            WolframModel[##, "NodeNamingFunction" -> Automatic] & @@
+              namingTestModel]
+        ],
+
+        VerificationTest[
+          (#[[1]] /. Thread[Rule @@ Flatten /@ #]) == #[[2]] & @ (Table[
+            WolframModel[##, "NodeNamingFunction" -> namingFunction] & @@ namingTestModel,
+            {namingFunction, {All, None}}])
+        ]
+      }],
+
+      (*** For anonymous rules, all level-2 expressions must be atomized, similar to ToPatternRules behavior ***)
+      VerificationTest[
+        WolframModel[
+          {{s[1], s[2]}} -> {{s[1], s[3]}, {s[3], s[2]}},
+          {{s[1], s[2]}},
+          1,
+          "FinalState",
+          "NodeNamingFunction" -> All],
+        {{1, 3}, {3, 2}}
+      ],
+
+      (** TimeConstraint **)
+
+      With[{timeConstraintRule = $timeConstraintRule, timeConstraintInit = $timeConstraintInit}, {
+        (*** Check that aborted evaluation still produces correct evolutions. ***)
+        Table[With[{method = method, time = time}, VerificationTest[
+          And @@ Table[
+            With[{
+                output =
+                  WolframModel[timeConstraintRule, timeConstraintInit, 100, Method -> method, TimeConstraint -> time]},
+              WolframModel[timeConstraintRule, timeConstraintInit, <|"Events" -> output["EventsCount"]|>] === output],
+            100],
+          TimeConstraint -> 60
+        ]], {method, $SetReplaceMethods}, {time, {1.*^-100, 0.1}}],
+
+        (*** This does not work with TimeConstrained though, $Aborted is returned in that case. ***)
+        VerificationTest[
+          TimeConstrained[WolframModel[timeConstraintRule, timeConstraintInit, 100, Method -> #], 0.1],
+          $Aborted
+        ] & /@ $SetReplaceMethods,
+
+        (*** $Aborted should be returned if not an evolution object is asked for. ***)
+        VerificationTest[
+          WolframModel[timeConstraintRule, timeConstraintInit, 100, "FinalState", Method -> #, TimeConstraint -> 0.1],
+          $Aborted
+        ] & /@ $SetReplaceMethods
+      }]
+    }
+  |>,
+
+  "$SetReplaceMethods" -> <|
+    "tests" -> {
+      VerificationTest[
+        ListQ[$SetReplaceMethods]
+      ],
+
+      VerificationTest[
+        AllTrue[
+          $SetReplaceMethods,
+          SetReplace[{{0}}, {{0}} -> {{1}}, Method -> #] === {{1}} &]
+      ]
+    }
+  |>,
+
+  "$WolframModelProperties" -> <|
+    "tests" -> {
+      VerificationTest[
+        ListQ[$WolframModelProperties]
+      ],
+
+      VerificationTest[
+        AllTrue[
+          $WolframModelProperties,
+          Head[WolframModel[{{0}} -> {{1}}, {{0}}, 1, #]] =!= WolframModel &]
+      ]
+    }
+  |>
+|>

--- a/SetReplace/WolframModelEvolutionObject.wlt
+++ b/SetReplace/WolframModelEvolutionObject.wlt
@@ -1,657 +1,630 @@
-BeginTestSection["WolframModelEvolutionObject"]
-
-(** Argument checks **)
-
-(* Corrupt object *)
-
-VerificationTest[
-  WolframModelEvolutionObject[],
-  WolframModelEvolutionObject[],
-  {WolframModelEvolutionObject::argx}
-]
-
-VerificationTest[
-  WolframModelEvolutionObject[<||>],
-  WolframModelEvolutionObject[<||>],
-  {WolframModelEvolutionObject::corrupt}
-]
-
-VerificationTest[
-  WolframModelEvolutionObject[<|a -> 1, b -> 2|>],
-  WolframModelEvolutionObject[<|a -> 1, b -> 2|>],
-  {WolframModelEvolutionObject::corrupt}
-]
-
-(* Incorrect property arguments *)
-
-VerificationTest[
-  WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    4]["$$$UnknownProperty$$$,,,"],
-  WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    4]["$$$UnknownProperty$$$,,,"],
-  {WolframModelEvolutionObject::unknownProperty}
-]
-
-VerificationTest[
-  WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    4]["GenerationsCount", 3],
-  WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    4]["GenerationsCount", 3],
-  {WolframModelEvolutionObject::pargx}
-]
-
-VerificationTest[
-  WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    4]["GenerationsCount", 3, 3],
-  WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    4]["GenerationsCount", 3, 3],
-  {WolframModelEvolutionObject::pargx}
-]
-
-VerificationTest[
-  WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    4]["Generation", 3, 3],
-  WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    4]["Generation", 3, 3],
-  {WolframModelEvolutionObject::pargx}
-]
-
-VerificationTest[
-  WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    4]["Generation"],
-  WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    4]["Generation"],
-  {WolframModelEvolutionObject::pargx}
-]
-
-VerificationTest[
-  WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    4]["SetAfterEvent"],
-  WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    4]["SetAfterEvent"],
-  {WolframModelEvolutionObject::pargx}
-]
-
-(* Incorrect step arguments *)
-
-VerificationTest[
-  WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    4]["SetAfterEvent", 16],
-  WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    4]["SetAfterEvent", 16],
-  {WolframModelEvolutionObject::eventTooLarge}
-]
-
-VerificationTest[
-  WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    4]["SetAfterEvent", -17],
-  WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    4]["SetAfterEvent", -17],
-  {WolframModelEvolutionObject::eventTooLarge}
-]
-
-VerificationTest[
-  WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    4]["SetAfterEvent", 1.2],
-  WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    4]["SetAfterEvent", 1.2],
-  {WolframModelEvolutionObject::eventNotInteger}
-]
-
-VerificationTest[
-  WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    4]["SetAfterEvent", "good"],
-  WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    4]["SetAfterEvent", "good"],
-  {WolframModelEvolutionObject::eventNotInteger}
-]
-
-(* Incorrect generation arguments *)
-
-VerificationTest[
-  WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    4]["Generation", 5],
-  WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    4]["Generation", 5],
-  {WolframModelEvolutionObject::generationTooLarge}
-]
-
-VerificationTest[
-  WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    4]["Generation", -6],
-  WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    4]["Generation", -6],
-  {WolframModelEvolutionObject::generationTooLarge}
-]
-
-VerificationTest[
-  WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    4]["Generation", 2.3],
-  WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    4]["Generation", 2.3],
-  {WolframModelEvolutionObject::generationNotInteger}
-]
-
-(** Boxes **)
-
-VerificationTest[
-  Head @ ToBoxes @ WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    4],
-  InterpretationBox
-]
-
-(** Implementation of properties **)
-
-(* Properties *)
-
-VerificationTest[
-  WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    4]["Properties"],
-  ListQ,
-  SameTest -> (#2[#1] &)
-]
-
-(* EvolutionObject *)
-
-VerificationTest[
-  WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    4]["EvolutionObject"],
-  WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    4]
-]
-
-(* Rules *)
-
-VerificationTest[
-  WolframModel[
-    <|"PatternRules" -> {{a_, b_}, {b_, c_}} :> {{a, c}}|>,
-    Partition[Range[17], 2, 1],
-    4]["Rules"],
-  <|"PatternRules" -> {{a_, b_}, {b_, c_}} :> {{a, c}}|>
-]
-
-VerificationTest[
-  WolframModel[
-    {{{1, 2}, {2, 3}} -> {{1, 3}}, {{1, 2}} -> {{1, 3}, {3, 2}}},
-    Partition[Range[17], 2, 1],
-    4]["Rules"],
-  {{{1, 2}, {2, 3}} -> {{1, 3}}, {{1, 2}} -> {{1, 3}, {3, 2}}}
-]
-
-VerificationTest[
-  WolframModel[1 -> 2, {1}, 4]["Rules"],
-  1 -> 2
-]
-
-(* GenerationsCount *)
-
-VerificationTest[
-  WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    4]["GenerationsCount"],
-  4
-]
-
-(* EventsCount *)
-
-VerificationTest[
-  WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    4]["EventsCount"],
-  15
-]
-
-(* SetAfterEvent *)
-
-VerificationTest[
-  WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    4]["SetAfterEvent", 0],
-  Partition[Range[17], 2, 1]
-]
-
-VerificationTest[
-  WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    4]["SetAfterEvent", 1],
-  Join[Partition[Range[3, 17], 2, 1], {{1, 3}}]
-]
-
-VerificationTest[
-  WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    4]["SetAfterEvent", 2],
-  Join[Partition[Range[5, 17], 2, 1], {{1, 3}, {3, 5}}]
-]
-
-VerificationTest[
-  WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    4]["SetAfterEvent", 14],
-  {{1, 9}, {9, 17}}
-]
-
-VerificationTest[
-  WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    4]["SetAfterEvent", -2],
-  WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    4]["SetAfterEvent", 14]
-]
-
-VerificationTest[
-  WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    4]["SetAfterEvent", 15],
-  {{1, 17}}
-]
-
-VerificationTest[
-  WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    4]["SetAfterEvent", -1],
-  WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    4]["SetAfterEvent", 15]
-]
-
-(* FinalState *)
-
-VerificationTest[
-  WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    4]["FinalState"],
-  WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    4]["SetAfterEvent", -1]
-]
-
-VerificationTest[
-  WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    0]["FinalState"],
-  Partition[Range[17], 2, 1]
-]
-
-(* UpdatedStatesList *)
-
-VerificationTest[
-  WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    4]["UpdatedStatesList"],
-  WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    4]["SetAfterEvent", #] & /@ Range[0, 15]
-]
-
-VerificationTest[
-  WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    0]["UpdatedStatesList"],
-  {Partition[Range[17], 2, 1]}
-]
-
-(* Generation *)
-
-VerificationTest[
-  WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    4]["Generation", 0],
-  Partition[Range[17], 2, 1]
-]
-
-VerificationTest[
-  WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    4]["Generation", 1],
-  Partition[Range[1, 17, 2], 2, 1]
-]
-
-VerificationTest[
-  WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    4]["Generation", 2],
-  Partition[Range[1, 17, 4], 2, 1]
-]
-
-VerificationTest[
-  WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    4]["Generation", 3],
-  {{1, 9}, {9, 17}}
-]
-
-VerificationTest[
-  WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    4]["Generation", -2],
-  WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    4]["Generation", 3]
-]
-
-VerificationTest[
-  WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    4]["Generation", 4],
-  {{1, 17}}
-]
-
-VerificationTest[
-  WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    4]["Generation", -1],
-  WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    4]["Generation", 4]
-]
-
-(* StatesList *)
-
-VerificationTest[
-  WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    4]["StatesList"],
-  WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    4]["Generation", #] & /@ Range[0, 4]
-]
-
-VerificationTest[
-  WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    0]["StatesList"],
-  {Partition[Range[17], 2, 1]}
-]
-
-(* AtomsCountFinal *)
-
-VerificationTest[
-  WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    4]["AtomsCountFinal"],
-  2
-]
-
-VerificationTest[
-  WolframModel[
-    1 -> 2,
-    {1},
-    5]["AtomsCountFinal"],
-  1
-]
-
-VerificationTest[
-  WolframModel[
-    1 -> 1,
-    {1},
-    5]["AtomsCountFinal"],
-  1
-]
-
-(* AtomsCountTotal *)
-
-VerificationTest[
-  WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    4]["AtomsCountTotal"],
-  17
-]
-
-VerificationTest[
-  WolframModel[
-    1 -> 2,
-    {1},
-    5]["AtomsCountTotal"],
-  6
-]
-
-VerificationTest[
-  WolframModel[
-    1 -> 1,
-    {1},
-    5]["AtomsCountTotal"],
-  1
-]
-
-(* ExpressionsCountFinal *)
-
-VerificationTest[
-  WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    4]["ExpressionsCountFinal"],
-  1
-]
-
-(* ExpressionsCountTotal *)
-
-VerificationTest[
-  WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    4]["ExpressionsCountTotal"],
-  16 + 8 + 4 + 2 + 1
-]
-
-(* CausalGraph *)
-
-VerificationTest[
-  WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    4]["CausalGraph", 1],
-   WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    4]["CausalGraph", 1],
-  {WolframModelEvolutionObject::nonopt}
-]
-
-VerificationTest[
-  WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    4]["CausalGraph", 1, "str" -> 3],
-   WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    4]["CausalGraph", 1, "str" -> 3],
-  {WolframModelEvolutionObject::nonopt}
-]
-
-VerificationTest[
-  WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    4]["CausalGraph", "BadOpt" -> "NotExist"],
-   WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    4]["CausalGraph", "BadOpt" -> "NotExist"],
-  {WolframModelEvolutionObject::optx}
-]
-
-VerificationTest[
-  WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    4]["CausalGraph"],
-  Graph[Range[15], {
-    1 -> 9, 2 -> 9, 3 -> 10, 4 -> 10, 5 -> 11, 6 -> 11, 7 -> 12, 8 -> 12,
-    9 -> 13, 10 -> 13, 11 -> 14, 12 -> 14,
-    13 -> 15, 14 -> 15
-  }]
-]
-
-VerificationTest[
-  WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    4]["CausalGraph", VertexLabels -> "Name", GraphLayout -> "SpringElectricalEmbedding"],
-  Graph[Range[15], {
-    1 -> 9, 2 -> 9, 3 -> 10, 4 -> 10, 5 -> 11, 6 -> 11, 7 -> 12, 8 -> 12,
-    9 -> 13, 10 -> 13, 11 -> 14, 12 -> 14,
-    13 -> 15, 14 -> 15
-  }, VertexLabels -> "Name", GraphLayout -> "SpringElectricalEmbedding"]
-]
-
-VerificationTest[
-  WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    1]["CausalGraph"],
-  Graph[Range[8], {}]
-]
-
-VerificationTest[
-  WolframModel[
-    {{1, 2}, {2, 3}} -> {{1, 3}},
-    Partition[Range[17], 2, 1],
-    2]["CausalGraph"],
-  Graph[Range[12], {1 -> 9, 2 -> 9, 3 -> 10, 4 -> 10, 5 -> 11, 6 -> 11, 7 -> 12, 8 -> 12}]
-]
-
-$largeEvolution = WolframModel[
-  {{0, 1}, {0, 2}, {0, 3}} ->
-    {{4, 5}, {5, 6}, {6, 4}, {4, 6}, {6, 5}, {5, 4},
-    {4, 1}, {5, 2}, {6, 3},
-    {1, 6}, {3, 4}},
-  {{0, 0}, {0, 0}, {0, 0}},
-  7];
-
-VerificationTest[
-  AcyclicGraphQ[$largeEvolution["CausalGraph"]]
-]
-
-VerificationTest[
-  LoopFreeGraphQ[$largeEvolution["CausalGraph"]]
-]
-
-VerificationTest[
-  Count[VertexInDegree[$largeEvolution["CausalGraph"]], 3],
-  $largeEvolution["EventsCount"] - 1
-]
-
-VerificationTest[
-  VertexCount[$largeEvolution["CausalGraph"]],
-  $largeEvolution["EventsCount"]
-]
-
-VerificationTest[
-  GraphDistance[$largeEvolution["CausalGraph"], 1, $largeEvolution["EventsCount"]],
-  $largeEvolution["GenerationsCount"] - 1
-]
-
-VerificationTest[
-  WolframModel[
-    {{0, 1}, {0, 2}, {0, 3}} ->
-      {{4, 5}, {5, 6}, {6, 4}, {4, 6}, {6, 5}, {5, 4},
-      {4, 1}, {5, 2}, {6, 3},
-      {1, 6}, {3, 4}},
-    {{0, 0}, {0, 0}, {0, 0}},
-    3,
-    Method -> "Symbolic"]["CausalGraph"],
-  WolframModel[
-    {{0, 1}, {0, 2}, {0, 3}} ->
-      {{4, 5}, {5, 6}, {6, 4}, {4, 6}, {6, 5}, {5, 4},
-      {4, 1}, {5, 2}, {6, 3},
-      {1, 6}, {3, 4}},
-    {{0, 0}, {0, 0}, {0, 0}},
-    3,
-    Method -> "LowLevel"]["CausalGraph"]
-]
-
-EndTestSection[]
+<|
+  "WolframModelEvolutionObject" -> <|
+    "init" -> (
+      Attributes[Global`testUnevaluated] = {HoldAll};
+      Global`testUnevaluated[args___] := SetReplace`PackageScope`testUnevaluated[VerificationTest, args];
+
+      $largeEvolution = Hold[WolframModel[
+        {{0, 1}, {0, 2}, {0, 3}} ->
+          {{4, 5}, {5, 6}, {6, 4}, {4, 6}, {6, 5}, {5, 4},
+          {4, 1}, {5, 2}, {6, 3},
+          {1, 6}, {3, 4}},
+        {{0, 0}, {0, 0}, {0, 0}},
+        7]];
+    ),
+    "tests" -> With[{pathGraph17 = Partition[Range[17], 2, 1]}, {
+      (** Argument checks **)
+
+      (* Corrupt object *)
+
+      testUnevaluated[
+        WolframModelEvolutionObject[],
+        {WolframModelEvolutionObject::argx}
+      ],
+
+      testUnevaluated[
+        WolframModelEvolutionObject[<||>],
+        {WolframModelEvolutionObject::corrupt}
+      ],
+
+      testUnevaluated[
+        WolframModelEvolutionObject[<|a -> 1, b -> 2|>],
+        {WolframModelEvolutionObject::corrupt}
+      ],
+
+      (* Incorrect property arguments *)
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4]["$$$UnknownProperty$$$,,,"],
+        WolframModelEvolutionObject[___]["$$$UnknownProperty$$$,,,"],
+        {WolframModelEvolutionObject::unknownProperty},
+        SameTest -> MatchQ
+      ],
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4]["GenerationsCount", 3],
+        WolframModelEvolutionObject[___]["GenerationsCount", 3],
+        {WolframModelEvolutionObject::pargx},
+        SameTest -> MatchQ
+      ],
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4]["GenerationsCount", 3, 3],
+        WolframModelEvolutionObject[___]["GenerationsCount", 3, 3],
+        {WolframModelEvolutionObject::pargx},
+        SameTest -> MatchQ
+      ],
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4]["Generation", 3, 3],
+        WolframModelEvolutionObject[___]["Generation", 3, 3],
+        {WolframModelEvolutionObject::pargx},
+        SameTest -> MatchQ
+      ],
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4]["Generation"],
+        WolframModelEvolutionObject[___]["Generation"],
+        {WolframModelEvolutionObject::pargx},
+        SameTest -> MatchQ
+      ],
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4]["SetAfterEvent"],
+        WolframModelEvolutionObject[___]["SetAfterEvent"],
+        {WolframModelEvolutionObject::pargx},
+        SameTest -> MatchQ
+      ],
+
+      (* Incorrect step arguments *)
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4]["SetAfterEvent", 16],
+        WolframModelEvolutionObject[___]["SetAfterEvent", 16],
+        {WolframModelEvolutionObject::eventTooLarge},
+        SameTest -> MatchQ
+      ],
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4]["SetAfterEvent", -17],
+        WolframModelEvolutionObject[___]["SetAfterEvent", -17],
+        {WolframModelEvolutionObject::eventTooLarge},
+        SameTest -> MatchQ
+      ],
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4]["SetAfterEvent", 1.2],
+        WolframModelEvolutionObject[___]["SetAfterEvent", 1.2],
+        {WolframModelEvolutionObject::eventNotInteger},
+        SameTest -> MatchQ
+      ],
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4]["SetAfterEvent", "good"],
+        WolframModelEvolutionObject[___]["SetAfterEvent", "good"],
+        {WolframModelEvolutionObject::eventNotInteger},
+        SameTest -> MatchQ
+      ],
+
+      (* Incorrect generation arguments *)
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4]["Generation", 5],
+        WolframModelEvolutionObject[___]["Generation", 5],
+        {WolframModelEvolutionObject::generationTooLarge},
+        SameTest -> MatchQ
+      ],
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4]["Generation", -6],
+        WolframModelEvolutionObject[___]["Generation", -6],
+        {WolframModelEvolutionObject::generationTooLarge},
+        SameTest -> MatchQ
+      ],
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4]["Generation", 2.3],
+        WolframModelEvolutionObject[___]["Generation", 2.3],
+        {WolframModelEvolutionObject::generationNotInteger},
+        SameTest -> MatchQ
+      ],
+
+      (** Boxes **)
+
+      VerificationTest[
+        Head @ ToBoxes @ WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4],
+        InterpretationBox
+      ],
+
+      (** Implementation of properties **)
+
+      (* Properties *)
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4]["Properties"],
+        _List,
+        SameTest -> MatchQ
+      ],
+
+      (* EvolutionObject *)
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4]["EvolutionObject"],
+        WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4]
+      ],
+
+      (* Rules *)
+
+      VerificationTest[
+        WolframModel[
+          <|"PatternRules" -> {{a_, b_}, {b_, c_}} :> {{a, c}}|>,
+          pathGraph17,
+          4]["Rules"],
+        <|"PatternRules" -> {{a_, b_}, {b_, c_}} :> {{a, c}}|>
+      ],
+
+      VerificationTest[
+        WolframModel[
+          {{{1, 2}, {2, 3}} -> {{1, 3}}, {{1, 2}} -> {{1, 3}, {3, 2}}},
+          pathGraph17,
+          4]["Rules"],
+        {{{1, 2}, {2, 3}} -> {{1, 3}}, {{1, 2}} -> {{1, 3}, {3, 2}}}
+      ],
+
+      VerificationTest[
+        WolframModel[1 -> 2, {1}, 4]["Rules"],
+        1 -> 2
+      ],
+
+      (* GenerationsCount *)
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4]["GenerationsCount"],
+        4
+      ],
+
+      (* EventsCount *)
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4]["EventsCount"],
+        15
+      ],
+
+      (* SetAfterEvent *)
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4]["SetAfterEvent", 0],
+        pathGraph17
+      ],
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4]["SetAfterEvent", 1],
+        Join[Partition[Range[3, 17], 2, 1], {{1, 3}}]
+      ],
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4]["SetAfterEvent", 2],
+        Join[Partition[Range[5, 17], 2, 1], {{1, 3}, {3, 5}}]
+      ],
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4]["SetAfterEvent", 14],
+        {{1, 9}, {9, 17}}
+      ],
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4]["SetAfterEvent", -2],
+        WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4]["SetAfterEvent", 14]
+      ],
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4]["SetAfterEvent", 15],
+        {{1, 17}}
+      ],
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4]["SetAfterEvent", -1],
+        WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4]["SetAfterEvent", 15]
+      ],
+
+      (* FinalState *)
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4]["FinalState"],
+        WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4]["SetAfterEvent", -1]
+      ],
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          0]["FinalState"],
+        pathGraph17
+      ],
+
+      (* UpdatedStatesList *)
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4]["UpdatedStatesList"],
+        WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4]["SetAfterEvent", #] & /@ Range[0, 15]
+      ],
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          0]["UpdatedStatesList"],
+        {pathGraph17}
+      ],
+
+      (* Generation *)
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4]["Generation", 0],
+        pathGraph17
+      ],
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4]["Generation", 1],
+        Partition[Range[1, 17, 2], 2, 1]
+      ],
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4]["Generation", 2],
+        Partition[Range[1, 17, 4], 2, 1]
+      ],
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4]["Generation", 3],
+        {{1, 9}, {9, 17}}
+      ],
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4]["Generation", -2],
+        WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4]["Generation", 3]
+      ],
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4]["Generation", 4],
+        {{1, 17}}
+      ],
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4]["Generation", -1],
+        WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4]["Generation", 4]
+      ],
+
+      (* StatesList *)
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4]["StatesList"],
+        WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4]["Generation", #] & /@ Range[0, 4]
+      ],
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          0]["StatesList"],
+        {pathGraph17}
+      ],
+
+      (* AtomsCountFinal *)
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4]["AtomsCountFinal"],
+        2
+      ],
+
+      VerificationTest[
+        WolframModel[
+          1 -> 2,
+          {1},
+          5]["AtomsCountFinal"],
+        1
+      ],
+
+      VerificationTest[
+        WolframModel[
+          1 -> 1,
+          {1},
+          5]["AtomsCountFinal"],
+        1
+      ],
+
+      (* AtomsCountTotal *)
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4]["AtomsCountTotal"],
+        17
+      ],
+
+      VerificationTest[
+        WolframModel[
+          1 -> 2,
+          {1},
+          5]["AtomsCountTotal"],
+        6
+      ],
+
+      VerificationTest[
+        WolframModel[
+          1 -> 1,
+          {1},
+          5]["AtomsCountTotal"],
+        1
+      ],
+
+      (* ExpressionsCountFinal *)
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4]["ExpressionsCountFinal"],
+        1
+      ],
+
+      (* ExpressionsCountTotal *)
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4]["ExpressionsCountTotal"],
+        16 + 8 + 4 + 2 + 1
+      ],
+
+      (* CausalGraph *)
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4]["CausalGraph", 1],
+        WolframModelEvolutionObject[___]["CausalGraph", 1],
+        {WolframModelEvolutionObject::nonopt},
+        SameTest -> MatchQ
+      ],
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4]["CausalGraph", 1, "str" -> 3],
+        WolframModelEvolutionObject[___]["CausalGraph", 1, "str" -> 3],
+        {WolframModelEvolutionObject::nonopt},
+        SameTest -> MatchQ
+      ],
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4]["CausalGraph", "BadOpt" -> "NotExist"],
+        WolframModelEvolutionObject[___]["CausalGraph", "BadOpt" -> "NotExist"],
+        {WolframModelEvolutionObject::optx},
+        SameTest -> MatchQ
+      ],
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4]["CausalGraph"],
+        Graph[Range[15], {
+          1 -> 9, 2 -> 9, 3 -> 10, 4 -> 10, 5 -> 11, 6 -> 11, 7 -> 12, 8 -> 12,
+          9 -> 13, 10 -> 13, 11 -> 14, 12 -> 14,
+          13 -> 15, 14 -> 15
+        }]
+      ],
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4]["CausalGraph", VertexLabels -> "Name", GraphLayout -> "SpringElectricalEmbedding"],
+        Graph[Range[15], {
+          1 -> 9, 2 -> 9, 3 -> 10, 4 -> 10, 5 -> 11, 6 -> 11, 7 -> 12, 8 -> 12,
+          9 -> 13, 10 -> 13, 11 -> 14, 12 -> 14,
+          13 -> 15, 14 -> 15
+        }, VertexLabels -> "Name", GraphLayout -> "SpringElectricalEmbedding"]
+      ],
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          1]["CausalGraph"],
+        Graph[Range[8], {}]
+      ],
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          Partition[Range[17], 2, 1],
+          2]["CausalGraph"],
+        Graph[Range[12], {1 -> 9, 2 -> 9, 3 -> 10, 4 -> 10, 5 -> 11, 6 -> 11, 7 -> 12, 8 -> 12}]
+      ],
+
+      With[{largeEvolution = $largeEvolution}, {
+        VerificationTest[
+          AcyclicGraphQ[ReleaseHold[largeEvolution["CausalGraph"]]]
+        ],
+
+        VerificationTest[
+          LoopFreeGraphQ[ReleaseHold[largeEvolution["CausalGraph"]]]
+        ],
+
+        VerificationTest[
+          Count[VertexInDegree[ReleaseHold[largeEvolution["CausalGraph"]]], 3],
+          ReleaseHold[largeEvolution["EventsCount"]] - 1
+        ],
+
+        VerificationTest[
+          VertexCount[ReleaseHold[largeEvolution["CausalGraph"]]],
+          ReleaseHold[largeEvolution["EventsCount"]]
+        ],
+
+        VerificationTest[
+          GraphDistance[ReleaseHold[largeEvolution["CausalGraph"]], 1, ReleaseHold[largeEvolution["EventsCount"]]],
+          ReleaseHold[largeEvolution["GenerationsCount"]] - 1
+        ]
+      }] /. HoldPattern[ReleaseHold[Hold[expr_]]] :> expr,
+
+      VerificationTest[
+        WolframModel[
+          {{0, 1}, {0, 2}, {0, 3}} ->
+            {{4, 5}, {5, 6}, {6, 4}, {4, 6}, {6, 5}, {5, 4},
+            {4, 1}, {5, 2}, {6, 3},
+            {1, 6}, {3, 4}},
+          {{0, 0}, {0, 0}, {0, 0}},
+          3,
+          Method -> "Symbolic"]["CausalGraph"],
+        WolframModel[
+          {{0, 1}, {0, 2}, {0, 3}} ->
+            {{4, 5}, {5, 6}, {6, 4}, {4, 6}, {6, 5}, {5, 4},
+            {4, 1}, {5, 2}, {6, 3},
+            {1, 6}, {3, 4}},
+          {{0, 0}, {0, 0}, {0, 0}},
+          3,
+          Method -> "LowLevel"]["CausalGraph"]
+      ]
+    }]
+  |>
+|>

--- a/SetReplace/correctness.wlt
+++ b/SetReplace/correctness.wlt
@@ -258,10 +258,10 @@
 
       (** Evaluation order **)
 
-      VerificationTest[
-        SetReplace[{{1}, {2}, {3}, {4}, {5}}, {{{2}, {3}, {4}} -> {{X}}, {{3}} -> {{X}}}, Method -> #],
+      {VerificationTest[
+        SetReplace[{{1}, {2}, {3}, {4}, {5}}, {{{2}, {3}, {4}} -> {{X}}, {{3}} -> {{X}}}],
         {{1}, {2}, {4}, {5}, {X}}
-      ] & /@ $methods,
+      ]},
 
       {VerificationTest[
         Table[

--- a/SetReplace/correctness.wlt
+++ b/SetReplace/correctness.wlt
@@ -123,7 +123,7 @@
             RandomSeeding -> ToString[{"randomDegenerateGraphMatchTest", edgeCount, edgeLength, graphCount, method}]]]
       ];
     ),
-    "tests" -> Join[
+    "tests" -> {
       (* Fixed number of events *)
 
       VerificationTest[
@@ -164,14 +164,14 @@
 
       (** Complex matching **)
 
-      Catenate[Table[With[{graph = graph, method = method}, VerificationTest[
+      Table[With[{graph = graph, method = method}, VerificationTest[
         SetReplace[
           graph,
           ToPatternRules[graph -> {}],
           1,
           Method -> method],
         {}
-      ]], {graph, $graphsForMatching}, {method, $methods}]],
+      ]], {graph, $graphsForMatching}, {method, $methods}],
 
       VerificationTest[
         SetReplace[
@@ -258,12 +258,12 @@
 
       (** Evaluation order **)
 
-      {VerificationTest[
+      VerificationTest[
         SetReplace[{{1}, {2}, {3}, {4}, {5}}, {{{2}, {3}, {4}} -> {{X}}, {{3}} -> {{X}}}],
         {{1}, {2}, {4}, {5}, {X}}
-      ]},
+      ],
 
-      {VerificationTest[
+      VerificationTest[
         Table[
           WolframModel[
               <|"PatternRules" -> {{{1, 2}, {2, 3}} -> {{R1}}, {{4, 5}, {5, 6}} -> {{R2}}}|>,
@@ -277,9 +277,9 @@
             R1, R1, R1, R2, R1, R2, R1, R1, R1, R2, R1, R2,
             R1, R2, R1, R2, R2, R2, R1, R2, R1, R2, R2, R2},
           2]
-      ]},
+      ],
 
-      {VerificationTest[
+      VerificationTest[
         Table[
           WolframModel[
               <|"PatternRules" -> {{1, 2, x_}, {1, 2, z_}} :> {{x, z}}|>,
@@ -292,9 +292,9 @@
         ConstantArray[
           {{x, y}, {x, z}, {y, x}, {y, z}, {z, x}, {z, y}},
           2]
-      ]},
+      ],
 
-      {VerificationTest[
+      VerificationTest[
         Table[
           WolframModel[
               <|"PatternRules" -> {
@@ -309,7 +309,7 @@
         ConstantArray[
           {{2, x, y}, {1, x, z}, {2, y, x}, {1, y, z}, {1, x, z}, {1, y, z}},
           2]
-      ]}
-    ]
+      ]
+    }
   |>
 |>

--- a/SetReplace/meta.wlt
+++ b/SetReplace/meta.wlt
@@ -1,38 +1,49 @@
-BeginTestSection["Meta"]
+<|
+  "meta" -> <|
+    "init" -> (
+      $testsDirectory = If[$TestFileName =!= "",
+        FileNameJoin[Most @ FileNameSplit @ $TestFileName],
+        FileNameJoin[Append[Most[FileNameSplit[$ScriptCommandLine[[1]]]], "SetReplace"]]
+      ];
+    ),
+    "tests" -> {
+      (* All public symbols have usage message *)
 
-(* All public symbols have usage message *)
+      VerificationTest[
+        AllTrue[
+          ReleaseHold[{Function[symbol, MessageName[symbol, "usage"], HoldFirst] /@
+            ("PackageExports" /. Package`PackageInformation["SetReplace`"])}],
+          StringQ]
+      ],
 
-VerificationTest[
-  AllTrue[
-    ReleaseHold[{Function[symbol, MessageName[symbol, "usage"], HoldFirst] /@
-      ("PackageExports" /. Package`PackageInformation["SetReplace`"])}],
-    StringQ]
-]
+      (* All public symbols have syntax information *)
 
-(* All public symbols have syntax information *)
+      VerificationTest[
+        AllTrue[
+          ReleaseHold[{Function[
+              symbol,
+              {SymbolName[Unevaluated[symbol]], SyntaxInformation[symbol]},
+              HoldFirst] /@
+            ("PackageExports" /. Package`PackageInformation["SetReplace`"])}],
+          If[StringStartsQ[#[[1]], "$"], #[[2]] === {}, #[[2]] =!= {}] &]
+      ],
 
-VerificationTest[
-  AllTrue[
-    ReleaseHold[{Function[
-        symbol,
-        {SymbolName[Unevaluated[symbol]], SyntaxInformation[symbol]},
-        HoldFirst] /@
-      ("PackageExports" /. Package`PackageInformation["SetReplace`"])}],
-    If[StringStartsQ[#[[1]], "$"], #[[2]] === {}, #[[2]] =!= {}] &]
-]
+      (* Test coverage: all public symbols appear in unit tests *)
 
-(* Test coverage: all public symbols appear in unit tests *)
-
-VerificationTest[
-  AllTrue[
-    ReleaseHold[{Function[
-        symbol,
-        SymbolName[Unevaluated[symbol]],
-        HoldFirst] /@
-      ("PackageExports" /. Package`PackageInformation["SetReplace`"])}],
-    StringContainsQ[StringJoin[Import[
-      FileNameJoin[Append[Most @ FileNameSplit @ $TestFileName, "*.wlt"]],
-      "Text"]], "BeginTestSection[\"" <> # <> "\"]"] &]
-]
-
-EndTestSection[]
+      With[{testsDirectory = $testsDirectory}, VerificationTest[
+        AllTrue[
+          ReleaseHold[{Function[
+              symbol,
+              SymbolName[Unevaluated[symbol]],
+              HoldFirst] /@
+            ("PackageExports" /. Package`PackageInformation["SetReplace`"])}],
+          StringContainsQ[StringJoin[Import[
+            FileNameJoin[Append[FileNameSplit @ testsDirectory, "*.wlt"]],
+            "Text"]], #] &]
+      ]]
+    },
+    "options" -> {
+      "Parallel" -> False
+    }
+  |>
+|>

--- a/SetReplace/performance.wlt
+++ b/SetReplace/performance.wlt
@@ -1,88 +1,96 @@
-BeginTestSection["performance"]
+<|
+  "performance" -> <|
+    "init" -> (
+      $init = {{0, 0}, {0, 0}, {0, 0}};
+      $rule =
+        {{{a_, b_}, {a_, c_}, {a_, d_}} :>
+          Module[{$0, $1, $2}, {
+            {$0, $1}, {$1, $2}, {$2, $0}, {$0, $2}, {$2, $1}, {$1, $0},
+            {$0, b}, {$1, c}, {$2, d}, {b, $2}, {d, $0}}]};
 
-(** C++ performance **)
+      $largeSet = Hold[WolframModel[
+        {{1, 2, 3}} -> {{5, 6, 1}, {6, 4, 2}, {4, 5, 3}},
+        {{0, 0, 0}},
+        7,
+        "FinalState"]];
 
-$init = {{0, 0}, {0, 0}, {0, 0}};
+      {$normalPlotTiming, $normalPlotMemory} =
+        AbsoluteTiming[MaxMemoryUsed[GraphPlot[Rule @@@ Catenate[Partition[#, 2, 1] & /@ ReleaseHold[$largeSet]]]]];
 
-$rule =
-  {{{a_, b_}, {a_, c_}, {a_, d_}} :>
-    Module[{$0, $1, $2}, {
-      {$0, $1}, {$1, $2}, {$2, $0}, {$0, $2}, {$2, $1}, {$1, $0},
-      {$0, b}, {$1, c}, {$2, d}, {b, $2}, {d, $0}}]};
+      $edgeTypes = {"Ordered", "Cyclic"};
+      $hyperedgeRenderings = {"Subgraphs", "Polygons"};
+    ),
+    "tests" -> {
+      With[{init = $init, rule = $rule}, {
+        (** C++ performance **)
+  
+          VerificationTest[
+            Head[SetReplace[
+              init,
+              rule,
+              1000]],
+            List,
+            TimeConstraint -> 10,
+            MemoryConstraint -> 5*^6
+          ],
+  
+          (** WL performance **)
+  
+          VerificationTest[
+            Head[SetReplace[
+              init,
+              rule,
+              100,
+              Method -> "Symbolic"]],
+            List,
+            TimeConstraint -> 60,
+            MemoryConstraint -> 5*^6
+          ],
+  
+          (** Naming function performance **)
+  
+          VerificationTest[
+            Head[WolframModel[
+              <|"PatternRules" -> rule|>,
+              init,
+              <|"Events" -> 1000|>,
+              "FinalState",
+              "NodeNamingFunction" -> All]],
+            List,
+            TimeConstraint -> 10,
+            MemoryConstraint -> 10*^6
+        ]
+      }],
 
-VerificationTest[
-  Head[SetReplace[
-    $init,
-    $rule,
-    1000]],
-  List,
-  TimeConstraint -> 3,
-  MemoryConstraint -> 5*^6
-]
+      (** C++ aborting **)
 
-(** WL performance **)
+      (* assumes example below runs slow, may need to be replaced in the future *)
+      VerificationTest[
+        (* it is possible for evaluation to finish slightly earlier than the constraint, hence the min of 0.8;
+           timing varies around +-0.05, so using tolerance 0.2 to avoid random failures *)
+        AbsoluteTiming[TimeConstrained[SetReplace[
+            {{0}},
+            ToPatternRules[{{{0}} -> {{0}, {0}, {0}}, {{0}, {0}, {0}} -> {{0}}}],
+            30], 1]][[1]],
+        1.0,
+        SameTest -> (Abs[#1 - #2] < 0.2 &),
+        TimeConstraint -> 3
+      ],
 
-VerificationTest[
-  Head[SetReplace[
-    $init,
-    $rule,
-    100,
-    Method -> "Symbolic"]],
-  List,
-  TimeConstraint -> 60,
-  MemoryConstraint -> 5*^6
-]
+      (** HypergraphPlot **)
 
-(** Naming function performance **)
-
-VerificationTest[
-  Head[WolframModel[
-    <|"PatternRules" -> $rule|>,
-    $init,
-    <|"Events" -> 1000|>,
-    "FinalState",
-    "NodeNamingFunction" -> All]],
-  List,
-  TimeConstraint -> 3,
-  MemoryConstraint -> 10*^6
-]
-
-(** C++ aborting **)
-
-(* assumes example below runs slow, may need to be replaced in the future *)
-VerificationTest[
-  (* it is possible for evaluation to finish slightly earlier than the constraint, hence the min of 0.8;
-     timing varies around +-0.05, so using tolerance 0.2 to avoid random failures *)
-  AbsoluteTiming[TimeConstrained[SetReplace[
-      {{0}},
-      ToPatternRules[{{{0}} -> {{0}, {0}, {0}}, {{0}, {0}, {0}} -> {{0}}}],
-      30], 1]][[1]],
-  1.0,
-  SameTest -> (Abs[#1 - #2] < 0.2 &),
-  TimeConstraint -> 3
-]
-
-(** HypergraphPlot **)
-
-$largeSet = WolframModel[
-  {{1, 2, 3}} -> {{5, 6, 1}, {6, 4, 2}, {4, 5, 3}},
-  {{0, 0, 0}},
-  7,
-  "FinalState"];
-
-{$normalPlotTiming, $normalPlotMemory} =
-  AbsoluteTiming[MaxMemoryUsed[GraphPlot[Rule @@@ Catenate[Partition[#, 2, 1] & /@ $largeSet]]]];
-
-$edgeTypes = {"Ordered", "Cyclic"};
-$hyperedgeRenderings = {"Subgraphs", "Polygons"};
-
-Table[
-  VerificationTest[
-    Head[HypergraphPlot[$largeSet, edgeType, "HyperedgeRendering" -> hyperedgeRendering]],
-    Graphics,
-    TimeConstraint -> (4 $normalPlotTiming),
-    MemoryConstraint -> (7 $normalPlotMemory)],
-  {edgeType, $edgeTypes},
-  {hyperedgeRendering, $hyperedgeRenderings}]
-
-EndTestSection[]
+      Table[
+        With[{edgeType = edgeType, hyperedgeRendering = hyperedgeRendering, $largeSet = $largeSet}, VerificationTest[
+          With[{largeSet = ReleaseHold[$largeSet]},
+          Head[HypergraphPlot[largeSet, edgeType, "HyperedgeRendering" -> hyperedgeRendering]]],
+          Graphics,
+          TimeConstraint -> (5 $normalPlotTiming),
+          MemoryConstraint -> (10 $normalPlotMemory)] /. HoldPattern[ReleaseHold[Hold[set_]]] -> set],
+        {edgeType, $edgeTypes},
+        {hyperedgeRendering, $hyperedgeRenderings}]
+    },
+    "options" -> {
+      "Parallel" -> False
+    }
+  |>
+|>

--- a/SetReplace/testUtilities.m
+++ b/SetReplace/testUtilities.m
@@ -2,11 +2,15 @@ Package["SetReplace`"]
 
 PackageScope["testUnevaluated"]
 
+(* VerificationTest should not directly appear here, as it is replaced by test.wls into other heads during evaluation.
+    Use testHead argument instead. *)
+
+(* It is necessary to compare strings because, i.e.,
+    MatchQ[<|x -> 1|>, HoldPattern[<|x -> 1|>]] returns False. *)
 Attributes[testUnevaluated] = {HoldAll};
-testUnevaluated[input_, messages_, opts___] :=
-  VerificationTest[
-    input,
-    HoldPattern[input],
+testUnevaluated[testHead_, input_, messages_, opts___] :=
+  testHead[
+    ToString[FullForm[input]],
+    StringReplace[ToString[FullForm[Hold[input]]], StartOfString ~~ "Hold[" ~~ expr___ ~~ "]" ~~ EndOfString :> expr],
     messages,
-    SameTest -> MatchQ,
     opts];

--- a/SetReplace/testUtilities.m
+++ b/SetReplace/testUtilities.m
@@ -1,0 +1,12 @@
+Package["SetReplace`"]
+
+PackageScope["testUnevaluated"]
+
+Attributes[testUnevaluated] = {HoldAll};
+testUnevaluated[input_, messages_, opts___] :=
+  VerificationTest[
+    input,
+    HoldPattern[input],
+    messages,
+    SameTest -> MatchQ,
+    opts];

--- a/build.wls
+++ b/build.wls
@@ -1,55 +1,51 @@
 #!/usr/bin/env wolframscript
-(* ::Package:: *)
 
-(* ::Text:: *)
-(*Create build directory*)
+<< CCompilerDriver`;
 
+$successQ = True;
 
-buildDirectory = FileNameJoin[{".", "Build"}];
-If[FileExistsQ[buildDirectory], DeleteDirectory[buildDirectory, DeleteContents -> True]];
-CreateDirectory[buildDirectory];
+(* If any messages are produced, fail with non-zero exit code. *)
+Check[
+	(*Create build directory*)
+	buildDirectory = FileNameJoin[{".", "Build"}];
+	If[FileExistsQ[buildDirectory], DeleteDirectory[buildDirectory, DeleteContents -> True]];
+	CreateDirectory[buildDirectory];
+	
+	(*Copy package files inside*)
+	files = Select[StringMatchQ[#, __ ~~ (".wl" | ".m")] &] @ Import["SetReplace/"];
+	CreateDirectory /@
+		Function[FileNameJoin[Join[{buildDirectory}, #]]] /@
+		Most /@
+		Select[Length[#] > 1 &][FileNameSplit /@ files];
+	CopyFile[FileNameJoin[{".", "SetReplace", #}], FileNameJoin[{buildDirectory, #}]] & /@
+		files;
+	
+	(*Build and copy library file*)
+	$TryEnvironment[var_, default_] := If[# === $Failed, default, #] & @ Environment[var];
+	
+	SetDirectory["SetReplace/libSetReplace"];
+	If[CreateLibrary[
+			{"Expression.cpp", "Match.cpp", "Set.cpp", "SetReplace.cpp"},
+			"libSetReplace",
+			"Language" -> "C++",
+			"CompileOptions" -> "-std=c++17",
+			"TargetDirectory" -> "../../Build/LibraryResources/" <> $SystemID,
+			"Compiler" -> ToExpression @ $TryEnvironment["COMPILER", Automatic],
+			"CompilerInstallation" -> $TryEnvironment["COMPILER_INSTALLATION", Automatic]
+		] === $Failed,
+		$successQ = False;
+		Print["Compilation failed. Paclet will be created without low level implementation."]];
+	SetDirectory["../.."];
+	
+	(*Pack paclet*)
+	PackPaclet[buildDirectory];,
 
+	$successQ = False;
+];
 
-(* ::Text:: *)
-(*Copy package files inside*)
-
-
-files = Select[StringMatchQ[#, __ ~~ (".wl" | ".m")] &] @ Import["SetReplace/"];
-CreateDirectory /@
-	Function[FileNameJoin[Join[{buildDirectory}, #]]] /@
-	Most /@
-	Select[Length[#] > 1 &][FileNameSplit /@ files];
-CopyFile[FileNameJoin[{".", "SetReplace", #}], FileNameJoin[{buildDirectory, #}]] & /@
-	files;
-
-
-(* ::Text:: *)
-(*Build and copy library file*)
-
-
-$TryEnvironment[var_, default_] := If[# === $Failed, default, #] & @ Environment[var]
-
-
-<< CCompilerDriver`
-SetDirectory["SetReplace/libSetReplace"];
-If[CreateLibrary[
-		{"Expression.cpp", "Match.cpp", "Set.cpp", "SetReplace.cpp"},
-		"libSetReplace",
-		"Language" -> "C++",
-		"CompileOptions" -> "-std=c++17",
-		"TargetDirectory" -> "../../Build/LibraryResources/" <> $SystemID,
-		"Compiler" -> ToExpression @ $TryEnvironment["COMPILER", Automatic],
-		"CompilerInstallation" -> $TryEnvironment["COMPILER_INSTALLATION", Automatic]
-	] === $Failed,
-	Print["Compilation failed. Paclet will be created without low level implementation."]];
-SetDirectory["../.."];
-
-
-(* ::Text:: *)
-(*Pack paclet*)
-
-
-PackPaclet[buildDirectory];
-
-
-Print["Done."];
+If[$successQ,
+	Print["Build done."];
+	Exit[0],
+	Print["Build failed."];
+	Exit[1]
+]

--- a/install.wls
+++ b/install.wls
@@ -1,22 +1,27 @@
 #!/usr/bin/env wolframscript
-(* ::Package:: *)
 
-pacletInfo = Association @@ Import[FileNameJoin[{".", "SetReplace", "PacletInfo.m"}]];
+$successQ = True;
 
+(* If any messages are produced, fail with non-zero exit code. *)
+Check[
+  pacletInfo = Association @@ Import[FileNameJoin[{".", "SetReplace", "PacletInfo.m"}]];
+    
+  filename = pacletInfo[Name] <> "-" <> pacletInfo[Version] <> ".paclet";
+  
+  If[!FileExistsQ[filename],
+  	Print[
+  		"The paclet file ", filename, " was not found. ",
+  		"Run ./build.wls."];
+  	Exit[1];
+  ];
+  
+  If[PacletInformation["SetReplace"] != {}, PacletUninstall["SetReplace"]];
+  
+  If[Head[PacletInstall[filename]] == Paclet,
+  	Print["Installed. Restart running kernels to complete installation."],
+    $successQ = False];,
 
-filename = pacletInfo[Name] <> "-" <> pacletInfo[Version] <> ".paclet";
+  $successQ = False;
+];
 
-
-If[!FileExistsQ[filename],
-	Print[
-		"The paclet file ", filename, " was not found. ",
-		"Run ./build.wls."];
-	Quit[];
-]
-
-
-If[PacletInformation["SetReplace"] != {}, PacletUninstall["SetReplace"]];
-
-
-If[Head[PacletInstall[filename]] == Paclet,
-	Print["Done. Restart running kernels to complete installation."]];
+Exit[If[$successQ, 0, 1]]

--- a/test.wls
+++ b/test.wls
@@ -50,7 +50,7 @@ $results = Association[KeyValueMap[Function[{testGroupName, testGroup}, Module[{
 	testList = ReleaseHold[testGroup["tests"] /. VerificationTest -> timeConstrainedTest];
 
 	(* Run tests in parallel *)
-	testResults = ParallelMap[# /. test -> VerificationTest &, testList];
+	testResults = Flatten[ParallelMap[# /. test -> VerificationTest &, testList]];
 	testReport = TestReport[testResults];
 
 	$redColor = "\033[0;31m";

--- a/test.wls
+++ b/test.wls
@@ -29,11 +29,17 @@ Check[
 		KeyMap[ReleaseHold, #] & /@
 			ReleaseHold @ Map[Hold, ToExpression[Import[#, "Text"], InputForm, Hold], {5}] & /@ $testFiles);
 	
-	Attributes[test] = Attributes[timeConstrainedTest] = {HoldAll};
+	Attributes[test] = Attributes[constrainedTest] = {HoldAll};
 	
 	$singleTestTimeConstraint = 300;
-	timeConstrainedTest[args___] :=
-		If[FreeQ[Hold[{args}], TimeConstraint], test[args, TimeConstraint -> $singleTestTimeConstraint], test[args]];
+	$singleTestMemoryConstraint = 1*^9;
+	constrainedTest[args___] := With[{
+			timeConstraintOpt =
+				If[FreeQ[Hold[{args}], TimeConstraint], {TimeConstraint -> $singleTestTimeConstraint}, {}],
+			memoryConstraintOpt =
+				If[FreeQ[Hold[{args}], MemoryConstraint], {MemoryConstraint -> $singleTestMemoryConstraint}, {}]},
+		test[args, ##] & @@ Join[timeConstraintOpt, memoryConstraintOpt]
+	];
 		
 	removeHoldFormFromInputString[input_String] := StringReplace[
 		input,
@@ -52,12 +58,12 @@ Check[
 		parallelQ = Lookup[options, "Parallel", True];
 
 		(* Run init, changing VerificationTest to test in all definitions *)
-		runInit[] := ReleaseHold[testGroup["init"] /. VerificationTest -> timeConstrainedTest];
+		runInit[] := ReleaseHold[testGroup["init"] /. VerificationTest -> constrainedTest];
 		runInit[];
 		If[parallelQ, ParallelEvaluate[runInit[]]];
 	
 		(* Make a list of tests, but don't run them yet *)
-		testList = ReleaseHold[testGroup["tests"] /. VerificationTest -> timeConstrainedTest];
+		testList = ReleaseHold[testGroup["tests"] /. VerificationTest -> constrainedTest];
 	
 		(* Run tests in parallel *)
 		testResults = Flatten[If[parallelQ, ParallelMap, Map][# /. test -> VerificationTest &, testList]];

--- a/test.wls
+++ b/test.wls
@@ -1,59 +1,116 @@
 #!/usr/bin/env wolframscript
-(* ::Package:: *)
 
-<< SetReplace`
-
-
-(* ::Text:: *)
-(*Launch kernels preemptively to avoid "Launching kernels..." interrupting test log*)
-
-
+<< SetReplace`;
+(* Launch kernels preemptively to avoid "Launching kernels..." interrupting test log *)
 CloseKernels[];
 LaunchKernels[];
-ParallelEvaluate[<< SetReplace`]
+ParallelEvaluate[<< SetReplace`];
 
+(* Get test files *)
 
-(* ::Text:: *)
-(*Find all test files*)
-
-
-testFiles = If[Length @ $ScriptCommandLine >= 2,
+$testFiles = If[Length @ $ScriptCommandLine >= 2,
 	FileNameJoin[{".", "SetReplace", # <> ".wlt"}] & /@ $ScriptCommandLine[[2 ;; ]],
 	FileNames[FileNameJoin[{".", "SetReplace", "*.wlt"}]]
 ];
 
-
 If[!FileExistsQ[#],
 	Print["Test file ", #, " does not exist."];
-	Quit[];] & /@ testFiles
+	Exit[1];] & /@ $testFiles;
 
+(* Read tests *)
 
-(* ::Text:: *)
-(*Run tests in each file*)
+$testGroups = Join @@ (
+	KeyMap[ReleaseHold, #] & /@
+		ReleaseHold @ Map[Hold, ToExpression[Import[#, "Text"], InputForm, Hold], {5}] & /@ $testFiles);
 
+Attributes[test] = Attributes[timeConstrainedTest] = {HoldAll};
 
-results = AssociationMap[Module[{report, filename},
+$singleTestTimeConstraint = 300;
+timeConstrainedTest[args___] := test[args, TimeConstraint -> $singleTestTimeConstraint];
+
+$successQ = True;
+
+removeHoldFormFromInputString[input_String] := StringReplace[
+	input,
+	StartOfString ~~ "HoldForm[" ~~ expr__ ~~ "]" ~~ EndOfString :> expr
+];
+
+$results = Association[KeyValueMap[Function[{testGroupName, testGroup}, Module[{testList, testResults, testReport},
+	(* Notify the user which test group we are running *)
 	WriteString["stdout",
-		filename = Last @ FileNameSplit[#],
-		StringJoin[ConstantArray[" ", Max[40 - StringLength[filename], 1]]]];
-	report = TestReport[#, TimeConstraint -> 60];
-	WriteString["stdout", If[report["AllTestsSucceeded"],
-		"\033[0;32m[ok]\033[0m",
+		testGroupName,
+		StringJoin[ConstantArray[" ", Max[40 - StringLength[testGroupName], 1]]]];
+
+	(* Run init, changing VerificationTest to test in all definitions *)
+	runInit[] := ReleaseHold[testGroup["init"] /. VerificationTest -> timeConstrainedTest];
+	runInit[];
+	ParallelEvaluate[runInit[]];
+
+	(* Make a list of tests, but don't run them yet *)
+	testList = ReleaseHold[testGroup["tests"] /. VerificationTest -> timeConstrainedTest];
+
+	(* Run tests in parallel *)
+	testResults = ParallelMap[# /. test -> VerificationTest &, testList];
+	testReport = TestReport[testResults];
+
+	$redColor = "\033[0;31m";
+	$greenColor = "\033[0;32m";
+	$orangeColor = "\033[0;33m";
+	$yellowColor = "\033[1;33m";
+	$endColor = "\033[0m";
+
+	(* Print the summery (green if ok, red if failed) *)
+	WriteString["stdout", If[testReport["AllTestsSucceeded"],
+		$greenColor <> "[ok]" <> $endColor,
 		StringJoin[
-			"\033[0;31m[",
-			ToString @ report["TestsFailedCount"],
+			$redColor <> "[",
+			ToString @ testReport["TestsFailedCount"],
 			"/",
-			ToString @ Length @ report["TestResults"],
-			" failed]\033[0m"]], "\n"];
-	report
-] &, testFiles]
+			ToString @ Length @ testReport["TestResults"],
+			" failed]" <> $endColor]], "\n"];
 
+	(* If tests failed, print why *)
+	failedTests = Join @@ testReport["TestsFailed"];
+	If[Length[failedTests] > 0, $successQ = False];
+	Switch[#["Outcome"],
+		"Failure",
+			WriteString["stdout",
+				$redColor <> "Input" <> $endColor <> "\n",
+				">> ", removeHoldFormFromInputString[ToString[#["Input"], InputForm]], "\n",
+				$redColor <> "evaluated to" <> $endColor <> "\n",
+				">> ", ToString[#["ActualOutput"], OutputForm], "\n",
+				$redColor <> "instead of expected " <> $endColor <> "\n",
+				">> ", ToString[#["ExpectedOutput"], OutputForm], "\n\n"],
+		"MessagesFailure",
+			WriteString["stdout",
+				$orangeColor <> "Input" <> $endColor <> "\n",
+				">> ", removeHoldFormFromInputString[ToString[#["Input"], InputForm]], "\n",
+				$orangeColor <> "generated messages" <> $endColor <> "\n",
+				">> ", ToString[#["ActualMessages"], OutputForm], "\n",
+				$orangeColor <> "instead of expected" <> $endColor <> "\n",
+				">> ", ToString[#["ExpectedMessages"], OutputForm], "\n\n"],
+		"Error",
+			WriteString["stdout",
+				$yellowColor <> "Error while evaluating the test with input" <> $endColor <> "\n",
+				">> ", removeHoldFormFromInputString[ToString[#["Input"], InputForm]], "\n\n"]
+	] & /@ failedTests[[1 ;; UpTo[3]]];
 
-(* ::Text:: *)
-(*Create a notebook with results*)
+	(* If too many tests have failed, print how many remain *)
+	If[Length[failedTests] > 3,
+		WriteString["stdout",
+			"Omitting remaining ",
+			Length[failedTests] - 3,
+			" " <> testGroupName,
+			" test failures.\n\n"]
+	];
 
+	(* Return the report, we'll need it later *)
+	testGroupName -> testReport
+]], $testGroups]];
 
-reportFile = UsingFrontEnd @ Export[
+(* Create a notebook with results *)
+
+$reportFile = UsingFrontEnd @ Export[
 	FileNameJoin[Join[FileNameSplit[CreateDirectory[]], {"testReport.nb"}]],
 	Notebook @ Catenate @ Prepend[KeyValueMap[
 		{Cell[Last @ FileNameSplit @ #1, "Section"],
@@ -61,7 +118,9 @@ reportFile = UsingFrontEnd @ Export[
 				BoxData[RowBox[{"TestReport", "[", "\"" <> #1 <> "\"", "]"}]],
 				"Input"],
 			Cell[BoxData[ToBoxes[#2]], "Output"]} &,
-		results], {Cell["SetReplace Test Report", "Title"]}]];
+		$results], {Cell["SetReplace Test Report", "Title"]}]];
 
 
-Print["Report file: ", reportFile];
+Print["Report file: ", $reportFile];
+
+Exit[If[$successQ, 0, 1]]

--- a/test.wls
+++ b/test.wls
@@ -40,7 +40,7 @@ Check[
 				If[FreeQ[Hold[{args}], MemoryConstraint], {MemoryConstraint -> $singleTestMemoryConstraint}, {}]},
 		test[args, ##] & @@ Join[timeConstraintOpt, memoryConstraintOpt]
 	];
-		
+
 	removeHoldFormFromInputString[input_String] := StringReplace[
 		input,
 		StartOfString ~~ "HoldForm[" ~~ expr__ ~~ "]" ~~ EndOfString :> expr
@@ -63,10 +63,10 @@ Check[
 		If[parallelQ, ParallelEvaluate[runInit[]]];
 	
 		(* Make a list of tests, but don't run them yet *)
-		testList = ReleaseHold[testGroup["tests"] /. VerificationTest -> constrainedTest];
+		testList = Flatten[ReleaseHold[testGroup["tests"] /. VerificationTest -> constrainedTest]];
 	
 		(* Run tests in parallel *)
-		testResults = Flatten[If[parallelQ, ParallelMap, Map][# /. test -> VerificationTest &, testList]];
+		testResults = If[parallelQ, ParallelMap, Map][# /. test -> VerificationTest &, testList];
 		testReport = TestReport[testResults];
 	
 		$redColor = "\033[0;31m";

--- a/test.wls
+++ b/test.wls
@@ -32,7 +32,8 @@ Check[
 	Attributes[test] = Attributes[timeConstrainedTest] = {HoldAll};
 	
 	$singleTestTimeConstraint = 300;
-	timeConstrainedTest[args___] := test[args, TimeConstraint -> $singleTestTimeConstraint];
+	timeConstrainedTest[args___] :=
+		If[FreeQ[Hold[{args}], TimeConstraint], test[args, TimeConstraint -> $singleTestTimeConstraint], test[args]];
 		
 	removeHoldFormFromInputString[input_String] := StringReplace[
 		input,

--- a/test.wls
+++ b/test.wls
@@ -1,126 +1,138 @@
 #!/usr/bin/env wolframscript
 
+(* Disable messages about outdated cloud. *)
+Off[CloudConnect::clver];
+
 << SetReplace`;
 (* Launch kernels preemptively to avoid "Launching kernels..." interrupting test log *)
 CloseKernels[];
 LaunchKernels[];
 ParallelEvaluate[<< SetReplace`];
 
-(* Get test files *)
-
-$testFiles = If[Length @ $ScriptCommandLine >= 2,
-	FileNameJoin[{".", "SetReplace", # <> ".wlt"}] & /@ $ScriptCommandLine[[2 ;; ]],
-	FileNames[FileNameJoin[{".", "SetReplace", "*.wlt"}]]
-];
-
-If[!FileExistsQ[#],
-	Print["Test file ", #, " does not exist."];
-	Exit[1];] & /@ $testFiles;
-
-(* Read tests *)
-
-$testGroups = Join @@ (
-	KeyMap[ReleaseHold, #] & /@
-		ReleaseHold @ Map[Hold, ToExpression[Import[#, "Text"], InputForm, Hold], {5}] & /@ $testFiles);
-
-Attributes[test] = Attributes[timeConstrainedTest] = {HoldAll};
-
-$singleTestTimeConstraint = 300;
-timeConstrainedTest[args___] := test[args, TimeConstraint -> $singleTestTimeConstraint];
-
 $successQ = True;
 
-removeHoldFormFromInputString[input_String] := StringReplace[
-	input,
-	StartOfString ~~ "HoldForm[" ~~ expr__ ~~ "]" ~~ EndOfString :> expr
+Check[
+	(* Get test files *)
+	
+	$testFiles = If[Length @ $ScriptCommandLine >= 2,
+		FileNameJoin[{".", "SetReplace", # <> ".wlt"}] & /@ $ScriptCommandLine[[2 ;; ]],
+		FileNames[FileNameJoin[{".", "SetReplace", "*.wlt"}]]
+	];
+	
+	If[!FileExistsQ[#],
+		Print["Test file ", #, " does not exist."];
+		Exit[1];] & /@ $testFiles;
+	
+	(* Read tests *)
+	
+	$testGroups = Join @@ (
+		KeyMap[ReleaseHold, #] & /@
+			ReleaseHold @ Map[Hold, ToExpression[Import[#, "Text"], InputForm, Hold], {5}] & /@ $testFiles);
+	
+	Attributes[test] = Attributes[timeConstrainedTest] = {HoldAll};
+	
+	$singleTestTimeConstraint = 300;
+	timeConstrainedTest[args___] := test[args, TimeConstraint -> $singleTestTimeConstraint];
+		
+	removeHoldFormFromInputString[input_String] := StringReplace[
+		input,
+		StartOfString ~~ "HoldForm[" ~~ expr__ ~~ "]" ~~ EndOfString :> expr
+	];
+	
+	$results = Association[KeyValueMap[Function[{testGroupName, testGroup}, Module[{testList, testResults, testReport},
+		(* Notify the user which test group we are running *)
+		WriteString["stdout",
+			testGroupName,
+			StringJoin[ConstantArray[" ", Max[40 - StringLength[testGroupName], 1]]]];
+	
+		(* Run init, changing VerificationTest to test in all definitions *)
+		runInit[] := ReleaseHold[testGroup["init"] /. VerificationTest -> timeConstrainedTest];
+		runInit[];
+		ParallelEvaluate[runInit[]];
+	
+		(* Make a list of tests, but don't run them yet *)
+		testList = ReleaseHold[testGroup["tests"] /. VerificationTest -> timeConstrainedTest];
+	
+		(* Run tests in parallel *)
+		testResults = Flatten[ParallelMap[# /. test -> VerificationTest &, testList]];
+		testReport = TestReport[testResults];
+	
+		$redColor = "\033[0;31m";
+		$greenColor = "\033[0;32m";
+		$orangeColor = "\033[0;33m";
+		$yellowColor = "\033[1;33m";
+		$endColor = "\033[0m";
+	
+		(* Print the summery (green if ok, red if failed) *)
+		WriteString["stdout", If[testReport["AllTestsSucceeded"],
+			$greenColor <> "[ok]" <> $endColor,
+			StringJoin[
+				$redColor <> "[",
+				ToString @ testReport["TestsFailedCount"],
+				"/",
+				ToString @ Length @ testReport["TestResults"],
+				" failed]" <> $endColor]], "\n"];
+	
+		(* If tests failed, print why *)
+		failedTests = Join @@ testReport["TestsFailed"];
+		If[Length[failedTests] > 0, $successQ = False];
+		Switch[#["Outcome"],
+			"Failure",
+				WriteString["stdout",
+					$redColor <> "Input" <> $endColor <> "\n",
+					">> ", removeHoldFormFromInputString[ToString[#["Input"], InputForm]], "\n",
+					$redColor <> "evaluated to" <> $endColor <> "\n",
+					">> ", ToString[#["ActualOutput"], OutputForm], "\n",
+					$redColor <> "instead of expected " <> $endColor <> "\n",
+					">> ", ToString[#["ExpectedOutput"], OutputForm], "\n\n"],
+			"MessagesFailure",
+				WriteString["stdout",
+					$orangeColor <> "Input" <> $endColor <> "\n",
+					">> ", removeHoldFormFromInputString[ToString[#["Input"], InputForm]], "\n",
+					$orangeColor <> "generated messages" <> $endColor <> "\n",
+					">> ", ToString[#["ActualMessages"], OutputForm], "\n",
+					$orangeColor <> "instead of expected" <> $endColor <> "\n",
+					">> ", ToString[#["ExpectedMessages"], OutputForm], "\n\n"],
+			"Error",
+				WriteString["stdout",
+					$yellowColor <> "Error while evaluating the test with input" <> $endColor <> "\n",
+					">> ", removeHoldFormFromInputString[ToString[#["Input"], InputForm]], "\n\n"]
+		] & /@ failedTests[[1 ;; UpTo[3]]];
+	
+		(* If too many tests have failed, print how many remain *)
+		If[Length[failedTests] > 3,
+			WriteString["stdout",
+				"Omitting remaining ",
+				Length[failedTests] - 3,
+				" " <> testGroupName,
+				" test failures.\n\n"]
+		];
+	
+		(* Return the report, we'll need it later *)
+		testGroupName -> testReport
+	]], $testGroups]];
+	
+	(* Create a notebook with results *)
+	
+	$reportFile = UsingFrontEnd @ Export[
+		FileNameJoin[Join[FileNameSplit[CreateDirectory[]], {"testReport.nb"}]],
+		Notebook @ Catenate @ Prepend[KeyValueMap[
+			{Cell[Last @ FileNameSplit @ #1, "Section"],
+				Cell[
+					BoxData[RowBox[{"TestReport", "[", "\"" <> #1 <> "\"", "]"}]],
+					"Input"],
+				Cell[BoxData[ToBoxes[#2]], "Output"]} &,
+			$results], {Cell["SetReplace Test Report", "Title"]}]];
+	
+	
+	Print["Report file: ", $reportFile];,
+
+	$successQ = False;
 ];
 
-$results = Association[KeyValueMap[Function[{testGroupName, testGroup}, Module[{testList, testResults, testReport},
-	(* Notify the user which test group we are running *)
-	WriteString["stdout",
-		testGroupName,
-		StringJoin[ConstantArray[" ", Max[40 - StringLength[testGroupName], 1]]]];
-
-	(* Run init, changing VerificationTest to test in all definitions *)
-	runInit[] := ReleaseHold[testGroup["init"] /. VerificationTest -> timeConstrainedTest];
-	runInit[];
-	ParallelEvaluate[runInit[]];
-
-	(* Make a list of tests, but don't run them yet *)
-	testList = ReleaseHold[testGroup["tests"] /. VerificationTest -> timeConstrainedTest];
-
-	(* Run tests in parallel *)
-	testResults = Flatten[ParallelMap[# /. test -> VerificationTest &, testList]];
-	testReport = TestReport[testResults];
-
-	$redColor = "\033[0;31m";
-	$greenColor = "\033[0;32m";
-	$orangeColor = "\033[0;33m";
-	$yellowColor = "\033[1;33m";
-	$endColor = "\033[0m";
-
-	(* Print the summery (green if ok, red if failed) *)
-	WriteString["stdout", If[testReport["AllTestsSucceeded"],
-		$greenColor <> "[ok]" <> $endColor,
-		StringJoin[
-			$redColor <> "[",
-			ToString @ testReport["TestsFailedCount"],
-			"/",
-			ToString @ Length @ testReport["TestResults"],
-			" failed]" <> $endColor]], "\n"];
-
-	(* If tests failed, print why *)
-	failedTests = Join @@ testReport["TestsFailed"];
-	If[Length[failedTests] > 0, $successQ = False];
-	Switch[#["Outcome"],
-		"Failure",
-			WriteString["stdout",
-				$redColor <> "Input" <> $endColor <> "\n",
-				">> ", removeHoldFormFromInputString[ToString[#["Input"], InputForm]], "\n",
-				$redColor <> "evaluated to" <> $endColor <> "\n",
-				">> ", ToString[#["ActualOutput"], OutputForm], "\n",
-				$redColor <> "instead of expected " <> $endColor <> "\n",
-				">> ", ToString[#["ExpectedOutput"], OutputForm], "\n\n"],
-		"MessagesFailure",
-			WriteString["stdout",
-				$orangeColor <> "Input" <> $endColor <> "\n",
-				">> ", removeHoldFormFromInputString[ToString[#["Input"], InputForm]], "\n",
-				$orangeColor <> "generated messages" <> $endColor <> "\n",
-				">> ", ToString[#["ActualMessages"], OutputForm], "\n",
-				$orangeColor <> "instead of expected" <> $endColor <> "\n",
-				">> ", ToString[#["ExpectedMessages"], OutputForm], "\n\n"],
-		"Error",
-			WriteString["stdout",
-				$yellowColor <> "Error while evaluating the test with input" <> $endColor <> "\n",
-				">> ", removeHoldFormFromInputString[ToString[#["Input"], InputForm]], "\n\n"]
-	] & /@ failedTests[[1 ;; UpTo[3]]];
-
-	(* If too many tests have failed, print how many remain *)
-	If[Length[failedTests] > 3,
-		WriteString["stdout",
-			"Omitting remaining ",
-			Length[failedTests] - 3,
-			" " <> testGroupName,
-			" test failures.\n\n"]
-	];
-
-	(* Return the report, we'll need it later *)
-	testGroupName -> testReport
-]], $testGroups]];
-
-(* Create a notebook with results *)
-
-$reportFile = UsingFrontEnd @ Export[
-	FileNameJoin[Join[FileNameSplit[CreateDirectory[]], {"testReport.nb"}]],
-	Notebook @ Catenate @ Prepend[KeyValueMap[
-		{Cell[Last @ FileNameSplit @ #1, "Section"],
-			Cell[
-				BoxData[RowBox[{"TestReport", "[", "\"" <> #1 <> "\"", "]"}]],
-				"Input"],
-			Cell[BoxData[ToBoxes[#2]], "Output"]} &,
-		$results], {Cell["SetReplace Test Report", "Title"]}]];
-
-
-Print["Report file: ", $reportFile];
-
-Exit[If[$successQ, 0, 1]]
+If[$successQ,
+	Print["Tests passed."];
+	Exit[0],
+	Print["Tests failed."];
+	Exit[1]
+]

--- a/test.wls
+++ b/test.wls
@@ -39,22 +39,27 @@ Check[
 		StartOfString ~~ "HoldForm[" ~~ expr__ ~~ "]" ~~ EndOfString :> expr
 	];
 	
-	$results = Association[KeyValueMap[Function[{testGroupName, testGroup}, Module[{testList, testResults, testReport},
+	$results = Association[KeyValueMap[Function[{testGroupName, testGroup}, Module[{
+			testList, testResults, testReport, options, parallelQ},
 		(* Notify the user which test group we are running *)
 		WriteString["stdout",
 			testGroupName,
 			StringJoin[ConstantArray[" ", Max[40 - StringLength[testGroupName], 1]]]];
 	
+		(* Read options *)
+		options = Association[ReleaseHold[Lookup[testGroup, "options", <||>]]];
+		parallelQ = Lookup[options, "Parallel", True];
+
 		(* Run init, changing VerificationTest to test in all definitions *)
 		runInit[] := ReleaseHold[testGroup["init"] /. VerificationTest -> timeConstrainedTest];
 		runInit[];
-		ParallelEvaluate[runInit[]];
+		If[parallelQ, ParallelEvaluate[runInit[]]];
 	
 		(* Make a list of tests, but don't run them yet *)
 		testList = ReleaseHold[testGroup["tests"] /. VerificationTest -> timeConstrainedTest];
 	
 		(* Run tests in parallel *)
-		testResults = Flatten[ParallelMap[# /. test -> VerificationTest &, testList]];
+		testResults = Flatten[If[parallelQ, ParallelMap, Map][# /. test -> VerificationTest &, testList]];
 		testReport = TestReport[testResults];
 	
 		$redColor = "\033[0;31m";

--- a/test.wls
+++ b/test.wls
@@ -45,9 +45,9 @@ Check[
 		input,
 		StartOfString ~~ "HoldForm[" ~~ expr__ ~~ "]" ~~ EndOfString :> expr
 	];
-	
+
 	$results = Association[KeyValueMap[Function[{testGroupName, testGroup}, Module[{
-			testList, testResults, testReport, options, parallelQ},
+			testList, testResults, testReport, options, parallelQ, runInit, failedTests},
 		(* Notify the user which test group we are running *)
 		WriteString["stdout",
 			testGroupName,
@@ -78,6 +78,7 @@ Check[
 		(* Print the summery (green if ok, red if failed) *)
 		WriteString["stdout", If[testReport["AllTestsSucceeded"],
 			$greenColor <> "[ok]" <> $endColor,
+			$successQ = False;
 			StringJoin[
 				$redColor <> "[",
 				ToString @ testReport["TestsFailedCount"],
@@ -87,7 +88,6 @@ Check[
 	
 		(* If tests failed, print why *)
 		failedTests = Join @@ testReport["TestsFailed"];
-		If[Length[failedTests] > 0, $successQ = False];
 		Switch[#["Outcome"],
 			"Failure",
 				WriteString["stdout",


### PR DESCRIPTION
## Changes

* Resolves #125.
* Closes #68.
* Changes `.wlt` files to the new format, which allows for parsing and auto parallelizing of tests.
* `./test.wls` now replaces all `VerificationTest` heads in `.wlt` files with an inactive tests, collects and flattens all tests, and then runs them in parallel (an option for not running in parallel is available).
* It also now prints a descriptive message in case of tests failures saying what the input was, and what outputs (or messages) were obtained and expected.
* All scripts, `./build.wls`, `./install.wls` and `./test.wls` now return non-zero exit codes in case of failures or messages, which allows integration into automated systems, such as CI.
* As a side effect of refactoring, tests will also now check (for all functions) whether the expressions stay unevaluated when they should (i.e., for incorrect arguments).

## Tests

* Run unit tests and make sure they all pass: `./build.wls && ./install.wls && ./test.wls`:
```
Build done.
Installed. Restart running kernels to complete installation.
correctness                             [ok]
HypergraphPlot                          [ok]
meta                                    [ok]
performance                             [ok]
RulePlot                                [ok]
SetReplaceAll                           [ok]
SetReplaceFixedPointList                [ok]
SetReplaceFixedPoint                    [ok]
SetReplaceList                          [ok]
SetReplace                              [ok]
ToPatternRules                          [ok]
WolframModelEvolutionObject             [ok]
WolframModel                            [ok]
$SetReplaceMethods                      [ok]
$WolframModelProperties                 [ok]
Report file: /private/var/folders/pz/q1ty3f9x1yq5f2ppwrkhgz4r0000gn/T/m000001396971/testReport.nb
Tests passed.
```
* Break some tests and check the new error messages (the third one has incorrect arguments passed to `VerificationTest` itself):
```
SetReplaceAll                           [3/24 failed]
Input
>> SetReplaceAll[{1, 2, 3}, n_ :> -n]
evaluated to
>> {-1, -2, -3}
instead of expected 
>> {-1, -2}

Input
>> ToString[FullForm[SetReplaceAll[]]]
generated messages
>> {Message[SetReplaceAll::argt, SetReplaceAll, 0, 2, 3]}
instead of expected
>> {SetReplaceAll::arg}

Error while evaluating the test with input
>> Length[SetReplaceAll[{{0, 1}, {0, 2}, {0, 3}}, ToPatternRules[{{0, 1}, {0, 2}, {0, 3}} -> {{4, 5}, {5, 4}, {4, 6}, {6, 4}, {5, 6}, {6, 5}, {4, 1}, {5, 2}, {6, 3}}], 4]]

Report file: /private/var/folders/pz/q1ty3f9x1yq5f2ppwrkhgz4r0000gn/T/m000001441221/testReport.nb
Tests failed.
```