### PR TITLE
HypergraphPlot styles

### DIFF
--- a/SetReplace/HypergraphPlot.m
+++ b/SetReplace/HypergraphPlot.m
@@ -320,19 +320,13 @@ drawEmbedding[
 
 	{lines, polygons, edgePoints} = Cases[embeddingShapes[[2]], #, All] & /@ {
 		highlighted[Line[pts_], h_] :> {
-			If[h,
-				Directive[Opacity[1], highlightColor],
-				styles[$edgeLine]
-			],
+			If[h, Directive[Opacity[1], highlightColor], styles[$edgeLine]],
 			arrow[$arrowheadShape, arrowheadLength, vertexSize][pts]},
 		highlighted[Polygon[pts_], h_] :> {
 			If[h, Directive[Opacity[0.3], highlightColor], styles[$edgePolygon]],
 			Polygon[pts]},
 		highlighted[Point[p_], h_] :> {
-			If[h,
-				Directive[Opacity[1], highlightColor],
-				styles[$edgePoint]
-			],
+			If[h, Directive[Opacity[1], highlightColor], styles[$edgePoint]],
 			Circle[p, getSingleVertexEdgeRadius[p]]}
 	};
 

--- a/SetReplace/HypergraphPlot.m
+++ b/SetReplace/HypergraphPlot.m
@@ -284,7 +284,7 @@ drawEmbedding[
 			vertexSize_,
 			arrowheadLength_][
 			embedding_] := Module[{
-		highlightCounts, embeddingShapes, vertexPoints, lines, polygons, polygonBoundaries, edgePoints, labels,
+		highlightCounts, embeddingShapes, vertexPoints, lines, polygons, edgePoints, labels,
 		singleVertexEdgeCounts, getSingleVertexEdgeRadius},
 	highlightCounts = Counts[highlight];
 	embeddingShapes = Map[
@@ -307,7 +307,7 @@ drawEmbedding[
 		singleVertexEdgeCounts[coords] = Lookup[singleVertexEdgeCounts, Key[coords], vertexSize] + vertexSize
 	);
 
-	{lines, polygons, polygonBoundaries, edgePoints} = Cases[embeddingShapes[[2]], #, All] & /@ {
+	{lines, polygons, edgePoints} = Cases[embeddingShapes[[2]], #, All] & /@ {
 		highlighted[Line[pts_], h_] :> {
 			If[h,
 				Directive[Opacity[1], highlightColor],
@@ -320,10 +320,6 @@ drawEmbedding[
 				highlightColor,
 				Lighter[$edgeColor, 0.7]
 			],
-			Polygon[pts]},
-		highlighted[Polygon[pts_], h_] :> {
-			EdgeForm[White],
-			Transparent,
 			Polygon[pts]},
 		highlighted[Point[p_], h_] :> {
 			If[h,
@@ -342,5 +338,5 @@ drawEmbedding[
 			VertexLabels -> vertexLabels,
 			VertexShapeFunction -> None,
 			EdgeShapeFunction -> None]];
-	Show[Graphics[{polygons, polygonBoundaries, lines, vertexPoints, edgePoints}], labels]
+	Show[Graphics[{polygons, lines, vertexPoints, edgePoints}], labels]
 ]

--- a/SetReplace/HypergraphPlot.m
+++ b/SetReplace/HypergraphPlot.m
@@ -80,7 +80,8 @@ hypergraphPlot$parse[
 )
 
 hypergraphPlot$parse[
-			edges : {___List}, edgeType : Alternatives @@ $edgeTypes : $defaultEdgeType, o : OptionsPattern[]] := Module[{
+			edges : {___List}, edgeType : Alternatives @@ $edgeTypes : $defaultEdgeType, o : OptionsPattern[]] /;
+				correctHypergraphPlotOptionsQ[HypergraphPlot, Defer[HypergraphPlot[edges, o]], edges, {o}] := Module[{
 		optionValue, plotStyle, edgeStyle, styles},
 	optionValue[opt_] := OptionValue[HypergraphPlot, {o}, opt];
 	plotStyle = optionValue[PlotStyle];
@@ -99,8 +100,7 @@ hypergraphPlot$parse[
 				VertexCoordinateRules,
 				VertexLabels,
 				VertexSize,
-				"ArrowheadLength"}) /;
-		correctHypergraphPlotOptionsQ[HypergraphPlot, Defer[HypergraphPlot[edges, o]], edges, {o}]
+				"ArrowheadLength"})
 ]
 
 hypergraphPlot$parse[___] := $Failed

--- a/SetReplace/HypergraphPlot.m
+++ b/SetReplace/HypergraphPlot.m
@@ -17,7 +17,7 @@ SyntaxInformation[HypergraphPlot] = {"ArgumentsPattern" -> {_, _., OptionsPatter
 (* Automatic style pickes up, and possibly modifies the style it inherits from. *)
 Options[HypergraphPlot] = Join[{
 	"EdgePolygonStyle" -> Automatic, (* inherits from EdgeStyle, with specified small opacity *)
-	EdgeStyle -> Directive[Opacity[0.7], Hue[0.6, 0.7, 0.5]],
+	EdgeStyle -> Directive[Opacity[0.7], Hue[0.6, 0.7, 0.5]], (* inherits from PlotStyle *)
 	GraphHighlight -> {},
 	GraphHighlightStyle -> Hue[1.0, 1.0, 0.7],
 	"HyperedgeRendering" -> "Polygons",
@@ -25,6 +25,7 @@ Options[HypergraphPlot] = Join[{
 	"UnaryEdgeStyle" -> Automatic, (* inherits from EdgeStyle *)
 	VertexCoordinateRules -> {},
 	VertexLabels -> None,
+	(* inherits from PlotStyle *)
 	VertexStyle -> Directive[Hue[0.6, 0.2, 0.8], EdgeForm[Directive[GrayLevel[0], Opacity[0.7]]]]},
 	Options[Graphics]];
 

--- a/SetReplace/HypergraphPlot.m
+++ b/SetReplace/HypergraphPlot.m
@@ -20,7 +20,8 @@ Options[HypergraphPlot] = Join[{
 	"HyperedgeRendering" -> "Polygons",
 	VertexCoordinateRules -> {},
 	VertexLabels -> None,
-	VertexStyle -> Directive[Hue[0.6, 0.2, 0.8], EdgeForm[Directive[GrayLevel[0], Opacity[0.7]]]]},
+	VertexStyle -> Directive[Hue[0.6, 0.2, 0.8], EdgeForm[Directive[GrayLevel[0], Opacity[0.7]]]],
+	EdgeStyle -> Directive[Opacity[0.7], Hue[0.6, 0.7, 0.5]]},
 	Options[Graphics]];
 
 $edgeTypes = {"Ordered", "Cyclic"};
@@ -71,7 +72,7 @@ hypergraphPlot$parse[
 hypergraphPlot$parse[
 			edges : {___List}, edgeType : Alternatives @@ $edgeTypes : $defaultEdgeType, o : OptionsPattern[]] := Module[{
 		styles},
-	styles = <|$vertexPoint -> OptionValue[HypergraphPlot, {o}, "VertexStyle"]|>;
+	styles = OptionValue[HypergraphPlot, {o}, #] & /@ <|$vertexPoint -> VertexStyle, $edgeLine -> EdgeStyle|>;
 	hypergraphPlot[edges, edgeType, styles, ##, FilterRules[{o}, Options[Graphics]]] & @@
 			(OptionValue[HypergraphPlot, {o}, #] & /@ {
 				GraphHighlight, GraphHighlightStyle, "HyperedgeRendering", VertexCoordinateRules, VertexLabels}) /;
@@ -269,8 +270,6 @@ hypergraphEmbedding[edgeType_, hyperedgeRendering : "Polygons", vertexCoordinate
 
 (** Drawing **)
 
-$edgeColor = Hue[0.6, 0.7, 0.5];
-
 $arrowheadShape = Polygon[{
 	{-1.10196, -0.289756}, {-1.08585, -0.257073}, {-1.05025, -0.178048}, {-1.03171, -0.130243}, {-1.01512, -0.0824391},
 	{-1.0039, -0.037561}, {-1., 0.}, {-1.0039, 0.0341466}, {-1.01512, 0.0780486}, {-1.03171, 0.127805},
@@ -311,20 +310,20 @@ drawEmbedding[
 		highlighted[Line[pts_], h_] :> {
 			If[h,
 				Directive[Opacity[1], highlightColor],
-				Directive[Opacity[0.7], $edgeColor]
+				styles[$edgeLine]
 			],
 			arrow[$arrowheadShape, arrowheadLength, vertexSize][pts]},
 		highlighted[Polygon[pts_], h_] :> {
 			Opacity[0.3],
 			If[h,
 				highlightColor,
-				Lighter[$edgeColor, 0.7]
+				Lighter[Hue[0.6, 0.7, 0.5], 0.7]
 			],
 			Polygon[pts]},
 		highlighted[Point[p_], h_] :> {
 			If[h,
 				Directive[Opacity[1], highlightColor],
-				Directive[Opacity[0.7], $edgeColor]
+				Directive[Opacity[0.7], Hue[0.6, 0.7, 0.5]]
 			],
 			Circle[p, getSingleVertexEdgeRadius[p]]}
 	};

--- a/SetReplace/HypergraphPlot.m
+++ b/SetReplace/HypergraphPlot.m
@@ -5,7 +5,6 @@ PackageExport["HypergraphPlot"]
 PackageScope["correctHypergraphPlotOptionsQ"]
 PackageScope["$edgeTypes"]
 PackageScope["hypergraphEmbedding"]
-PackageScope["hypergraphPlot"]
 
 (* Documentation *)
 

--- a/SetReplace/HypergraphPlot.m
+++ b/SetReplace/HypergraphPlot.m
@@ -21,6 +21,7 @@ Options[HypergraphPlot] = Join[{
 	GraphHighlight -> {},
 	GraphHighlightStyle -> Hue[1.0, 1.0, 0.7],
 	"HyperedgeRendering" -> "Polygons",
+	PlotStyle -> Hue[0.6, 0.7, 0.5],
 	"UnaryEdgeStyle" -> Automatic, (* inherits from EdgeStyle *)
 	VertexCoordinateRules -> {},
 	VertexLabels -> None,
@@ -74,14 +75,16 @@ hypergraphPlot$parse[
 
 hypergraphPlot$parse[
 			edges : {___List}, edgeType : Alternatives @@ $edgeTypes : $defaultEdgeType, o : OptionsPattern[]] := Module[{
-		optionValue, styles},
+		optionValue, plotStyle, edgeStyle, styles},
 	optionValue[opt_] := OptionValue[HypergraphPlot, {o}, opt];
+	plotStyle = optionValue[PlotStyle];
 	styles = <|
-		$vertexPoint -> optionValue[VertexStyle],
-		$edgeLine -> optionValue[EdgeStyle],
-		$edgePoint -> Replace[optionValue["UnaryEdgeStyle"], Automatic -> optionValue[EdgeStyle]],
+		$vertexPoint -> Replace[
+			optionValue[VertexStyle], Automatic -> Directive[plotStyle, EdgeForm[Directive[GrayLevel[0], Opacity[0.7]]]]],
+		$edgeLine -> (edgeStyle = Replace[optionValue[EdgeStyle], Automatic -> Directive[plotStyle, Opacity[0.7]]]),
+		$edgePoint -> Replace[optionValue["UnaryEdgeStyle"], Automatic -> edgeStyle],
 		$edgePolygon ->
-			Replace[optionValue["EdgePolygonStyle"], Automatic -> Directive[optionValue[EdgeStyle], Opacity[0.09]]]|>;
+			Replace[optionValue["EdgePolygonStyle"], Automatic -> Directive[edgeStyle, Opacity[0.09]]]|>;
 	hypergraphPlot[edges, edgeType, styles, ##, FilterRules[{o}, Options[Graphics]]] & @@
 			(optionValue /@ {
 				GraphHighlight, GraphHighlightStyle, "HyperedgeRendering", VertexCoordinateRules, VertexLabels}) /;

--- a/SetReplace/HypergraphPlot.wlt
+++ b/SetReplace/HypergraphPlot.wlt
@@ -238,6 +238,25 @@
         Graphics
       ],
 
+      (* Valid VertexSize and "ArrowheadLength" *)
+
+      {
+        testUnevaluated[
+          HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, # -> $$$invalid$$$],
+          {HypergraphPlot::invalidSize}
+        ],
+
+        testUnevaluated[
+          HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, # -> -1],
+          {HypergraphPlot::invalidSize}
+        ],
+
+        VerificationTest[
+          Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, # -> 1]],
+          Graphics
+        ]
+      } & /@ {VertexSize, "ArrowheadLength"},
+
       (* Implementation *)
 
       (** Simple examples **)
@@ -351,6 +370,126 @@
           HypergraphPlot[{{1, 2, 3}}, VertexCoordinateRules -> {1 -> {1, 0}, 2 -> {1, 0}}],
           Rotate[_, {v1_, v2_}] :> v1 != {0, 0} && v2 != {0, 0},
           All]
+      ],
+
+      (* Styles *)
+
+      With[{color = RGBColor[0.4, 0.6, 0.2]}, {
+        VerificationTest[
+          FreeQ[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "EdgePolygonStyle" -> color], color],
+          False
+        ],
+
+        VerificationTest[
+          FreeQ[
+            HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "HyperedgeRendering" -> "Subgraphs", "EdgePolygonStyle" -> color],
+            color],
+          True
+        ],
+
+        VerificationTest[
+          FreeQ[HypergraphPlot[{{1, 2, 3}, {3}, {3, 4, 5}}, "UnaryEdgeStyle" -> color], color],
+          False
+        ],
+
+        VerificationTest[
+          FreeQ[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "UnaryEdgeStyle" -> color], color],
+          True
+        ],
+
+        VerificationTest[
+          FreeQ[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, VertexStyle -> color], color],
+          False
+        ],
+
+        VerificationTest[
+          FreeQ[HypergraphPlot[{{1}, {3}}, VertexStyle -> color, EdgeStyle -> Transparent], color],
+          False
+        ],
+
+        VerificationTest[
+          FreeQ[HypergraphPlot[{}, VertexStyle -> color], color],
+          True
+        ],
+
+        VerificationTest[
+          FreeQ[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, EdgeStyle -> color], color],
+          False
+        ],
+
+        VerificationTest[
+          FreeQ[HypergraphPlot[{}, EdgeStyle -> color], color],
+          True
+        ],
+
+        VerificationTest[
+          FreeQ[HypergraphPlot[{{1}}, EdgeStyle -> color, "UnaryEdgeStyle" -> Black], color],
+          True
+        ],
+
+        VerificationTest[
+          FreeQ[HypergraphPlot[{{1}}, EdgeStyle -> color, "UnaryEdgeStyle" -> Automatic], color],
+          False
+        ],
+
+        VerificationTest[
+          FreeQ[HypergraphPlot[{{1, 2, 3}}, EdgeStyle -> color, "EdgePolygonStyle" -> Black], color],
+          False
+        ],
+
+        VerificationTest[
+          FreeQ[HypergraphPlot[{{1, 2, 3}}, EdgeStyle -> Black, "EdgePolygonStyle" -> color], color],
+          False
+        ],
+
+        VerificationTest[
+          FreeQ[
+            HypergraphPlot[{{1, 2, 3}}, PlotStyle -> color, EdgeStyle -> Automatic, VertexStyle -> Automatic], color],
+          False
+        ],
+
+        VerificationTest[
+          FreeQ[
+            HypergraphPlot[{{1, 2, 3}}, PlotStyle -> color, EdgeStyle -> Black, VertexStyle -> Automatic], color],
+          False
+        ],
+
+        VerificationTest[
+          FreeQ[
+            HypergraphPlot[{{1, 2, 3}}, PlotStyle -> color, EdgeStyle -> Automatic, VertexStyle -> Black], color],
+          False
+        ],
+
+        VerificationTest[
+          FreeQ[
+            HypergraphPlot[
+              {{1}}, PlotStyle -> color, EdgeStyle -> Automatic, "UnaryEdgeStyle" -> Black, VertexStyle -> Black],
+            color],
+          True
+        ],
+
+        VerificationTest[
+          FreeQ[
+            HypergraphPlot[
+              {{1, 2, 3}, {3, 4, 5}}, PlotStyle -> color, EdgeStyle -> Black, VertexStyle -> Black],
+            color],
+          True
+        ]
+      }],
+
+      VerificationTest[
+        Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, VertexSize -> 0.3]],
+        Graphics
+      ],
+
+      VerificationTest[
+        Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "ArrowheadLength" -> 0.3]],
+        Graphics
+      ],
+
+      VerificationTest[
+        Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, VertexSize -> 0.4, "ArrowheadLength" -> 0.3]],
+        Graphics
       ],
 
       (* GraphHighlight *)

--- a/SetReplace/RulePlot.m
+++ b/SetReplace/RulePlot.m
@@ -174,17 +174,16 @@ singleRulePlot[
   vertexCoordinateRules = Join[
     ruleCoordinateRules[edgeType, hyperedgeRendering, externalVertexCoordinateRules, rule],
     externalVertexCoordinateRules];
-  ruleSidePlots = hypergraphPlot[
+  ruleSidePlots = HypergraphPlot[
       #,
       edgeType,
-      sharedRuleElements[rule],
-      graphHighlightStyle,
-      hyperedgeRendering,
-      vertexCoordinateRules,
-      vertexLabels,
-      {},
-      $vertexSize,
-      $arrowheadsLength] & /@
+      GraphHighlight -> sharedRuleElements[rule],
+      GraphHighlightStyle -> graphHighlightStyle,
+      "HyperedgeRendering" -> hyperedgeRendering,
+      VertexCoordinateRules -> vertexCoordinateRules,
+      VertexLabels -> vertexLabels,
+      VertexSize -> $vertexSize,
+      "ArrowheadLength" -> $arrowheadsLength] & /@
     List @@ rule;
   plotRange =
     CoordinateBounds[Catenate[List @@ (Transpose[PlotRange[#]] & /@ ruleSidePlots)], $graphPadding];


### PR DESCRIPTION
## Changes
* Adds new options to `HypergraphPlot`:
  * `VertexStyle`: controls the style for vertices.
  * `EdgeStyle`: controls the style of edge lines. Also affects the style for unary edges and hyperedge polygons if they are set to `Automatic`.
  * `"UnaryEdgeStyle"`: controls the style of circles that represent unary edges.
  * `"EdgePolygonStyle"`: controls the style of hyperedge polygons.
  * `PlotStyle`: controls the overall style of the graph. Only has an effect if either `VertexStyle` or `EdgeStyle` are set to `Automatic` (which they are not by default).
  * `VertexSize`: controls the size of vertices.
  * `"ArrowheadLength"`: controls the length of arrowheads.

## Comments
* Note, the sizes in `HypergraphPlot` are always absolute. The length scale of graph edges is around `1`, and vertices are always the same size relative to that scale. Therefore, for instance, settings like `Small`, `Large` and `Tiny` would not work for vertices. Similarly, arrowheads are always the same size relative to vertices size, and they do not depend on rescaling the graphics. This makes everything consistent and predictable. Hence, both `VertexSize` and `"ArrowheadLength"` are just numbers.

## Tests
* Set an overall style for the `HypergraphPlot`:
```
In[] := HypergraphPlot[{{1, 2, 3}, {3}, {3, 4, 5}}, PlotStyle -> Black, 
 VertexStyle -> Automatic, EdgeStyle -> Automatic]
```
![image](https://user-images.githubusercontent.com/1479325/70169784-7e1f2880-1699-11ea-9ae3-f47961adb250.png)
* Set different styles for vertices, edges, and unary edges:
```
In[] := HypergraphPlot[{{1, 2, 3}, {3}, {3, 4, 5}}, PlotStyle -> Black, 
 VertexStyle -> Blue, EdgeStyle -> Red, "UnaryEdgeStyle" -> Green]
```
![image](https://user-images.githubusercontent.com/1479325/70169831-95f6ac80-1699-11ea-8b33-41ee73da3685.png)
* Set a different style for hyperedge polygons:
```
In[] := HypergraphPlot[{{1, 2, 3}, {3}, {3, 4, 5}}, PlotStyle -> Black, 
 VertexStyle -> Blue, EdgeStyle -> Red, 
 "EdgePolygonStyle" -> Darker@Green]
```
![image](https://user-images.githubusercontent.com/1479325/70169890-b292e480-1699-11ea-939c-f859a72f19e8.png)
* Make a dark mode hypergraph plot:
```
In[] := HypergraphPlot[{{1, 2, 3}, {3}, {3, 4, 5}}, VertexStyle -> White, 
 EdgeStyle -> White, Background -> Darker[Gray, 0.67]]
```
![image](https://user-images.githubusercontent.com/1479325/70169934-c9d1d200-1699-11ea-9020-b2dabfeb51ab.png)
* Go crazy with styles:
```
In[] := HypergraphPlot[{{1, 2, 3}, {3}, {1, 4, 3}}, 
 VertexStyle -> 
  Directive[LightBlue, EdgeForm[Directive[Gray, Dotted, Thick]]], 
 VertexLabels -> Automatic, 
 "UnaryEdgeStyle" -> Directive[ColorData[97, 3], Dotted], 
 "EdgePolygonStyle" -> 
  Directive[Green, Opacity[0.1], EdgeForm[White]], 
 EdgeStyle -> Directive[ColorData[97, 4], Dashed]]
```
![image](https://user-images.githubusercontent.com/1479325/70169959-d35b3a00-1699-11ea-9615-3a4e057b1ea7.png)
* Make vertices very large:
```
In[] := HypergraphPlot[{{1, 2, 3}, {3}, {3, 4, 5}}, VertexSize -> 0.2]
```
![image](https://user-images.githubusercontent.com/1479325/70169986-de15cf00-1699-11ea-93f0-aadfd968959f.png)
* Make arrows very large:
```
In[] := HypergraphPlot[{{1, 2, 3}, {3}, {3, 4, 5}}, "ArrowheadLength" -> 0.5]
```
![image](https://user-images.githubusercontent.com/1479325/70170010-e79f3700-1699-11ea-8978-3546606c9c68.png)
* Make some art with arrowheads:
```
In[] := HypergraphPlot[{Range[10]}, "Cyclic", "ArrowheadLength" -> #, 
   VertexSize -> 0, VertexStyle -> Transparent] & /@ {0.5, 1, 10}
```
![image](https://user-images.githubusercontent.com/1479325/70170042-f84fad00-1699-11ea-9b69-72041cafb323.png)
* Remove arrows altogether:
```
In[] := HypergraphPlot[{{1, 2, 3}, {3, 4, 5}, {5, 6, 7}, {7, 8, 9}, {9, 10, 
   1}}, "Cyclic", "ArrowheadLength" -> 0, VertexSize -> 0, 
 VertexStyle -> Transparent]
```
![image](https://user-images.githubusercontent.com/1479325/70170064-03a2d880-169a-11ea-962e-41f8e0053053.png)