### PR TITLE
Max vertex degree step constraint

### DIFF
--- a/SetReplace/WolframModel.wlt
+++ b/SetReplace/WolframModel.wlt
@@ -15,6 +15,8 @@
 
       $timeConstraintRule = {{1, 2}} -> {{1, 3}, {3, 2}};
       $timeConstraintInit = {{0, 0}};
+
+      maxVertexDegree[set_] := Max[Counts[Catenate[Union /@ set]]];
     ),
     "tests" -> {
       (* Argument checks *)
@@ -422,13 +424,13 @@
             "EventsCount",
             Method -> method] & /@ Range[2, 11],
           {0, 0, 0, 0, 2, 3, 3, 3, 3, 7}
-        ],
-
-        testUnevaluated[
-          WolframModel[{1, 2} -> {1, 3, 3, 2}, {1, 2, 2, 3}, <|"MaxVertices" -> #|>, "FinalState", Method -> method],
-          {WolframModel::nonListExpressions}
-        ] & /@ {3, Infinity, 0}
+        ]
       }], {method, DeleteCases[$SetReplaceMethods, Automatic]}],
+
+      testUnevaluated[
+        WolframModel[{1, 2} -> {1, 3, 3, 2}, {1, 2, 2, 3}, <|"MaxVertices" -> #|>, "FinalState"],
+        {WolframModel::nonListExpressions}
+      ] & /@ {3, Infinity, 0},
 
       With[{$incrementingRule = <|"PatternRules" -> {{a_}} :> {a + 1, a + 2}|>}, {
         testUnevaluated[
@@ -584,6 +586,142 @@
           12
         ]
       }],
+
+      Table[With[{
+          method = method,
+          $simpleGrowingRule = {{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}},
+          $simpleGrowingInit = {{1, 1}}}, {
+        testUnevaluated[
+          WolframModel[$simpleGrowingRule, $simpleGrowingInit, <|"MaxVertexDegree" -> x|>, Method -> method],
+          {WolframModel::invalidSteps}
+        ],
+
+        testUnevaluated[
+          WolframModel[$simpleGrowingRule, $simpleGrowingInit, <|"MaxVertexDegree" -> 0|>, Method -> method],
+          {WolframModel::tooSmallStepLimit}
+        ],
+
+        VerificationTest[
+          WolframModel[
+            $simpleGrowingRule, $simpleGrowingInit, <|"MaxVertexDegree" -> #1|>, "FinalState", Method -> method],
+          #2
+        ] & @@@ {
+          {1, {{1, 1}}},
+          {2, {{1, 1}}},
+          {3, {{1, 2}, {1, 2}, {2, 1}}},
+          {4, {{1, 2}, {2, 1}, {1, 3}, {1, 3}, {3, 2}}}},
+
+        VerificationTest[
+          WolframModel[
+            $simpleGrowingRule,
+            $simpleGrowingInit,
+            <|"MaxVertexDegree" -> Infinity, "MaxEvents" -> 100|>,
+            "EventsCount",
+            Method -> method],
+          100
+        ],
+
+        testUnevaluated[
+          WolframModel[
+            {{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, #, <|"MaxVertexDegree" -> #2|>, "FinalState", Method -> method],
+          {WolframModel::tooSmallStepLimit}
+        ] & @@@ {{{{1, 2}, {1, 3}}, 1}, {{{1, 2}, {1, 3}, {1, 4}}, 2}},
+
+        VerificationTest[
+          WolframModel[
+            {{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 2}, {1, 3}, {1, 4}},
+            <|"MaxVertexDegree" -> 3|>,
+            "FinalState",
+            Method -> method],
+          {{1, 2}, {1, 3}, {1, 4}}
+        ],
+
+        VerificationTest[
+          WolframModel[
+            {{1, 2}} -> {{1, 3}, {3, 2}},
+            {{1, 1}},
+            <|"MaxVertexDegree" -> #, "MaxEvents" -> 100|>,
+            "EventsCount",
+            Method -> method] & /@ {1, 2},
+          {0, 100}
+        ],
+
+        VerificationTest[
+          maxVertexDegree @ WolframModel[
+            {{1, 2}} -> {{1, 3}, {1, 4}, {1, 5}},
+            {{1, 1}},
+            <|"MaxVertexDegree" -> #|>,
+            "FinalState",
+            Method -> method] & /@ Range[20],
+          {1, 1, 3, 3, 5, 5, 7, 7, 9, 9, 11, 11, 13, 13, 15, 15, 17, 17, 19, 19}
+        ],
+
+        VerificationTest[
+          WolframModel[
+            {{1, 2}} -> {{1, 3}},
+            {{1, 2}, {1, 3}},
+            <|"MaxVertexDegree" -> 2, "MaxEvents" -> 100|>,
+            "EventsCount",
+            Method -> method],
+          100
+        ],
+
+        VerificationTest[
+          WolframModel[
+            {{{1, 2}} -> {{1, 2, 3}, {1, 3, 4}, {1, 4, 5}}, {{1, 2, 3}, {1, 3, 4}} -> {{1, 2}, {3, 4}}},
+            {{1, 2}},
+            <|"MaxVertexDegree" -> #|>,
+            "EventsCount",
+            Method -> method] & /@ Range[1, 5],
+          {0, 0, 2, 6, 14}
+        ]
+      }], {method, DeleteCases[$SetReplaceMethods, Automatic]}],
+
+      testUnevaluated[
+        WolframModel[{1, 2} -> {1, 3, 3, 2}, {1, 2, 2, 3}, <|"MaxVertexDegree" -> #|>, "FinalState", Method -> method],
+        {WolframModel::nonListExpressions}
+      ] & /@ {3, Infinity, 0},
+
+      With[{$incrementingRule = <|"PatternRules" -> {{a_}} :> {a + 1, a + 2}|>}, {
+        testUnevaluated[
+          WolframModel[$incrementingRule, {1}, <|"MaxVertexDegree" -> 4|>, "FinalState"],
+          {WolframModel::nonListExpressions}
+        ],
+      
+        VerificationTest[
+          maxVertexDegree[
+            WolframModel[$incrementingRule, {{{{{{{{{1}}}}}}}}}, <|"MaxVertexDegree" -> 34|>, "FinalState"]],
+          34
+        ],
+
+        testUnevaluated[
+          WolframModel[$incrementingRule, {{{{{{{{{1}}}}}}}}}, <|"MaxVertexDegree" -> 35|>, "FinalState"],
+          {WolframModel::nonListExpressions}
+        ],
+
+        testUnevaluated[
+          WolframModel[$incrementingRule, {{{{{{{{{1}}}}}}}}}, <|"MaxVertexDegree" -> DirectedInfinity[1]|>],
+          {WolframModel::nonListExpressions}
+        ]
+      }],
+
+      VerificationTest[
+        WolframModel[
+          <|"PatternRules" -> {{f[a_, x], f[b_, x]}} :> Module[{c}, {{f[a, x], f[b, x]}, {f[b, x], f[c, x]}}]|>,
+          {{f[1, x], f[1, x]}},
+          <|"MaxVertexDegree" -> 4|>,
+          "ExpressionsCountFinal"],
+        8
+      ],
+
+      VerificationTest[
+        WolframModel[
+          <|"PatternRules" -> {{{a_, x}, {b_, x}}} :> Module[{c}, {{{a, x}, {b, x}}, {{b, x}, {c, x}}}]|>,
+          {{{1, x}, {1, x}}},
+          <|"MaxVertexDegree" -> 4|>,
+          "ExpressionsCountFinal"],
+        8
+      ],
 
       (*** Multiple stop conditions ***)
 

--- a/SetReplace/WolframModel.wlt
+++ b/SetReplace/WolframModel.wlt
@@ -587,6 +587,8 @@
         ]
       }],
 
+      (** MaxVertexDegree **)
+
       Table[With[{
           method = method,
           $simpleGrowingRule = {{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}},
@@ -678,7 +680,7 @@
       }], {method, DeleteCases[$SetReplaceMethods, Automatic]}],
 
       testUnevaluated[
-        WolframModel[{1, 2} -> {1, 3, 3, 2}, {1, 2, 2, 3}, <|"MaxVertexDegree" -> #|>, "FinalState", Method -> method],
+        WolframModel[{1, 2} -> {1, 3, 3, 2}, {1, 2, 2, 3}, <|"MaxVertexDegree" -> #|>, "FinalState"],
         {WolframModel::nonListExpressions}
       ] & /@ {3, Infinity, 0},
 
@@ -730,7 +732,7 @@
         VerificationTest[
           WolframModel[
             model,
-            <|"MaxGenerations" -> 5, "MaxEvents" -> 41, "MaxVertices" -> 42, "MaxEdges" -> 84|>,
+            <|"MaxGenerations" -> 5, "MaxEvents" -> 41, "MaxVertices" -> 42, "MaxEdges" -> 84, "MaxVertexDegree" -> 9|>,
             "GenerationsCount",
             Method -> method],
           5
@@ -739,7 +741,7 @@
         VerificationTest[
           WolframModel[
             model,
-            <|"MaxGenerations" -> 6, "MaxEvents" -> 40, "MaxVertices" -> 42, "MaxEdges" -> 84|>,
+            <|"MaxGenerations" -> 6, "MaxEvents" -> 40, "MaxVertices" -> 42, "MaxEdges" -> 84, "MaxVertexDegree" -> 9|>,
             "EventsCount",
             Method -> method],
           40
@@ -748,7 +750,7 @@
         VerificationTest[
           WolframModel[
             model,
-            <|"MaxGenerations" -> 6, "MaxEvents" -> 41, "MaxVertices" -> 41, "MaxEdges" -> 84|>,
+            <|"MaxGenerations" -> 6, "MaxEvents" -> 41, "MaxVertices" -> 41, "MaxEdges" -> 84, "MaxVertexDegree" -> 9|>,
             "AtomsCountFinal",
             Method -> method],
           41
@@ -757,10 +759,19 @@
         VerificationTest[
           WolframModel[
             model,
-            <|"MaxGenerations" -> 6, "MaxEvents" -> 41, "MaxVertices" -> 42, "MaxEdges" -> 83|>,
+            <|"MaxGenerations" -> 6, "MaxEvents" -> 41, "MaxVertices" -> 42, "MaxEdges" -> 83, "MaxVertexDegree" -> 9|>,
             "ExpressionsCountFinal",
             Method -> method],
           82
+        ],
+
+        VerificationTest[
+          maxVertexDegree @ WolframModel[
+            model,
+            <|"MaxGenerations" -> 6, "MaxEvents" -> 41, "MaxVertices" -> 42, "MaxEdges" -> 84, "MaxVertexDegree" -> 8|>,
+            "FinalState",
+            Method -> method],
+          8
         ]
       }]] /@ DeleteCases[$SetReplaceMethods, Automatic],
 

--- a/SetReplace/libSetReplace/Set.hpp
+++ b/SetReplace/libSetReplace/Set.hpp
@@ -22,13 +22,15 @@ namespace SetReplace {
          * @var maxEvents Total number of events to produce.
          * @var maxGenerationsLocal Total number of generations. Local means the expressions of max generation will never even be matched, which means the evaluation order might be different than if the equivalent number of events is specified, and non-default evaluation order is used.
          * @var maxFinalAtoms The evaluation will be aborted at the first attempt to apply an event, which will cause the number of atoms in the final state to go over the limit.
+         * @var maxFinalAtomDegree Same as above, but for the maximum number of expressions a single atom is involved in.
          * @var maxFinalExpressions Same as for the atoms above, but for expressions.
          */
         struct StepSpecification {
-            int maxEvents;
-            int maxGenerationsLocal;
-            int maxFinalAtoms;
-            int maxFinalExpressions;
+            int maxEvents = 0;
+            int maxGenerationsLocal = 0;
+            int maxFinalAtoms = 0;
+            int maxFinalAtomDegree = 0;
+            int maxFinalExpressions = 0;
         };
         
         /** @brief Creates a new set with a given set of evolution rules, and initial condition.

--- a/SetReplace/libSetReplace/SetReplace.cpp
+++ b/SetReplace/libSetReplace/SetReplace.cpp
@@ -65,19 +65,21 @@ namespace SetReplace {
     
     Set::StepSpecification getStepSpec(WolframLibraryData libData, MTensor& stepsTensor) {
         mint tensorLength = libData->MTensor_getFlattenedLength(stepsTensor);
-        if (tensorLength != 4) {
+        constexpr int specLength = 5;
+        if (tensorLength != specLength) {
             throw LIBRARY_DIMENSION_ERROR;
         } else {
             mint* tensorData = libData->MTensor_getIntegerData(stepsTensor);
-            std::vector<int> stepSpecElements(4);
-            for (int k = 0; k < 4; ++k) {
-                stepSpecElements[k] = static_cast<int>(getData(tensorData, 4, k));
+            std::vector<int> stepSpecElements(specLength);
+            for (int k = 0; k < specLength; ++k) {
+                stepSpecElements[k] = static_cast<int>(getData(tensorData, specLength, k));
             }
             Set::StepSpecification result;
             result.maxEvents = stepSpecElements[0];
             result.maxGenerationsLocal = stepSpecElements[1];
             result.maxFinalAtoms = stepSpecElements[2];
-            result.maxFinalExpressions = stepSpecElements[3];
+            result.maxFinalAtomDegree = stepSpecElements[3];
+            result.maxFinalExpressions = stepSpecElements[4];
             
             return result;
         }

--- a/SetReplace/makeMessage.m
+++ b/SetReplace/makeMessage.m
@@ -50,7 +50,7 @@ messageTemplate["tooSmallStepLimit"] =
 
 
 messageTemplate["nonListExpressions"] =
-	"Encountered expression `2` which is not a list, even though the max `3` `4` is specified.";
+	"Encountered expression `2` which is not a list, even though a constraint on vertices is specified.";
 
 
 messageTemplate["invalidMethod"] =

--- a/SetReplace/makeMessage.m
+++ b/SetReplace/makeMessage.m
@@ -42,15 +42,15 @@ messageTemplate["invalidRules"] =
 
 
 messageTemplate["nonIntegerIterations"] =
-	"The number of `2` `3` should be a non-negative integer or infinity.";
+	"The `2` `3` should be a non-negative integer or infinity.";
 
 
 messageTemplate["tooSmallStepLimit"] =
-	"The maximum number of `2` `3` is smaller than that in initial condition `4`.";
+	"The maximum `2` `3` is smaller than that in initial condition `4`.";
 
 
 messageTemplate["nonListExpressions"] =
-	"Encountered expression `2` which is not a list, even though the max number of vertices `3` is specified.";
+	"Encountered expression `2` which is not a list, even though the max `3` `4` is specified.";
 
 
 messageTemplate["invalidMethod"] =

--- a/SetReplace/setSubstitutionSystem$cpp.m
+++ b/SetReplace/setSubstitutionSystem$cpp.m
@@ -46,7 +46,7 @@ $cpp$setReplace = If[$libraryFile =!= $Failed,
 		$libraryFile,
 		"setReplace",
 		{Integer, (* set ptr *)
-			{Integer, 1}}, (* {events, generations, atoms, expressions} *)
+			{Integer, 1}}, (* {events, generations, atoms, max expressions per atom, expressions} *)
 		"Void"],
 	$Failed];
 
@@ -197,7 +197,8 @@ setSubstitutionSystem$cpp[rules_, set_, stepSpec_, returnOnAbortQ_, timeConstrai
 		CheckAbort[
 			$cpp$setReplace[
 				setPtr,
-				stepSpec /@ {$maxEvents, $maxGenerationsLocal, $maxFinalVertices, $maxFinalExpressions} /.
+				stepSpec /@ {
+						$maxEvents, $maxGenerationsLocal, $maxFinalVertices, $maxFinalVertexDegree, $maxFinalExpressions} /.
 					{Infinity | (_ ? MissingQ) -> $maxInt}],
 			If[!returnOnAbortQ, Abort[]]],
 		timeConstraint,

--- a/SetReplace/setSubstitutionSystem$wl.m
+++ b/SetReplace/setSubstitutionSystem$wl.m
@@ -309,7 +309,7 @@ setSubstitutionSystem$wl[caller_, rules_, set_, stepSpec_, returnOnAbortQ_, time
 	outputWithMetadata = Catch[
 		Reap[setReplace$wl[setWithMetadata, rulesWithMetadata, stepSpec, vertexIndex, returnOnAbortQ, timeConstraint]],
 		$$nonListExpression,
-		(makeMessage[caller, "nonListExpressions", #, stepSpec[$maxFinalVertices]];
+		(makeMessage[caller, "nonListExpressions", #];
 			Return[$Failed]) &];
 	If[outputWithMetadata[[1]] === $Aborted, Return[$Aborted]];
 	result = SortBy[

--- a/SetReplace/setSubstitutionSystem$wl.m
+++ b/SetReplace/setSubstitutionSystem$wl.m
@@ -120,7 +120,8 @@ setReplace$wl[set_, rules_, stepSpec_, vertexIndex_, returnOnAbortQ_, timeConstr
 			CheckAbort[
 				FixedPoint[
 					AbortProtect[Module[{newResult, deletedExpressions},
-						{newResult, deletedExpressions} = Reap[Replace[#, normalRules]];
+						{newResult, deletedExpressions} = Reap[
+							Catch[Replace[#, normalRules], $$reachedAtomDegreeLimit, Throw[previousResult, $$setReplaceResult] &]];
 						If[vertexCount[vertexIndex] > Lookup[stepSpec, $maxFinalVertices, Infinity] ||
 								Length[newResult] > Lookup[stepSpec, $maxFinalExpressions, Infinity],
 							Throw[previousResult, $$setReplaceResult]];
@@ -155,6 +156,7 @@ addMetadataManagement[
 			getNextEvent_,
 			getNextExpression_,
 			maxGeneration_,
+			maxVertexDegree_,
 			vertexIndex_] := Module[{
 		inputIDs = Table[Unique["id"], Length[input]],
 		wholeInputPatternNames = Table[Unique["inputExpression"], Length[input]],
@@ -191,7 +193,7 @@ addMetadataManagement[
 								 nextEvent,
 								 Infinity,
 								 Max[0, inputGenerations] + 1,
-								 Hold[addToVertexIndex[vertexIndex, o]]},
+								 Hold[addToVertexIndex[vertexIndex, o, maxVertexDegree]]},
 								HoldAll],
 							moduleOutput,
 							{2}]],
@@ -267,11 +269,13 @@ deleteFromVertexIndex[$vertexIndex[index_], expr_] := ((
 deleteFromVertexIndex[$noIndex, expr_] := expr
 
 
-addToVertexIndex[$vertexIndex[index_], expr_] := (
-	(index[#] = Lookup[index, Key[#], 0] + 1;) & /@ expressionVertices[expr];
+addToVertexIndex[$vertexIndex[index_], expr_, limit_] := ((
+			index[#] = Lookup[index, Key[#], 0] + 1;
+			If[index[#] > limit, Throw[#, $$reachedAtomDegreeLimit]]) & /@
+		expressionVertices[expr];
 	expr
 );
-addToVertexIndex[$noIndex, expr_] := expr
+addToVertexIndex[$noIndex, expr_, limit_] := expr
 
 
 vertexCount[$vertexIndex[index_]] := Length[index]
@@ -290,10 +294,18 @@ setSubstitutionSystem$wl[caller_, rules_, set_, stepSpec_, returnOnAbortQ_, time
 	setWithMetadata = {nextExpression[], 0, \[Infinity], 0, #} & /@ set;
 	renamedRules = renameRuleInputs[toCanonicalRules[rules]];
 	If[renamedRules === $Failed, Return[$Failed]];
-	vertexIndex = If[MissingQ[stepSpec[$maxFinalVertices]], $noIndex, $vertexIndex[expressionsCountsPerVertex]];
+	vertexIndex = If[MissingQ[stepSpec[$maxFinalVertices]] && MissingQ[stepSpec[$maxFinalVertexDegree]],
+		$noIndex,
+		$vertexIndex[expressionsCountsPerVertex]];
 	initVertexIndex[vertexIndex, set];
 	rulesWithMetadata = addMetadataManagement[
-		#, nextEventID++ &, nextExpression, Lookup[stepSpec, $maxGenerationsLocal, Infinity], vertexIndex] & /@ renamedRules;
+			#,
+			nextEventID++ &,
+			nextExpression,
+			Lookup[stepSpec, $maxGenerationsLocal, Infinity],
+			Lookup[stepSpec, $maxFinalVertexDegree, Infinity],
+			vertexIndex] & /@
+		renamedRules;
 	outputWithMetadata = Catch[
 		Reap[setReplace$wl[setWithMetadata, rulesWithMetadata, stepSpec, vertexIndex, returnOnAbortQ, timeConstraint]],
 		$$nonListExpression,

--- a/SetReplace/setSubstitutionSystem.m
+++ b/SetReplace/setSubstitutionSystem.m
@@ -109,8 +109,7 @@ stepSpecQ[caller_, set_, spec_] :=
 	If[(MissingQ[spec[$maxFinalVertices]] && MissingQ[spec[$maxFinalVertexDegree]]) || AllTrue[set, ListQ],
 		True,
 		makeMessage[
-				caller, "nonListExpressions", SelectFirst[set, Not @* ListQ], $stepSpecNamesInErrorMessage[#], spec[#]] & @
-			If[MissingQ[spec[$maxFinalVertices]], $maxFinalVertexDegree, $maxFinalVertices]; False] &&
+				caller, "nonListExpressions", SelectFirst[set, Not @* ListQ]]; False] &&
 	(* Check initial condition does not violate the limits already. *)
 	And @@ (
 			If[Lookup[spec, #1, Infinity] >= #2,


### PR DESCRIPTION
## Changes

* Adds an option to limit the maximum vertex degree in the step specification.
* This is especially useful in `Method -> "LowLevel"`, because that implementation becomes exponentially slow in some cases when vertex degrees are large.

## Tests

* Run new unit tests.
* Limit max vertex degree for a universe that tends to grow vertices with large degrees (86337):
```
In[] := WolframModel[{{1, 2}, {1, 2}, {3, 1}} -> {{1, 1}, {1, 4}, {2, 1}, {2, 
    4}, {4, 3}}, {{1, 1}, {1, 1}, {1, 1}}, <|"MaxVertexDegree" -> 20|>]
```
![image](https://user-images.githubusercontent.com/1479325/69489527-56cd8d80-0e47-11ea-8367-9c0b11025a92.png)
```
In[] := HypergraphPlot[%[-1]]
```
![image](https://user-images.githubusercontent.com/1479325/69489528-5b924180-0e47-11ea-8578-e9f19fca0f26.png)