### PR TITLE
Fix installation for new paclet system in 12.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,5 +19,9 @@ jobs:
           command: ./install.wls
 
       - run:
+          name: Reinstall
+          command: ./install.wls
+
+      - run:
           name: Test
           command: ./test.wls

--- a/.fire.yml
+++ b/.fire.yml
@@ -16,6 +16,8 @@ pipeline:
         commands:
           - ./build.wls
           - ./install.wls
+          # Install twice to check re-installation.
+          - ./install.wls
 
     - step:
         phase: test

--- a/install.wls
+++ b/install.wls
@@ -15,10 +15,12 @@ Check[
   	Exit[1];
   ];
   
-  If[PacletInformation["SetReplace"] != {}, PacletUninstall["SetReplace"]];
-  
-  If[Head[PacletInstall[filename]] == Paclet,
+  (* This works in both 12.0 and 12.1. *)
+  pacletObjectQ[p_] := PacletObjectQ[p] || Head[p] === PacletManager`Paclet;
+
+  If[pacletObjectQ[PacletInstall[filename, "IgnoreVersion" -> True]],
   	Print["Installed. Restart running kernels to complete installation."],
+    Print["Install failed."];
     $successQ = False];,
 
   $successQ = False;


### PR DESCRIPTION
## Changes

* Instead of uninstalling the paclet, the install script now uses `"IgnoreVersion" -> True`.
* It also uses the new way to verify paclet installation on 12.1.
* Updates CIs to install the paclet twice to make sure it can be reinstalled.

## Tests

* CI.
