### PR TITLE
IncludePartialGenerations

### DIFF
--- a/SetReplace/WolframModel.m
+++ b/SetReplace/WolframModel.m
@@ -179,15 +179,17 @@ WolframModel[
 			$Failed];
 		propertyEvaluateWithOptions =
 			propertyEvaluate[OptionValue["IncludePartialGenerations"]][renamedNodesEvolution, WolframModel, #] &;
-		result = If[renamedNodesEvolution =!= $Failed,
-			If[ListQ[property],
-					Catch[
-						Check[propertyEvaluateWithOptions[#], Throw[$Failed, $propertyMessages]] & /@ property,
-						$propertyMessages,
-						$Failed &],
-					propertyEvaluateWithOptions @ property] /.
-				HoldPattern[WolframModelEvolutionObject[data_Association]] :>
-					WolframModelEvolutionObject[Join[data, <|$rules -> rulesSpec|>]],
+		result = Check[
+			If[renamedNodesEvolution =!= $Failed,
+				If[ListQ[property],
+						Catch[
+							Check[propertyEvaluateWithOptions[#], Throw[$Failed, $propertyMessages]] & /@ property,
+							$propertyMessages,
+							$Failed &],
+						propertyEvaluateWithOptions @ property] /.
+					HoldPattern[WolframModelEvolutionObject[data_Association]] :>
+						WolframModelEvolutionObject[Join[data, <|$rules -> rulesSpec|>]],
+				$Failed],
 			$Failed];
 		result /; result =!= $Failed
 	]

--- a/SetReplace/WolframModel.m
+++ b/SetReplace/WolframModel.m
@@ -51,7 +51,7 @@ SyntaxInformation[WolframModel] =
 
 
 Options[WolframModel] := Join[
-	{"NodeNamingFunction" -> Automatic},
+	{"NodeNamingFunction" -> Automatic, "IncludePartialGenerations" -> True},
 	Options[setSubstitutionSystem]];
 
 
@@ -177,10 +177,15 @@ WolframModel[
 					OptionValue["NodeNamingFunction"]],
 				$Failed],
 			$Failed];
+		propertyEvaluateWithOptions =
+			propertyEvaluate[OptionValue["IncludePartialGenerations"]][renamedNodesEvolution, WolframModel, #] &;
 		result = If[renamedNodesEvolution =!= $Failed,
 			If[ListQ[property],
-					renamedNodesEvolution /@ property,
-					renamedNodesEvolution @ property] /.
+					Catch[
+						Check[propertyEvaluateWithOptions[#], Throw[$Failed, $propertyMessages]] & /@ property,
+						$propertyMessages,
+						$Failed &],
+					propertyEvaluateWithOptions @ property] /.
 				HoldPattern[WolframModelEvolutionObject[data_Association]] :>
 					WolframModelEvolutionObject[Join[data, <|$rules -> rulesSpec|>]],
 			$Failed];

--- a/SetReplace/WolframModelEvolutionObject.m
+++ b/SetReplace/WolframModelEvolutionObject.m
@@ -604,7 +604,13 @@ WolframModelEvolutionObject[
 propertyEvaluate[True][args___] := propertyEvaluate[args]
 
 
-propertyEvaluate[False][evolution_, rest___] := propertyEvaluate[deleteIncompleteGenerations[evolution], rest]
+General::missingMaxCompleteGeneration = "Cannot drop incomplete generations in an object with missing information.";
+
+
+propertyEvaluate[False][evolution_, caller_, rest___] := If[MissingQ[evolution["MaxCompleteGeneration"]],
+	Message[caller::missingMaxCompleteGeneration],
+	propertyEvaluate[deleteIncompleteGenerations[evolution], caller, rest]
+]
 
 
 propertyEvaluate[includePartialGenerations_][evolution_, caller_, ___] :=


### PR DESCRIPTION
## Changes

* Adds an option to remove partial generations from the evolution object and other properties.
* The option `"IncludePartialGenerations"` can be used with both `WolframModel` and `WolframModelEvolutionObject`.
* Setting this option to `False` essentially creates a new evolution object with removed partial generations before computing any other properties, which means it will automatically work for new properties without any additional code.
* If `$maxCompleteGeneration` is set to `Missing[]`, a message is generated if `"IncludePartialGenerations" -> False`, but properties with `"IncludePartialGenerations" -> True` can still be calculated.

## Tests

* Create an evolution object with partial generations:
```
In[] := WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {2, 3}}, {{1, 1}}, <|
  "MaxEvents" -> 200|>]
```
![image](https://user-images.githubusercontent.com/1479325/71302060-fc0b5100-2374-11ea-971a-0de29494ad4a.png)
* Remove partial generations from it:
```
In[] := %["EvolutionObject", "IncludePartialGenerations" -> False]
```
![image](https://user-images.githubusercontent.com/1479325/71302064-0decf400-2375-11ea-849b-aaaf6f99a77c.png)
* Other properties can be requested directly as well:
```
In[] := %%["CausalGraph", "IncludePartialGenerations" -> False]
```
![image](https://user-images.githubusercontent.com/1479325/71302070-1f360080-2375-11ea-8811-fc4533671a75.png)
* Including directly from `WolframModel`:
```
In[] := WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {2, 3}}, {{1, 1}}, <|
  "MaxEvents" -> 200|>, "CausalGraph", 
 "IncludePartialGenerations" -> False]
```
![image](https://user-images.githubusercontent.com/1479325/71302074-34ab2a80-2375-11ea-94fe-151a63031237.png)