### PR TITLE
Use Docker Hub image in Fire CI

### DIFF
--- a/.fire.yml
+++ b/.fire.yml
@@ -7,9 +7,6 @@ pipeline:
         name: clone
         cache: []
         image: maxitg/set-replace:ci
-        auth:
-          username: maxitg
-          password: $DOCKERHUB_PASSWORD
         commands:
           - echo "cloned"
 

--- a/.fire.yml
+++ b/.fire.yml
@@ -6,9 +6,12 @@ pipeline:
         phase: install
         name: clone
         cache: []
-        image: setreplace/ci
+        image: maxitg/set-replace:ci
+        auth:
+          username: maxitg
+          password: $DOCKERHUB_PASSWORD
         commands:
-          - echo "do nothing"
+          - echo "cloned"
 
     - step:
         phase: build


### PR DESCRIPTION
## Changes

* Replaces local Docker image with one downloadable from a private Docker Hub repository in Fire CI config.
* Now, in order to run Fire CI, only three steps are necessary:
  * Install Docker.
  * Install Fire CI agent.
  * Log in to `maxitg` Docker account using the Fire CI agent.