### PR TITLE
Elementwise HypergraphPlot styles

### DIFF
--- a/SetReplace/HypergraphPlot.m
+++ b/SetReplace/HypergraphPlot.m
@@ -293,7 +293,7 @@ normalToHypergraphEmbedding[edges_, normalEdges_, normalEmbedding_] := Module[{
 	indexedSingleVertexEdges =
 		With[{
 				indices = Position[normalEdges, {}, 1][[All, 1]]},
-			Transpose[{Cases[edges[[indices]], Except[{}], 1], indices}]];
+			Cases[Transpose[{edges[[indices]], indices}], Except[{{}, _}], 1]];
 	indexedSingleVertexEdgeEmbedding = (# -> (#[[1, 1]] /. vertexEmbedding)) & /@ indexedSingleVertexEdges;
 
 	{vertexEmbedding,

--- a/SetReplace/HypergraphPlot.wlt
+++ b/SetReplace/HypergraphPlot.wlt
@@ -388,16 +388,6 @@
         ],
 
         VerificationTest[
-          FreeQ[HypergraphPlot[{{1, 2, 3}, {3}, {3, 4, 5}}, "UnaryEdgeStyle" -> color], color],
-          False
-        ],
-
-        VerificationTest[
-          FreeQ[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "UnaryEdgeStyle" -> color], color],
-          True
-        ],
-
-        VerificationTest[
           FreeQ[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, VertexStyle -> color], color],
           False
         ],
@@ -420,16 +410,6 @@
         VerificationTest[
           FreeQ[HypergraphPlot[{}, EdgeStyle -> color], color],
           True
-        ],
-
-        VerificationTest[
-          FreeQ[HypergraphPlot[{{1}}, EdgeStyle -> color, "UnaryEdgeStyle" -> Black], color],
-          True
-        ],
-
-        VerificationTest[
-          FreeQ[HypergraphPlot[{{1}}, EdgeStyle -> color, "UnaryEdgeStyle" -> Automatic], color],
-          False
         ],
 
         VerificationTest[
@@ -458,14 +438,6 @@
           FreeQ[
             HypergraphPlot[{{1, 2, 3}}, PlotStyle -> color, EdgeStyle -> Automatic, VertexStyle -> Black], color],
           False
-        ],
-
-        VerificationTest[
-          FreeQ[
-            HypergraphPlot[
-              {{1}}, PlotStyle -> color, EdgeStyle -> Automatic, "UnaryEdgeStyle" -> Black, VertexStyle -> Black],
-            color],
-          True
         ],
 
         VerificationTest[

--- a/SetReplace/utilities.m
+++ b/SetReplace/utilities.m
@@ -4,7 +4,7 @@ PackageScope["vertexList"]
 PackageScope["fromCounts"]
 PackageScope["multisetIntersection"]
 
-vertexList[edges_] := Union[Catenate[edges]]
+vertexList[edges_] := Sort[Union[Catenate[edges]]]
 
 fromCounts[association_] := Catenate @ KeyValueMap[ConstantArray] @ association
 


### PR DESCRIPTION
## Changes
* Closes #153.
* Styles in `HypergraphPlot` can now be specified per element, or per element pattern.
* Specifically, there are now three ways to specify a style (`EdgeStyle` used as an example, but the same works for `"EdgePolygonStyle"` and `VertexStyle`):
  * `EdgeStyle -> style` (use the same style for everything);
  * `EdgeStyle -> <|pattern -> style, ...|>` (use different styles for different patterns of edges);
  * `EdgeStyle -> {style1, style2, ...}` (specify styles for each edge).
* Removes `"UnaryEdgeStyle"` option, which is superseded by specifying a corresponding pattern in `EdgeStyle`, i.e., `"EdgeStyle" -> <|..., {_} -> unaryStyle|>`.
* `PlotStyle` can now be specified directly without manually setting `EdgeStyle` and `VertexStyle` to automatic, as it's default now uses patterns to match vertices vs. edges.

## Tests
* Make the whole graph black:
```
In[] := HypergraphPlot[{{1}, {1}, {1, 3}, {1, 2, 3}, {3, 4, 5, 6}, {6, 7, 8}},
  PlotStyle -> Black]
```
![image](https://user-images.githubusercontent.com/1479325/70559918-8a056180-1b55-11ea-9006-ef047ff0800a.png)
* Make the 3rd vertex black, and the 4th one blue:
```
In[] := HypergraphPlot[{{1}, {1}, {1, 3}, {1, 2, 3}, {3, 4, 5, 6}, {6, 7, 8}},
  VertexStyle -> <|3 -> Black, 4 -> Blue|>]
```
![image](https://user-images.githubusercontent.com/1479325/70559971-adc8a780-1b55-11ea-9d8c-7221ef9d7e69.png)
* Manually specify colors for some of the edges:
```
In[] := HypergraphPlot[{{1}, {1}, {1, 3}, {1, 2, 3}, {3, 4, 5, 6}, {6, 7, 8}},
  EdgeStyle -> <|{1, 2, 3} -> Blue, {3, 4, 5, 6} -> Red|>]
```
![image](https://user-images.githubusercontent.com/1479325/70560003-c0db7780-1b55-11ea-9a8e-d37302b01add.png)
* Use different colors for different edge lengths:
```
In[] := HypergraphPlot[{{1}, {1}, {1, 3}, {1, 2, 3}, {3, 4, 5, 6}, {6, 7, 8}},
  EdgeStyle -> <|e_ :> ColorData[97, Length[e]]|>]
```
![image](https://user-images.githubusercontent.com/1479325/70560104-fda76e80-1b55-11ea-89b5-2979f8e134cd.png)
* Only do that for edge polygons:
```
In[] := HypergraphPlot[{{1}, {1}, {1, 3}, {1, 2, 3}, {3, 4, 5, 6}, {6, 7, 8}},
  "EdgePolygonStyle" -> <|
   e_ :> Directive[ColorData[97, Length[e]], Opacity[0.2]]|>]
```
![image](https://user-images.githubusercontent.com/1479325/70561094-d8b3fb00-1b57-11ea-8d03-f3129f2684cc.png)
* Color each edge different color (like old `HypergraphPlot`):
```
In[] := HypergraphPlot[{{1}, {1}, {1, 3}, {1, 2, 3}, {3, 4, 5, 6}, {6, 7, 8}},
  EdgeStyle -> ColorData[97] /@ Range[6]]
```
![image](https://user-images.githubusercontent.com/1479325/70560596-e5841f00-1b56-11ea-9961-a6786fbc7948.png)
* Neat example: color edges based on their generation:
```
In[] := With[{evo = 
   WolframModel[{{{1, 2, 3}, {4, 5, 6}, {1, 4}} -> {{2, 8, 7}, {9, 3, 
        10}, {5, 11, 12}, {6, 13, 14}, {10, 13}, {7, 9}, {11, 8}, {12,
         14}}}, {{1, 1, 1}, {1, 1, 1}, {1, 1}, {1, 1}, {1, 1}}, 20]}, 
 HypergraphPlot[evo[-1], 
  EdgeStyle -> 
   Association[
    MapThread[#1 -> 
       ColorData["GrayTones", 
        1 - Exp[(#2 - evo["GenerationsCount"])]] &, {evo[
       "AllExpressions"], evo["ExpressionGenerations"]}]], 
  VertexStyle -> White]]
```
![image](https://user-images.githubusercontent.com/1479325/70560494-b077cc80-1b56-11ea-9f35-27ecbad3ae19.png)