### PR TITLE
Fix install script for WL build 6542432

### DIFF
--- a/install.wls
+++ b/install.wls
@@ -15,9 +15,7 @@ Check[
   	Exit[1];
   ];
   
-  If[PacletInformation["SetReplace"] != {}, PacletUninstall["SetReplace"]];
-  
-  If[Head[PacletInstall[filename]] == Paclet,
+  If[Head[PacletInstall[filename, IgnoreVersion -> True]] == Paclet,
   	Print["Installed. Restart running kernels to complete installation."],
     $successQ = False];,
 


### PR DESCRIPTION
## Changes

* Due to changes in the paclet system, install script is now failing to uninstall the paclet.
* The script now does not attempt to manually uninstall, and install passes `IgnoreVersion -> True` to `PacletInstall`.

## Tests

* CI.
