### PR TITLE
Revert "Fix install script for WL build 6542432"

### DIFF
--- a/install.wls
+++ b/install.wls
@@ -15,7 +15,9 @@ Check[
   	Exit[1];
   ];
   
-  If[Head[PacletInstall[filename, IgnoreVersion -> True]] == Paclet,
+  If[PacletInformation["SetReplace"] != {}, PacletUninstall["SetReplace"]];
+  
+  If[Head[PacletInstall[filename]] == Paclet,
   	Print["Installed. Restart running kernels to complete installation."],
     $successQ = False];,
 


### PR DESCRIPTION
That did not fix the issue. Paclet still cannot be reinstalled if the version is the same.