### PR TITLE
MaxCompleteGenerations

### DIFF
--- a/SetReplace/WolframModelEvolutionObject.m
+++ b/SetReplace/WolframModelEvolutionObject.m
@@ -29,6 +29,7 @@ PackageScope["$destroyerEvents"]
 PackageScope["$generations"]
 PackageScope["$atomLists"]
 PackageScope["$rules"]
+PackageScope["$maxCompleteGeneration"]
 
 
 (* ::Section:: *)
@@ -63,8 +64,12 @@ WolframModelEvolutionObject /:
 		MakeBoxes[
 			evo : WolframModelEvolutionObject[data_ ? evolutionDataQ],
 			format_] := Module[
-	{generationsCount, eventsCount, rules, initialSet},
+	{generationsCount, maxCompleteGeneration, eventsCount, rules, initialSet},
 	generationsCount = evo["GenerationsCount"];
+	maxCompleteGeneration = Replace[evo["MaxCompleteGeneration"], _ ? MissingQ -> "?"];
+	generationsDisplay = If[generationsCount === maxCompleteGeneration,
+		generationsCount,
+		Row[{maxCompleteGeneration, "\[Ellipsis]", generationsCount}]];
 	eventsCount = evo["EventsCount"];
 	rules = data[$rules];
 	initialSet = evo[0];
@@ -73,8 +78,8 @@ WolframModelEvolutionObject /:
 		evo,
 		$graphIcon,
 		(* Always grid *)
-		{{BoxForm`SummaryItem[{"Generations count: ", generationsCount}]},
-		{BoxForm`SummaryItem[{"Events count: ", eventsCount}]}},
+		{{BoxForm`SummaryItem[{"Generations: ", generationsDisplay}]},
+		{BoxForm`SummaryItem[{"Events: ", eventsCount}]}},
 		(* Sometimes grid *)
 		{{BoxForm`SummaryItem[{"Rules: ", Short[rules]}]},
 		{BoxForm`SummaryItem[{"Initial set: ", Short[initialSet]}]}},
@@ -92,7 +97,8 @@ $accessorProperties = <|
 	"CreatorEvents" -> $creatorEvents,
 	"DestroyerEvents" -> $destroyerEvents,
 	"ExpressionGenerations" -> $generations,
-	"AllExpressions" -> $atomLists
+	"AllExpressions" -> $atomLists,
+	"MaxCompleteGeneration" -> $maxCompleteGeneration
 |>;
 
 
@@ -612,7 +618,7 @@ WolframModelEvolutionObject::corrupt =
 
 
 evolutionDataQ[data_Association] := Sort[Keys[data]] ===
-	Sort[{$creatorEvents, $destroyerEvents, $generations, $atomLists, $rules}]
+	Sort[{$creatorEvents, $destroyerEvents, $generations, $atomLists, $rules, $maxCompleteGeneration}]
 
 
 evolutionDataQ[___] := False

--- a/SetReplace/libSetReplace/Match.cpp
+++ b/SetReplace/libSetReplace/Match.cpp
@@ -119,8 +119,11 @@ namespace SetReplace {
             return *matches_.begin();
         }
         
-    private:
+        const std::set<Match>& allMatches() {
+            return matches_;
+        }
         
+    private:
         void addMatchesForRule(const std::vector<ExpressionID>& expressionIDs, const RuleID& ruleID, const std::function<bool()> shouldAbort) {
             for (int i = 0; i < rules_[ruleID].inputs.size(); ++i) {
                 Match emptyMatch{ruleID, std::vector<ExpressionID>(rules_[ruleID].inputs.size(), -1)};
@@ -314,5 +317,9 @@ namespace SetReplace {
             }
         }
         return true;
+    }
+
+    const std::set<Match>& Matcher::allMatches() const {
+        return implementation_->allMatches();
     }
 }

--- a/SetReplace/libSetReplace/Match.hpp
+++ b/SetReplace/libSetReplace/Match.hpp
@@ -68,6 +68,9 @@ namespace SetReplace {
                                                      const std::vector<AtomsVector> patternMatches,
                                                      std::vector<AtomsVector>& atomsToReplace);
         
+        /** @brief Returns the set of expression IDs matched in any match. */
+        const std::set<Match>& allMatches() const;
+        
     private:
         class Implementation;
         std::shared_ptr<Implementation> implementation_;

--- a/SetReplace/libSetReplace/Set.cpp
+++ b/SetReplace/libSetReplace/Set.cpp
@@ -120,6 +120,11 @@ namespace SetReplace {
             return result;
         }
         
+        Generation maxCompleteGeneration(const std::function<bool()> shouldAbort) {
+            indexNewExpressions(shouldAbort);
+            return std::min(smallestGeneration(matcher_.allMatches()), largestGeneration_);
+        }
+        
     private:
         Implementation(const std::vector<Rule>& rules,
                        const std::vector<AtomsVector>& initialExpressions,
@@ -275,6 +280,18 @@ namespace SetReplace {
             }
             updateAtomDegrees(atomDegrees, expressions, deltaCount);
         }
+        
+        Generation smallestGeneration(const std::set<Match>& matches) const {
+            Generation smallestSoFar = std::numeric_limits<Generation>::max();
+            for (const auto& match : matches) {
+                Generation largestForTheMatch = 0;
+                for (const ExpressionID id : match.inputExpressions) {
+                    largestForTheMatch = std::max(largestForTheMatch, expressions_.at(id).generation);
+                }
+                smallestSoFar = std::min(smallestSoFar, largestForTheMatch);
+            }
+            return smallestSoFar;
+        }
     };
     
     Set::Set(const std::vector<Rule>& rules,
@@ -292,5 +309,9 @@ namespace SetReplace {
     
     std::vector<SetExpression> Set::expressions() const {
         return implementation_->expressions();
+    }
+    
+    Generation Set::maxCompleteGeneration(const std::function<bool()> shouldAbort) {
+        return implementation_->maxCompleteGeneration(shouldAbort);
     }
 }

--- a/SetReplace/libSetReplace/Set.hpp
+++ b/SetReplace/libSetReplace/Set.hpp
@@ -56,6 +56,11 @@ namespace SetReplace {
          */
         std::vector<SetExpression> expressions() const;
         
+        /** @brief Returns the largest generation that has both been reached, and has no matches that would produce expressions with that or lower generation.
+         * @details Takes O(matches count) + as long as it would take to do the next step (because new expressions need to be indexed).
+         */
+        Generation maxCompleteGeneration(const std::function<bool()> shouldAbort);
+        
     private:
         class Implementation;
         std::shared_ptr<Implementation> implementation_;

--- a/SetReplace/libSetReplace/SetReplace.cpp
+++ b/SetReplace/libSetReplace/SetReplace.cpp
@@ -160,6 +160,12 @@ namespace SetReplace {
         return LIBRARY_NO_ERROR;
     }
     
+    const std::function<bool()> shouldAbort(WolframLibraryData& libData) {
+        return [&libData]() {
+            return static_cast<bool>(libData->AbortQ());
+        };
+    }
+
     int setReplace(WolframLibraryData libData, mint argc, MArgument *argv, MArgument result) {
         if (argc != 2) {
             return LIBRARY_FUNCTION_ERROR;
@@ -173,11 +179,8 @@ namespace SetReplace {
             return LIBRARY_FUNCTION_ERROR;
         }
         
-        const auto shouldAbort = [&libData]() {
-            return static_cast<bool>(libData->AbortQ());
-        };
         try {
-            setPtr->replace(stepSpec, shouldAbort);
+            setPtr->replace(stepSpec, shouldAbort(libData));
         } catch (...) {
             return LIBRARY_FUNCTION_ERROR;
         }
@@ -194,6 +197,22 @@ namespace SetReplace {
         try {
             const auto expressions = setPtr->expressions();
             MArgument_setMTensor(result, putSet(expressions, libData));
+        } catch (...) {
+            return LIBRARY_FUNCTION_ERROR;
+        }
+        
+        return LIBRARY_NO_ERROR;
+    }
+
+    int maxCompleteGeneration(WolframLibraryData libData, mint argc, MArgument *argv, MArgument result) {
+        if (argc != 1) {
+            return LIBRARY_FUNCTION_ERROR;
+        }
+        
+        auto setPtr = (Set*)MArgument_getInteger(argv[0]);
+        try {
+            const auto maxCompleteGeneration = setPtr->maxCompleteGeneration(shouldAbort(libData));
+            MArgument_setInteger(result, maxCompleteGeneration);
         } catch (...) {
             return LIBRARY_FUNCTION_ERROR;
         }
@@ -228,4 +247,8 @@ EXTERN_C int setReplace(WolframLibraryData libData, mint argc, MArgument *argv, 
 
 EXTERN_C int setExpressions(WolframLibraryData libData, mint argc, MArgument *argv, MArgument result) {
     return SetReplace::setExpressions(libData, argc, argv, result);
+}
+
+EXTERN_C int maxCompleteGeneration(WolframLibraryData libData, mint argc, MArgument *argv, MArgument result) {
+    return SetReplace::maxCompleteGeneration(libData, argc, argv, result);
 }

--- a/SetReplace/libSetReplace/SetReplace.hpp
+++ b/SetReplace/libSetReplace/SetReplace.hpp
@@ -29,4 +29,9 @@ EXTERN_C DLLEXPORT int setReplace(WolframLibraryData libData, mint argc, MArgume
  */
 EXTERN_C DLLEXPORT int setExpressions(WolframLibraryData libData, mint argc, MArgument *argv, MArgument result);
 
+/** @brief Returns the largest generation that has both been reached, and has no matches that would produce expressions with that or lower generation.
+ * @details Is abortable, in which case returns LIBRARY_FUNCTION_ERROR.
+ */
+EXTERN_C DLLEXPORT int maxCompleteGeneration(WolframLibraryData libData, mint argc, MArgument *argv, MArgument result);
+
 #endif /* SetReplace_hpp */

--- a/SetReplace/performance.wlt
+++ b/SetReplace/performance.wlt
@@ -40,12 +40,12 @@
             Head[SetReplace[
               init,
               rule,
-              100,
+              #,
               Method -> "Symbolic"]],
             List,
             TimeConstraint -> 60,
             MemoryConstraint -> 5*^6
-          ],
+          ] & /@ {14, 100},
   
           (** Naming function performance **)
   

--- a/SetReplace/setSubstitutionSystem$cpp.m
+++ b/SetReplace/setSubstitutionSystem$cpp.m
@@ -60,6 +60,15 @@ $cpp$setExpressions = If[$libraryFile =!= $Failed,
 	$Failed];
 
 
+$cpp$maxCompleteGeneration = If[$libraryFile =!= $Failed,
+	LibraryFunctionLoad[
+		$libraryFile,
+		"maxCompleteGeneration",
+		{Integer}, (* set ptr *)
+		Integer], (* generation *)
+	$Failed];
+
+
 (* ::Section:: *)
 (*Implementation*)
 
@@ -174,7 +183,7 @@ setSubstitutionSystem$cpp[rules_, set_, stepSpec_, returnOnAbortQ_, timeConstrai
 			$cppSetReplaceAvailable := Module[{
 		canonicalRules,
 		setAtoms, atomsInRules, globalAtoms, globalIndex,
-		mappedSet, localIndices, mappedRules, setPtr, cppOutput, resultAtoms,
+		mappedSet, localIndices, mappedRules, setPtr, cppOutput, maxCompleteGeneration, resultAtoms,
 		inversePartialGlobalMap, inverseGlobalMap},
 	canonicalRules = toCanonicalRules[rules];
 	setAtoms = Hold /@ Union[Catenate[set]];
@@ -204,6 +213,8 @@ setSubstitutionSystem$cpp[rules_, set_, stepSpec_, returnOnAbortQ_, timeConstrai
 		timeConstraint,
 		If[!returnOnAbortQ, Return[$Aborted]]];
 	cppOutput = decodeExpressions @ $cpp$setExpressions[setPtr];
+	maxCompleteGeneration =
+		Replace[$cpp$maxCompleteGeneration[setPtr], LibraryFunctionError[___] -> Missing["Unknown", $Aborted]];
 	$cpp$setDelete[setPtr];
 	resultAtoms = Union[Catenate[cppOutput[$atomLists]]];
 	inversePartialGlobalMap = Association[Reverse /@ Normal @ globalIndex];
@@ -213,6 +224,7 @@ setSubstitutionSystem$cpp[rules_, set_, stepSpec_, returnOnAbortQ_, timeConstrai
 		cppOutput,
 		<|$atomLists ->
 				ReleaseHold @ Map[inverseGlobalMap, cppOutput[$atomLists], {2}],
-			$rules -> rules
+			$rules -> rules,
+			$maxCompleteGeneration -> maxCompleteGeneration
 		|>]]
 ]


### PR DESCRIPTION
## Changes

* Adds `"MaxCompleteGenerations"` property (and entry to the evolution object), which would return the last generation for which no more matches can be made.
* Given current evaluation order, it will be either the same as `"GenerationsCount"`, or one less than that, but the code allows generalization to other evaluation orders.
* Note, previous versions of the evolution objects are no longer compatible and would produce corrupt evolution object messages. One way to get around that is to manually add ``SetReplace`PackageScope`$maxCompleteGeneration -> Missing[]`` to the evolution object.

## Review comments

* If backwards compatibility with previous evolution objects is required that can be arranged, but it seems at this point it is better to avoid unnecessary complicating the code.

## Tests

* Evaluate a system for a number of events that puts it in between generations:
```
In[] := WolframModel[{{1, 2, 3}, {4, 5, 6}, {1, 4}} -> {{2, 8, 7}, {9, 3, 
    10}, {5, 11, 12}, {6, 13, 14}, {10, 13}, {7, 9}, {11, 8}, {12, 
    14}}, {{1, 1, 1}, {1, 1, 1}, {1, 1}, {1, 1}, {1, 1}}, <|
  "MaxEvents" -> 101|>]
```
![image](https://user-images.githubusercontent.com/1479325/71225245-e8dd8000-22a5-11ea-828e-6885a99dea8c.png)
* Note, a range is displayed in the evolution object denoting the last complete, and the last encountered generations.
* The number can be obtained programmatically as well:
```
In[] := WolframModel[{{1, 2, 3}, {4, 5, 6}, {1, 4}} -> {{2, 8, 7}, {9, 3, 
     10}, {5, 11, 12}, {6, 13, 14}, {10, 13}, {7, 9}, {11, 8}, {12, 
     14}}, {{1, 1, 1}, {1, 1, 1}, {1, 1}, {1, 1}, {1, 1}}, <|
   "MaxEvents" -> 101|>]["MaxCompleteGeneration"]
```
```
Out[] = 16
```
* If we hit the exact number of generations, a single number of displayed instead of a range:
```
In[] := WolframModel[{{1, 2, 3}, {4, 5, 6}, {1, 4}} -> {{2, 8, 7}, {9, 3, 
    10}, {5, 11, 12}, {6, 13, 14}, {10, 13}, {7, 9}, {11, 8}, {12, 
    14}}, {{1, 1, 1}, {1, 1, 1}, {1, 1}, {1, 1}, {1, 1}}, <|
  "MaxEvents" -> 100|>]
```
![image](https://user-images.githubusercontent.com/1479325/71225270-fd217d00-22a5-11ea-8210-b0d71fc77b47.png)