### PR TITLE
Layered causal graph

### DIFF
--- a/SetReplace/WolframModelEvolutionObject.m
+++ b/SetReplace/WolframModelEvolutionObject.m
@@ -111,7 +111,9 @@ $propertyArgumentCounts = Join[
 		"AtomsCountTotal" -> {0, 0},
 		"ExpressionsCountFinal" -> {0, 0},
 		"ExpressionsCountTotal" -> {0, 0},
+		"EventGenerations" -> {0, 0},
 		"CausalGraph" -> {0, Infinity},
+		"LayeredCausalGraph" -> {0, Infinity},
 		"Properties" -> {0, 0}|>,
 	Association[# -> {0, 0} & /@ Keys[$accessorProperties]]];
 
@@ -465,11 +467,36 @@ propertyEvaluate[
 
 
 (* ::Subsection:: *)
-(*CausalGraph*)
+(*EventGenerations*)
+
+
+propertyEvaluate[
+		WolframModelEvolutionObject[data_ ? evolutionDataQ],
+		caller_,
+		"EventGenerations"] :=
+	Values @ KeySort @ KeyDrop[
+		Join[
+			Association[Thread[data[$creatorEvents] -> data[$generations]]],
+			Association[Thread[data[$destroyerEvents] -> data[$generations] + 1]]],
+		{0, Infinity}]
+
+
+(* ::Subsection:: *)
+(*CausalGraph / LayeredCausalGraph*)
 
 
 (* ::Text:: *)
 (*This produces a causal network for the system. This is a Graph with all events as vertices, and directed edges connecting them if the same event is a creator and a destroyer for the same expression (i.e., if two events are causally related).*)
+
+
+(* ::Subsubsection:: *)
+(*Options*)
+
+
+$causalGraphOptions = Options[Graph];
+
+
+$layeredCausalGraphOptions = Join[Options[$causalGraphOptions], {"LayerHeight" -> 1}];
 
 
 (* ::Subsubsection:: *)
@@ -483,7 +510,7 @@ propertyEvaluate[
 propertyEvaluate[
 		WolframModelEvolutionObject[data_ ? evolutionDataQ],
 		caller_,
-		"CausalGraph",
+		"CausalGraph" | "LayeredCausalGraph",
 		o___] := 0 /;
 	!MatchQ[{o}, OptionsPattern[]] &&
 	makeMessage[caller, "nonopt", Last[{o}]]
@@ -492,15 +519,21 @@ propertyEvaluate[
 propertyEvaluate[
 		WolframModelEvolutionObject[data_ ? evolutionDataQ],
 		caller_,
-		"CausalGraph",
-		o : OptionsPattern[]] := 0 /;
-	With[{incorrectOptions = Complement[{o}, FilterRules[{o}, Options[Graph]]]},
-		incorrectOptions != {} &&
-		makeMessage[caller, "optx", Last[incorrectOptions]]]
+		property : "CausalGraph" | "LayeredCausalGraph",
+		o : OptionsPattern[]] := 0 /; Module[{allOptions, incorrectOptions},
+	allOptions =
+		If[property == "CausalGraph", $causalGraphOptions, $layeredCausalGraphOptions];
+	incorrectOptions = Complement[{o}, FilterRules[{o}, allOptions]];
+	incorrectOptions != {} &&
+		Message[
+			caller::optx,
+			Last[incorrectOptions],
+			Defer[WolframModelEvolutionObject[data][property, o]]]
+]
 
 
 (* ::Subsubsection:: *)
-(*Implementation*)
+(*CausalGraph Implementation*)
 
 
 propertyEvaluate[
@@ -508,13 +541,36 @@ propertyEvaluate[
 		caller_,
 		"CausalGraph",
 		o : OptionsPattern[]] /;
-			(Complement[{o}, FilterRules[{o}, Options[Graph]]] == {}) :=
+			(Complement[{o}, FilterRules[{o}, $causalGraphOptions]] == {}) :=
 	Graph[
 		DeleteCases[
 			Union[data[$creatorEvents], data[$destroyerEvents]], 0 | Infinity],
 		Select[FreeQ[#, 0 | Infinity] &] @
 			Thread[data[$creatorEvents] \[DirectedEdge] data[$destroyerEvents]],
 		o]
+
+
+(* ::Subsubsection:: *)
+(*LayeredCausalGraph Implementation*)
+
+
+propertyEvaluate[
+		evolution : WolframModelEvolutionObject[data_ ? evolutionDataQ],
+		caller_,
+		"LayeredCausalGraph",
+		o : OptionsPattern[]] /;
+			(Complement[{o}, FilterRules[{o}, $layeredCausalGraphOptions]] == {}) :=
+	Graph[
+		propertyEvaluate[evolution, caller, "CausalGraph", ##] & @@
+			FilterRules[{o}, $causalGraphOptions],
+		FilterRules[{o}, Options[Graph]],
+		VertexCoordinates -> MapIndexed[
+			First[#2] -> {
+				Automatic,
+				propertyEvaluate[evolution, caller, "GenerationsCount"] -
+					OptionValue[$layeredCausalGraphOptions, {o}, "LayerHeight"] #1} &,
+			propertyEvaluate[evolution, caller, "EventGenerations"]],
+		GraphLayout -> "SpringElectricalEmbedding"]
 
 
 (* ::Subsection:: *)

--- a/SetReplace/WolframModelEvolutionObject.m
+++ b/SetReplace/WolframModelEvolutionObject.m
@@ -567,8 +567,8 @@ propertyEvaluate[
 		VertexCoordinates -> MapIndexed[
 			First[#2] -> {
 				Automatic,
-				propertyEvaluate[evolution, caller, "GenerationsCount"] -
-					OptionValue[$layeredCausalGraphOptions, {o}, "LayerHeight"] #1} &,
+				OptionValue[$layeredCausalGraphOptions, {o}, "LayerHeight"]
+					(propertyEvaluate[evolution, caller, "GenerationsCount"] - #1)} &,
 			propertyEvaluate[evolution, caller, "EventGenerations"]],
 		GraphLayout -> "SpringElectricalEmbedding"]
 

--- a/SetReplace/WolframModelEvolutionObject.wlt
+++ b/SetReplace/WolframModelEvolutionObject.wlt
@@ -550,6 +550,16 @@
         Catenate[Table[Partition[Range[1, 17, 2^k], 2, 1], {k, 0, 4}]]
       ],
 
+      (* EventGenerations *)
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4]["EventGenerations"],
+        {1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 4}
+      ],
+
       (* CausalGraph *)
 
       Table[With[{type = type}, {

--- a/SetReplace/WolframModelEvolutionObject.wlt
+++ b/SetReplace/WolframModelEvolutionObject.wlt
@@ -237,6 +237,14 @@
         4
       ],
 
+      VerificationTest[
+        WolframModel[
+          {{1, 2}} -> {},
+          {{1, 2}, {2, 3}},
+          2]["GenerationsCount"],
+        1
+      ],
+
       (* EventsCount *)
 
       VerificationTest[
@@ -245,6 +253,14 @@
           pathGraph17,
           4]["EventsCount"],
         15
+      ],
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}} -> {},
+          {{1, 2}, {2, 3}},
+          2]["EventsCount"],
+        2
       ],
 
       (* SetAfterEvent *)
@@ -311,6 +327,14 @@
           4]["SetAfterEvent", 15]
       ],
 
+      VerificationTest[
+        WolframModel[
+          {{1, 2}} -> {},
+          {{1, 2}, {2, 3}},
+          2]["SetAfterEvent", #],
+        #2
+      ] & @@@ {{0, {{1, 2}, {2, 3}}}, {1, {{2, 3}}}, {2, {}}},
+
       (* FinalState *)
 
       VerificationTest[
@@ -332,6 +356,14 @@
         pathGraph17
       ],
 
+      VerificationTest[
+        WolframModel[
+          {{1, 2}} -> {},
+          {{1, 2}, {2, 3}},
+          2]["FinalState"],
+        {}
+      ],
+
       (* UpdatedStatesList *)
 
       VerificationTest[
@@ -351,6 +383,14 @@
           pathGraph17,
           0]["UpdatedStatesList"],
         {pathGraph17}
+      ],
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}} -> {},
+          {{1, 2}, {2, 3}},
+          2]["UpdatedStatesList"],
+        {{{1, 2}, {2, 3}}, {{2, 3}}, {}}
       ],
 
       (* Generation *)
@@ -417,6 +457,14 @@
           4]["Generation", 4]
       ],
 
+      VerificationTest[
+        WolframModel[
+          {{1, 2}} -> {},
+          {{1, 2}, {2, 3}},
+          2]["Generation", #],
+        #2
+      ] & @@@ {{0, {{1, 2}, {2, 3}}}, {1, {}}},
+
       (* StatesList *)
 
       VerificationTest[
@@ -436,6 +484,14 @@
           pathGraph17,
           0]["StatesList"],
         {pathGraph17}
+      ],
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}} -> {},
+          {{1, 2}, {2, 3}},
+          2]["StatesList"],
+        {{{1, 2}, {2, 3}}, {}}
       ],
 
       (* AtomsCountFinal *)
@@ -464,6 +520,14 @@
         1
       ],
 
+      VerificationTest[
+        WolframModel[
+          {{1, 2}} -> {},
+          {{1, 2}, {2, 3}},
+          2]["AtomsCountFinal"],
+        0
+      ],
+
       (* AtomsCountTotal *)
 
       VerificationTest[
@@ -490,6 +554,14 @@
         1
       ],
 
+      VerificationTest[
+        WolframModel[
+          {{1, 2}} -> {},
+          {{1, 2}, {2, 3}},
+          2]["AtomsCountTotal"],
+        3
+      ],
+
       (* ExpressionsCountFinal *)
 
       VerificationTest[
@@ -500,6 +572,14 @@
         1
       ],
 
+      VerificationTest[
+        WolframModel[
+          {{1, 2}} -> {},
+          {{1, 2}, {2, 3}},
+          2]["ExpressionsCountFinal"],
+        0
+      ],
+
       (* ExpressionsCountTotal *)
 
       VerificationTest[
@@ -508,6 +588,14 @@
           pathGraph17,
           4]["ExpressionsCountTotal"],
         16 + 8 + 4 + 2 + 1
+      ],
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}} -> {},
+          {{1, 2}, {2, 3}},
+          2]["ExpressionsCountTotal"],
+        2
       ],
 
       (* CreatorEvents *)
@@ -558,6 +646,14 @@
           pathGraph17,
           4]["EventGenerations"],
         {1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 4}
+      ],
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}} -> {},
+          {{1, 2}, {2, 3}},
+          2]["EventGenerations"],
+        {1, 1}
       ],
 
       (* CausalGraph *)
@@ -661,6 +757,14 @@
             Partition[Range[17], 2, 1],
             2][type]]],
           {Range[12], {1 -> 9, 2 -> 9, 3 -> 10, 4 -> 10, 5 -> 11, 6 -> 11, 7 -> 12, 8 -> 12}}
+        ],
+
+        VerificationTest[
+          Through[{VertexList, Rule @@@ EdgeList[#] &}[WolframModel[
+            {{1, 2}} -> {},
+            {{1, 2}, {2, 3}},
+            2][type]]],
+          {{1, 2}, {}}
         ],
 
         VerificationTest[

--- a/SetReplace/WolframModelEvolutionObject.wlt
+++ b/SetReplace/WolframModelEvolutionObject.wlt
@@ -552,119 +552,123 @@
 
       (* CausalGraph *)
 
-      VerificationTest[
-        WolframModel[
-          {{1, 2}, {2, 3}} -> {{1, 3}},
-          pathGraph17,
-          4]["CausalGraph", 1],
-        WolframModelEvolutionObject[___]["CausalGraph", 1],
-        {WolframModelEvolutionObject::nonopt},
-        SameTest -> MatchQ
-      ],
-
-      VerificationTest[
-        WolframModel[
-          {{1, 2}, {2, 3}} -> {{1, 3}},
-          pathGraph17,
-          4]["CausalGraph", 1, "str" -> 3],
-        WolframModelEvolutionObject[___]["CausalGraph", 1, "str" -> 3],
-        {WolframModelEvolutionObject::nonopt},
-        SameTest -> MatchQ
-      ],
-
-      VerificationTest[
-        WolframModel[
-          {{1, 2}, {2, 3}} -> {{1, 3}},
-          pathGraph17,
-          4]["CausalGraph", "BadOpt" -> "NotExist"],
-        WolframModelEvolutionObject[___]["CausalGraph", "BadOpt" -> "NotExist"],
-        {WolframModelEvolutionObject::optx},
-        SameTest -> MatchQ
-      ],
-
-      VerificationTest[
-        WolframModel[
-          {{1, 2}, {2, 3}} -> {{1, 3}},
-          pathGraph17,
-          4]["CausalGraph"],
-        Graph[Range[15], {
-          1 -> 9, 2 -> 9, 3 -> 10, 4 -> 10, 5 -> 11, 6 -> 11, 7 -> 12, 8 -> 12,
-          9 -> 13, 10 -> 13, 11 -> 14, 12 -> 14,
-          13 -> 15, 14 -> 15
-        }]
-      ],
-
-      VerificationTest[
-        WolframModel[
-          {{1, 2}, {2, 3}} -> {{1, 3}},
-          pathGraph17,
-          4]["CausalGraph", VertexLabels -> "Name", GraphLayout -> "SpringElectricalEmbedding"],
-        Graph[Range[15], {
-          1 -> 9, 2 -> 9, 3 -> 10, 4 -> 10, 5 -> 11, 6 -> 11, 7 -> 12, 8 -> 12,
-          9 -> 13, 10 -> 13, 11 -> 14, 12 -> 14,
-          13 -> 15, 14 -> 15
-        }, VertexLabels -> "Name", GraphLayout -> "SpringElectricalEmbedding"]
-      ],
-
-      VerificationTest[
-        WolframModel[
-          {{1, 2}, {2, 3}} -> {{1, 3}},
-          pathGraph17,
-          1]["CausalGraph"],
-        Graph[Range[8], {}]
-      ],
-
-      VerificationTest[
-        WolframModel[
-          {{1, 2}, {2, 3}} -> {{1, 3}},
-          Partition[Range[17], 2, 1],
-          2]["CausalGraph"],
-        Graph[Range[12], {1 -> 9, 2 -> 9, 3 -> 10, 4 -> 10, 5 -> 11, 6 -> 11, 7 -> 12, 8 -> 12}]
-      ],
-
-      With[{largeEvolution = $largeEvolution}, {
+      Table[With[{type = type}, {
         VerificationTest[
-          AcyclicGraphQ[ReleaseHold[largeEvolution["CausalGraph"]]]
+          WolframModel[
+            {{1, 2}, {2, 3}} -> {{1, 3}},
+            pathGraph17,
+            4][type, 1],
+          WolframModelEvolutionObject[___][type, 1],
+          {WolframModelEvolutionObject::nonopt},
+          SameTest -> MatchQ
+        ],
+  
+        VerificationTest[
+          WolframModel[
+            {{1, 2}, {2, 3}} -> {{1, 3}},
+            pathGraph17,
+            4][type, 1, "str" -> 3],
+          WolframModelEvolutionObject[___][type, 1, "str" -> 3],
+          {WolframModelEvolutionObject::nonopt},
+          SameTest -> MatchQ
+        ],
+  
+        VerificationTest[
+          WolframModel[
+            {{1, 2}, {2, 3}} -> {{1, 3}},
+            pathGraph17,
+            4][type, "BadOpt" -> "NotExist"],
+          WolframModelEvolutionObject[___][type, "BadOpt" -> "NotExist"],
+          {WolframModelEvolutionObject::optx},
+          SameTest -> MatchQ
+        ],
+  
+        With[{largeEvolution = $largeEvolution}, {
+          VerificationTest[
+            AcyclicGraphQ[ReleaseHold[largeEvolution[type]]]
+          ],
+  
+          VerificationTest[
+            LoopFreeGraphQ[ReleaseHold[largeEvolution[type]]]
+          ],
+  
+          VerificationTest[
+            Count[VertexInDegree[ReleaseHold[largeEvolution[type]]], 3],
+            ReleaseHold[largeEvolution["EventsCount"]] - 1
+          ],
+  
+          VerificationTest[
+            VertexCount[ReleaseHold[largeEvolution[type]]],
+            ReleaseHold[largeEvolution["EventsCount"]]
+          ],
+  
+          VerificationTest[
+            GraphDistance[ReleaseHold[largeEvolution[type]], 1, ReleaseHold[largeEvolution["EventsCount"]]],
+            ReleaseHold[largeEvolution["GenerationsCount"]] - 1
+          ]
+        }] /. HoldPattern[ReleaseHold[Hold[expr_]]] :> expr,
+  
+        VerificationTest[
+          WolframModel[
+            {{0, 1}, {0, 2}, {0, 3}} ->
+              {{4, 5}, {5, 6}, {6, 4}, {4, 6}, {6, 5}, {5, 4},
+              {4, 1}, {5, 2}, {6, 3},
+              {1, 6}, {3, 4}},
+            {{0, 0}, {0, 0}, {0, 0}},
+            3,
+            Method -> "Symbolic"][type],
+          WolframModel[
+            {{0, 1}, {0, 2}, {0, 3}} ->
+              {{4, 5}, {5, 6}, {6, 4}, {4, 6}, {6, 5}, {5, 4},
+              {4, 1}, {5, 2}, {6, 3},
+              {1, 6}, {3, 4}},
+            {{0, 0}, {0, 0}, {0, 0}},
+            3,
+            Method -> "LowLevel"][type]
         ],
 
         VerificationTest[
-          LoopFreeGraphQ[ReleaseHold[largeEvolution["CausalGraph"]]]
+          Through[{VertexList, Rule @@@ EdgeList[#] &}[WolframModel[
+            {{1, 2}, {2, 3}} -> {{1, 3}},
+            pathGraph17,
+            4][type]]],
+          {Range[15],
+            {1 -> 9, 2 -> 9, 3 -> 10, 4 -> 10, 5 -> 11, 6 -> 11, 7 -> 12, 8 -> 12, 9 -> 13, 10 -> 13, 11 -> 14,
+              12 -> 14, 13 -> 15, 14 -> 15}}
         ],
 
         VerificationTest[
-          Count[VertexInDegree[ReleaseHold[largeEvolution["CausalGraph"]]], 3],
-          ReleaseHold[largeEvolution["EventsCount"]] - 1
+          Through[{VertexList, EdgeList}[WolframModel[
+            {{1, 2}, {2, 3}} -> {{1, 3}},
+            pathGraph17,
+            1][type]]],
+          {Range[8], {}}
+        ],
+        
+        VerificationTest[
+          Through[{VertexList, Rule @@@ EdgeList[#] &}[WolframModel[
+            {{1, 2}, {2, 3}} -> {{1, 3}},
+            Partition[Range[17], 2, 1],
+            2][type]]],
+          {Range[12], {1 -> 9, 2 -> 9, 3 -> 10, 4 -> 10, 5 -> 11, 6 -> 11, 7 -> 12, 8 -> 12}}
         ],
 
         VerificationTest[
-          VertexCount[ReleaseHold[largeEvolution["CausalGraph"]]],
-          ReleaseHold[largeEvolution["EventsCount"]]
-        ],
-
-        VerificationTest[
-          GraphDistance[ReleaseHold[largeEvolution["CausalGraph"]], 1, ReleaseHold[largeEvolution["EventsCount"]]],
-          ReleaseHold[largeEvolution["GenerationsCount"]] - 1
+          FilterRules[AbsoluteOptions[WolframModel[
+            {{1, 2}, {2, 3}} -> {{1, 3}},
+            Partition[Range[17], 2, 1],
+            2][type, VertexLabels -> "Name"]], VertexLabels],
+          {VertexLabels -> {"Name"}}
         ]
-      }] /. HoldPattern[ReleaseHold[Hold[expr_]]] :> expr,
+      }], {type, {"CausalGraph", "LayeredCausalGraph"}}],
 
       VerificationTest[
-        WolframModel[
-          {{0, 1}, {0, 2}, {0, 3}} ->
-            {{4, 5}, {5, 6}, {6, 4}, {4, 6}, {6, 5}, {5, 4},
-            {4, 1}, {5, 2}, {6, 3},
-            {1, 6}, {3, 4}},
-          {{0, 0}, {0, 0}, {0, 0}},
-          3,
-          Method -> "Symbolic"]["CausalGraph"],
-        WolframModel[
-          {{0, 1}, {0, 2}, {0, 3}} ->
-            {{4, 5}, {5, 6}, {6, 4}, {4, 6}, {6, 5}, {5, 4},
-            {4, 1}, {5, 2}, {6, 3},
-            {1, 6}, {3, 4}},
-          {{0, 0}, {0, 0}, {0, 0}},
-          3,
-          Method -> "LowLevel"]["CausalGraph"]
-      ]
+        Round[Replace[VertexCoordinates, FilterRules[AbsoluteOptions[WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4]["LayeredCausalGraph", ##2]], VertexCoordinates]][[All, 2]]],
+        # Floor[Log2[16 - Range[15]]]
+      ] & @@@ {{1}, {2, "LayerHeight" -> 2}}
     }]
   |>
 |>


### PR DESCRIPTION
## Changes

* Adds `"LayeredCausalGraph"` property to `WolframModel` and `WolframModelEvolutionObject`, which returns the same `Graph` as `CausalGraph`, but arranges the heights of events based on their generations.
* Adds `"EventGenerations"` property, which returns the list of generations for all events.

## Tests

* Produce a causal graph for a particular system (this was possible before):
```
In[] := WolframModel[{{1, 2}, {1, 3}, {2, 4}} -> {{1, 3}, {1, 5}, {2, 4}, {2, 
    5}, {4, 5}}, {{1, 1}, {1, 1}, {1, 1}}, 11, "CausalGraph"]
```
![image](https://user-images.githubusercontent.com/1479325/69906961-eb7d4180-1399-11ea-9960-f26f68bc8ed4.png)
* Now, arrange events generation-by-generation:
```
In[] := WolframModel[{{1, 2}, {1, 3}, {2, 4}} -> {{1, 3}, {1, 5}, {2, 4}, {2, 
    5}, {4, 5}}, {{1, 1}, {1, 1}, {1, 1}}, 11, "LayeredCausalGraph"]
```
![image](https://user-images.githubusercontent.com/1479325/69906966-f59f4000-1399-11ea-9af3-dc8f8c2bd3e5.png)
* Change the height of each layer:
```
In[] := WolframModel[{{1, 2}, {1, 3}, {2, 4}} -> {{1, 3}, {1, 5}, {2, 4}, {2, 
     5}, {4, 5}}, {{1, 1}, {1, 1}, {1, 1}}, 11]["LayeredCausalGraph", 
 "LayerHeight" -> 0.1]
```
![image](https://user-images.githubusercontent.com/1479325/69906972-06e84c80-139a-11ea-9ced-39516431da15.png)
* `"CausalGraph"` options work with `"LayeredCausalGraph"` as well:
```
In[] := WolframModel[{{1, 2}, {1, 3}, {2, 4}} -> {{1, 3}, {1, 5}, {2, 4}, {2, 
     5}, {4, 5}}, {{1, 1}, {1, 1}, {1, 1}}, 11]["LayeredCausalGraph", 
 VertexLabels -> Automatic]
```
![image](https://user-images.githubusercontent.com/1479325/69906975-1b2c4980-139a-11ea-8f99-427bec174fd6.png)