### PR TITLE
LayeredDigraphEmbedding for LayeredCausalGraph

### DIFF
--- a/SetReplace/WolframModelEvolutionObject.m
+++ b/SetReplace/WolframModelEvolutionObject.m
@@ -570,13 +570,12 @@ propertyEvaluate[
 		propertyEvaluate[evolution, caller, "CausalGraph", ##] & @@
 			FilterRules[{o}, $causalGraphOptions],
 		FilterRules[{o}, Options[Graph]],
-		VertexCoordinates -> MapIndexed[
-			First[#2] -> {
-				Automatic,
-				OptionValue[$layeredCausalGraphOptions, {o}, "LayerHeight"]
-					(propertyEvaluate[evolution, caller, "GenerationsCount"] - #1)} &,
-			propertyEvaluate[evolution, caller, "EventGenerations"]],
-		GraphLayout -> "SpringElectricalEmbedding"]
+		GraphLayout -> {
+			"LayeredDigraphEmbedding",
+			"VertexLayerPosition" ->
+				(propertyEvaluate[evolution, caller, "GenerationsCount"] -
+						propertyEvaluate[evolution, caller, "EventGenerations"])}
+	]
 
 
 (* ::Subsection:: *)

--- a/SetReplace/WolframModelEvolutionObject.m
+++ b/SetReplace/WolframModelEvolutionObject.m
@@ -502,7 +502,7 @@ propertyEvaluate[
 $causalGraphOptions = Options[Graph];
 
 
-$layeredCausalGraphOptions = Join[Options[$causalGraphOptions], {"LayerHeight" -> 1}];
+$layeredCausalGraphOptions = Options[$causalGraphOptions];
 
 
 (* ::Subsubsection:: *)

--- a/SetReplace/WolframModelEvolutionObject.wlt
+++ b/SetReplace/WolframModelEvolutionObject.wlt
@@ -780,9 +780,9 @@
         Round[Replace[VertexCoordinates, FilterRules[AbsoluteOptions[WolframModel[
           {{1, 2}, {2, 3}} -> {{1, 3}},
           pathGraph17,
-          4]["LayeredCausalGraph", ##2]], VertexCoordinates]][[All, 2]]],
-        # Floor[Log2[16 - Range[15]]]
-      ] & @@@ {{1}, {2, "LayerHeight" -> 2}}
+          4]["LayeredCausalGraph"]], VertexCoordinates]][[All, 2]]],
+        Floor[Log2[16 - Range[15]]]
+      ]
     }]
   |>
 |>


### PR DESCRIPTION
## Changes

* Changes `"LayeredCausalGraph"` property to use `"LayeredDigraphEmbedding"` instead of "SpringElectricalEmbedding".
* This produces embeddings that are less entangled than previously.

## Tests

* Produce a picture that better illustrates the structure of the causal graph:
```
In[] := WolframModel[{{1}, {1}} -> {{1}, {1}, {1}}, {{1}, {1}}, 13, \
"LayeredCausalGraph"]
```
![image](https://user-images.githubusercontent.com/1479325/71377258-3f8ed680-2592-11ea-951f-69578a9206bf.png)
* For a tree, we will no longer have entangled branches:
```
In[] := WolframModel[{{1, 2}} -> {{1, 3}, {3, 2}, {3, 2}}, {{1, 
   1}}, 4, "LayeredCausalGraph"]
```
![image](https://user-images.githubusercontent.com/1479325/71377285-60efc280-2592-11ea-80bf-629ec84b8214.png)
* Label vertices:
```
In[] := WolframModel[{{1, 2}, {1, 3}, {1, 4}} -> {{2, 3}, {2, 4}, {3, 3}, {3, 
     5}, {4, 5}}, {{1, 1}, {1, 1}, {1, 1}}, 6]["LayeredCausalGraph", 
 VertexLabels -> Automatic]
```
![image](https://user-images.githubusercontent.com/1479325/71377316-75cc5600-2592-11ea-84f6-1c548b20258a.png)