### PR TITLE
Fix leaked symbols

### DIFF
--- a/SetReplace/HypergraphPlot.wlt
+++ b/SetReplace/HypergraphPlot.wlt
@@ -31,8 +31,9 @@
         Missing[],
         All];
 
-      Attributes[Global`testUnevaluated] = {HoldAll};
+      Attributes[Global`testUnevaluated] = Attributes[Global`testSymbolLeak] = {HoldAll};
       Global`testUnevaluated[args___] := SetReplace`PackageScope`testUnevaluated[VerificationTest, args];
+      Global`testSymbolLeak[args___] := SetReplace`PackageScope`testSymbolLeak[VerificationTest, args];
 
       {color, color2, color3, color4, color5} =
         BlockRandom[Table[RGBColor[RandomReal[{0, 1}, 3]], 5], RandomSeeding -> 0];
@@ -59,6 +60,13 @@
       testColorPresence[args___] := testColor[True, args];
     ),
     "tests" -> {
+      (* Symbol Leak *)
+
+      testSymbolLeak[
+        SeedRandom[123];
+        HypergraphPlot[RandomInteger[200, {100, 3}]]
+      ],
+
       (* Argument Checks *)
 
       (** Argument count **)

--- a/SetReplace/RulePlot.wlt
+++ b/SetReplace/RulePlot.wlt
@@ -1,8 +1,9 @@
 <|
   "RulePlot" -> <|
     "init" -> (
-      Attributes[Global`testUnevaluated] = {HoldAll};
+      Attributes[Global`testUnevaluated] = Attributes[Global`testSymbolLeak] = {HoldAll};
       Global`testUnevaluated[args___] := SetReplace`PackageScope`testUnevaluated[VerificationTest, args];
+      Global`testSymbolLeak[args___] := SetReplace`PackageScope`testSymbolLeak[VerificationTest, args];
 
       $rulesForVertexSizeConsistency = {
         {{1}} -> {{1}},
@@ -18,6 +19,13 @@
         {{1, 2, 3}} -> {{2, 3}, {3, 4}}};
     ),
     "tests" -> {
+      (* Symbol Leak *)
+
+      testSymbolLeak[
+        SeedRandom[123];
+        RulePlot[WolframModel[Rule @@ RandomInteger[100, {2, 50, 3}]]]
+      ],
+
       (* Rule correctness checking *)
 
       testUnevaluated[

--- a/SetReplace/SetReplace.wlt
+++ b/SetReplace/SetReplace.wlt
@@ -1,10 +1,17 @@
 <|
 	"SetReplace" -> <|
 		"init" -> (
-			Attributes[Global`testUnevaluated] = {HoldAll};
+			Attributes[Global`testUnevaluated] = Attributes[Global`testSymbolLeak] = {HoldAll};
       Global`testUnevaluated[args___] := SetReplace`PackageScope`testUnevaluated[VerificationTest, args];
+      Global`testSymbolLeak[args___] := SetReplace`PackageScope`testSymbolLeak[VerificationTest, args];
 		),
 		"tests" -> {
+			(* Symbol Leak *)
+
+			testSymbolLeak[
+				SetReplace[Range[10], {a_, b_} :> {a + b, a - b, a b}, 1000]
+			],
+
 			(* Argument checks *)
 
 			(** Argument count **)

--- a/SetReplace/SetReplaceAll.wlt
+++ b/SetReplace/SetReplaceAll.wlt
@@ -1,10 +1,17 @@
 <|
   "SetReplaceAll" -> <|
     "init" -> (
-      Attributes[Global`testUnevaluated] = {HoldAll};
+      Attributes[Global`testUnevaluated] = Attributes[Global`testSymbolLeak] = {HoldAll};
       Global`testUnevaluated[args___] := SetReplace`PackageScope`testUnevaluated[VerificationTest, args];
+      Global`testSymbolLeak[args___] := SetReplace`PackageScope`testSymbolLeak[VerificationTest, args];
     ),
     "tests" -> {
+      (* Symbol Leak *)
+
+      testSymbolLeak[
+        SetReplaceAll[Range[10], {a_, b_} :> {a + b, a - b, a b}, 7]
+      ],
+      
       (* Argument Checks *)
 
       (** Argument count **)

--- a/SetReplace/SetReplaceFixedPoint.wlt
+++ b/SetReplace/SetReplaceFixedPoint.wlt
@@ -1,10 +1,17 @@
 <|
   "SetReplaceFixedPoint" -> <|
     "init" -> (
-      Attributes[Global`testUnevaluated] = {HoldAll};
+      Attributes[Global`testUnevaluated] = Attributes[Global`testSymbolLeak] = {HoldAll};
       Global`testUnevaluated[args___] := SetReplace`PackageScope`testUnevaluated[VerificationTest, args];
+      Global`testSymbolLeak[args___] := SetReplace`PackageScope`testSymbolLeak[VerificationTest, args];
     ),
     "tests" -> {
+      (* Symbol Leak *)
+
+      testSymbolLeak[
+        SetReplaceFixedPoint[Range[1000], {a_, b_} :> {a + b}]
+      ],
+      
       (* Argument Checks *)
 
       (** Argument count **)

--- a/SetReplace/SetReplaceFixedPointList.wlt
+++ b/SetReplace/SetReplaceFixedPointList.wlt
@@ -1,10 +1,17 @@
 <|
   "SetReplaceFixedPointList" -> <|
     "init" -> (
-      Attributes[Global`testUnevaluated] = {HoldAll};
+      Attributes[Global`testUnevaluated] = Attributes[Global`testSymbolLeak] = {HoldAll};
       Global`testUnevaluated[args___] := SetReplace`PackageScope`testUnevaluated[VerificationTest, args];
+      Global`testSymbolLeak[args___] := SetReplace`PackageScope`testSymbolLeak[VerificationTest, args];
     ),
     "tests" -> {
+      (* Symbol Leak *)
+
+      testSymbolLeak[
+        SetReplaceFixedPointList[Range[100], {a_, b_} :> {a + b}]
+      ],
+      
       (* Argument Checks *)
 
       (** Argument count **)

--- a/SetReplace/SetReplaceList.wlt
+++ b/SetReplace/SetReplaceList.wlt
@@ -1,10 +1,17 @@
 <|
   "SetReplaceList" -> <|
     "init" -> (
-      Attributes[Global`testUnevaluated] = {HoldAll};
+      Attributes[Global`testUnevaluated] = Attributes[Global`testSymbolLeak] = {HoldAll};
       Global`testUnevaluated[args___] := SetReplace`PackageScope`testUnevaluated[VerificationTest, args];
+      Global`testSymbolLeak[args___] := SetReplace`PackageScope`testSymbolLeak[VerificationTest, args];
     ),
     "tests" -> {
+      (* Symbol Leak *)
+
+      testSymbolLeak[
+        SetReplaceList[Range[100], {a_, b_} :> {a + b}, 5]
+      ],
+      
       (* Argument Checks *)
 
       (** Argument count **)

--- a/SetReplace/ToPatternRules.wlt
+++ b/SetReplace/ToPatternRules.wlt
@@ -1,10 +1,18 @@
 <|
   "ToPatternRules" -> <|
     "init" -> (
-      Attributes[Global`testUnevaluated] = {HoldAll};
+      Attributes[Global`testUnevaluated] = Attributes[Global`testSymbolLeak] = {HoldAll};
       Global`testUnevaluated[args___] := SetReplace`PackageScope`testUnevaluated[VerificationTest, args];
+      Global`testSymbolLeak[args___] := SetReplace`PackageScope`testSymbolLeak[VerificationTest, args];
     ),
     "tests" -> {
+      (* Symbol Leak *)
+
+      testSymbolLeak[
+        SeedRandom[123];
+        ToPatternRules[Rule @@ RandomInteger[100, {2, 50, 3}]]
+      ],
+
       (* Argument Checks *)
 
       (** Argument count **)

--- a/SetReplace/WolframModel.wlt
+++ b/SetReplace/WolframModel.wlt
@@ -1,8 +1,9 @@
 <|
   "WolframModel" -> <|
     "init" -> (
-      Attributes[Global`testUnevaluated] = {HoldAll};
+      Attributes[Global`testUnevaluated] = Attributes[Global`testSymbolLeak] = {HoldAll};
       Global`testUnevaluated[args___] := SetReplace`PackageScope`testUnevaluated[VerificationTest, args];
+      Global`testSymbolLeak[args___] := SetReplace`PackageScope`testSymbolLeak[VerificationTest, args];
 
       $interestingRule = {{0, 1}, {0, 2}, {0, 3}} ->
         {{4, 5}, {5, 4}, {4, 6}, {6, 4}, {5, 6},
@@ -17,6 +18,13 @@
       maxVertexDegree[set_] := Max[Counts[Catenate[Union /@ set]]];
     ),
     "tests" -> {
+      (* Symbol Leak *)
+
+      testSymbolLeak[
+        WolframModel[
+          {{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 5, "FinalState", Method -> #1, "NodeNamingFunction" -> #2]
+      ] & @@@ Tuples[{$SetReplaceMethods, {Automatic, All}}],
+
       (* Argument checks *)
 
       (** Argument counts, simple rule and inits **)

--- a/SetReplace/WolframModelEvolutionObject.wlt
+++ b/SetReplace/WolframModelEvolutionObject.wlt
@@ -1,8 +1,9 @@
 <|
   "WolframModelEvolutionObject" -> <|
     "init" -> (
-      Attributes[Global`testUnevaluated] = {HoldAll};
+      Attributes[Global`testUnevaluated] = Attributes[Global`testSymbolLeak] = {HoldAll};
       Global`testUnevaluated[args___] := SetReplace`PackageScope`testUnevaluated[VerificationTest, args];
+      Global`testSymbolLeak[args___] := SetReplace`PackageScope`testSymbolLeak[VerificationTest, args];
 
       $largeEvolution = Hold[WolframModel[
         {{0, 1}, {0, 2}, {0, 3}} ->
@@ -13,6 +14,12 @@
         7]];
     ),
     "tests" -> With[{pathGraph17 = Partition[Range[17], 2, 1]}, {
+      (* Symbol Leak *)
+
+      testSymbolLeak[
+        WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 5] /@ $WolframModelProperties
+      ],
+
       (** Argument checks **)
 
       (* Corrupt object *)

--- a/SetReplace/setSubstitutionSystem$cpp.m
+++ b/SetReplace/setSubstitutionSystem$cpp.m
@@ -219,7 +219,7 @@ setSubstitutionSystem$cpp[rules_, set_, stepSpec_, returnOnAbortQ_, timeConstrai
 	resultAtoms = Union[Catenate[cppOutput[$atomLists]]];
 	inversePartialGlobalMap = Association[Reverse /@ Normal @ globalIndex];
 	inverseGlobalMap = Association @ Thread[resultAtoms
-		-> (Lookup[inversePartialGlobalMap, #, Unique["v"]] & /@ resultAtoms)];
+		-> (Lookup[inversePartialGlobalMap, #, Unique["v", {Temporary}]] & /@ resultAtoms)];
 	WolframModelEvolutionObject[Join[
 		cppOutput,
 		<|$atomLists ->

--- a/SetReplace/setSubstitutionSystem$wl.m
+++ b/SetReplace/setSubstitutionSystem$wl.m
@@ -69,11 +69,11 @@ toNormalRules[input_List :> output_Module] := Module[
 toNormalRules[rules_List] := Module[{
 		ruleNames, separateNormalRules, longestRuleLength, untouchedNames,
 		finalMatchName, input, output},
-	ruleNames = Table[Unique[], Length[rules]];
+	ruleNames = Table[Unique["rule", {Temporary}], Length[rules]];
 	separateNormalRules = toNormalRules /@ rules;
 	longestRuleLength = Max[Map[Length, separateNormalRules[[All, All, 1]], {2}]];
-	untouchedNames = Table[Unique[], longestRuleLength + 1];
-	finalMatchName = Unique[];
+	untouchedNames = Table[Unique["untouched", {Temporary}], longestRuleLength + 1];
+	finalMatchName = Unique["match", {Temporary}];
 	input = With[{match = finalMatchName}, List[
 		match : Shortest[Alternatives @@ Catenate[Transpose @ PadRight[
 			MapIndexed[
@@ -158,10 +158,10 @@ addMetadataManagement[
 			maxGeneration_,
 			maxVertexDegree_,
 			vertexIndex_] := Module[{
-		inputIDs = Table[Unique["id"], Length[input]],
-		wholeInputPatternNames = Table[Unique["inputExpression"], Length[input]],
-		inputCreators = Table[Unique["creator"], Length[input]],
-		inputGenerations = Table[Unique["generation"], Length[input]],
+		inputIDs = Table[Unique["id", {Temporary}], Length[input]],
+		wholeInputPatternNames = Table[Unique["inputExpression", {Temporary}], Length[input]],
+		inputCreators = Table[Unique["creator", {Temporary}], Length[input]],
+		inputGenerations = Table[Unique["generation", {Temporary}], Length[input]],
 		nextEvent},
 	With[{
 			heldModule = Map[Hold, Hold[output], {2}]},
@@ -256,7 +256,7 @@ renameRuleInputs[patternRules_] := Catch[Module[{pattern, inputAtoms, newInputAt
 					With[{originalP = p /. pattern -> Pattern}, Message[Pattern::patvar, originalP]]; Throw[$Failed]],
 				All],
 			{RuleDelayed::rhs}]];
-	newInputAtoms = Table[Unique[], Length[inputAtoms]];
+	newInputAtoms = Table[Unique["inputAtom", {Temporary}], Length[inputAtoms]];
 	# /. (((HoldPattern[#1] /. Hold[s_] :> s) -> #2) & @@@ Thread[inputAtoms -> newInputAtoms])
 ] & /@ patternRules]
 

--- a/SetReplace/setSubstitutionSystem$wl.m
+++ b/SetReplace/setSubstitutionSystem$wl.m
@@ -246,7 +246,7 @@ maxCompleteGeneration[output_, rulesNoMetadata_] := Module[{
 
 
 renameRuleInputs[patternRules_] := Catch[Module[{pattern, inputAtoms, newInputAtoms},
-	Attributes[pattern] = {HoldFirst};
+	SetAttributes[pattern, HoldFirst];
 	inputAtoms = Union[
 		Quiet[
 			Cases[

--- a/SetReplace/testUtilities.m
+++ b/SetReplace/testUtilities.m
@@ -1,6 +1,7 @@
 Package["SetReplace`"]
 
 PackageScope["testUnevaluated"]
+PackageScope["testSymbolLeak"]
 
 (* VerificationTest should not directly appear here, as it is replaced by test.wls into other heads during evaluation.
     Use testHead argument instead. *)
@@ -14,3 +15,17 @@ testUnevaluated[testHead_, input_, messages_, opts___] :=
     StringReplace[ToString[FullForm[Hold[input]]], StartOfString ~~ "Hold[" ~~ expr___ ~~ "]" ~~ EndOfString :> expr],
     messages,
     opts];
+
+Attributes[testSymbolLeak] = {HoldAll};
+testSymbolLeak[testHead_, expr_, opts___] :=
+  testHead[
+    Module[{Global`before, Global`after},
+      expr; (* symbols might get created at the first run due to initialization *)
+      Global`before = Length[Names["*`*"]];
+      expr;
+      Global`after = Length[Names["*`*"]];
+      Global`after - Global`before
+    ],
+    0,
+    opts
+  ];


### PR DESCRIPTION
## Changes

* Resolves #163.
* Assignes `Temporary` attribute to all relevant symbols created with `Unique[]` and so on, so that they don't cause a memory leak.
* The symbols affected are new atom names (which are created even with `"NodeNamingFunction" -> All`, but are now automatically removed after renaming is done), and symbols used in patterns in symbolic WL code.
* There was also a `Module` symbol where `Attributes` were manually assigned without `Temporary`.

## Tests

* Run new unit tests checking for leaked symbols.
* The memory use ***before*** this PR (LowLevel code):
```
In[] := ListPlot[Table[
  WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 9, 
   "GenerationsCount", Method -> "LowLevel"]; MemoryInUse[], 10]]
```
![image](https://user-images.githubusercontent.com/1479325/71394459-a4bce900-25df-11ea-808d-bff53e4ebd5a.png)
* Symbolic code ***before***:
```
In[] := ListPlot[Table[
  WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 7, 
   "GenerationsCount", Method -> "Symbolic"]; MemoryInUse[], 10]]
```
![image](https://user-images.githubusercontent.com/1479325/71394471-b0a8ab00-25df-11ea-8e29-bb3b18dea72a.png)
* LowLevel code now:
```
In[] := ListPlot[Table[
  WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 9, 
   "GenerationsCount", Method -> "LowLevel"]; MemoryInUse[], 10]]
```
![image](https://user-images.githubusercontent.com/1479325/71394479-bb634000-25df-11ea-9dd7-fecf88e53cb6.png)
* Symbolic code now:
```
In[] := ListPlot[Table[
  WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 7, 
   "GenerationsCount", Method -> "Symbolic"]; MemoryInUse[], 10]]
```
![image](https://user-images.githubusercontent.com/1479325/71394483-c4541180-25df-11ea-9d93-da42f2fe35ac.png)