### PR TITLE
IncludeBoundaryEvents

### DIFF
--- a/SetReplace/WolframModel.m
+++ b/SetReplace/WolframModel.m
@@ -181,7 +181,7 @@ WolframModel[
 				$Failed],
 			$Failed];
 		propertyEvaluateWithOptions =
-			propertyEvaluate[OptionValue["IncludePartialGenerations"]][renamedNodesEvolution, WolframModel, #] &;
+			propertyEvaluate[OptionValue["IncludePartialGenerations"], None][renamedNodesEvolution, WolframModel, #] &;
 		result = Check[
 			If[renamedNodesEvolution =!= $Failed,
 				If[ListQ[property],

--- a/SetReplace/WolframModel.m
+++ b/SetReplace/WolframModel.m
@@ -53,7 +53,8 @@ SyntaxInformation[WolframModel] =
 Options[WolframModel] := Join[{
 	"NodeNamingFunction" -> Automatic,
 	"EventOrderingFunction" -> "Sequential", (* Possible values are "Sequential" and "Random" *)
-	"IncludePartialGenerations" -> True},
+	"IncludePartialGenerations" -> True,
+	"IncludeBoundaryEvents" -> None},
 	Options[setSubstitutionSystem]];
 
 
@@ -180,8 +181,12 @@ WolframModel[
 					OptionValue["NodeNamingFunction"]],
 				$Failed],
 			$Failed];
-		propertyEvaluateWithOptions =
-			propertyEvaluate[OptionValue["IncludePartialGenerations"], None][renamedNodesEvolution, WolframModel, #] &;
+		propertyEvaluateWithOptions = propertyEvaluate[
+			OptionValue["IncludePartialGenerations"],
+			OptionValue["IncludeBoundaryEvents"]][
+			renamedNodesEvolution,
+			WolframModel,
+			#] &;
 		result = Check[
 			If[renamedNodesEvolution =!= $Failed,
 				If[ListQ[property],

--- a/SetReplace/WolframModel.wlt
+++ b/SetReplace/WolframModel.wlt
@@ -1401,6 +1401,18 @@
         WolframModel[{} -> {{1, 2}}, {}, <|"MaxEvents" -> 0|>]
       ],
 
+      (** IncludeBoundaryEvents **)
+
+      testUnevaluated[
+        WolframModel[{{1, 2}} -> {{1, 2}}, {{1, 1}}, 1, "EventsCount", "IncludeBoundaryEvents" -> $$$invalid$$$],
+        {WolframModel::invalidFiniteOption}
+      ],
+
+      VerificationTest[
+        WolframModel[{{1, 2}} -> {{1, 2}}, {{1, 1}}, 1, "EventsCount", "IncludeBoundaryEvents" -> All],
+        3
+      ],
+
       (** EventOrderingFunction **)
 
       VerificationTest[

--- a/SetReplace/WolframModelEvolutionObject.wlt
+++ b/SetReplace/WolframModelEvolutionObject.wlt
@@ -175,6 +175,23 @@
         SameTest -> MatchQ
       ],
 
+      (* IncludeBoundaryEvents *)
+
+      With[{evo = WolframModel[{{1, 2}} -> {{1, 2}}, {{1, 1}}, 1]},
+        testUnevaluated[
+          evo["EventsCount", "IncludeBoundaryEvents" -> $$$invalid$$$],
+          {WolframModelEvolutionObject::invalidFiniteOption}
+        ]
+      ],
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}} -> {{1, 2}},
+          {{1, 1}},
+          1]["GenerationsCount", "IncludeBoundaryEvents" -> #],
+        1
+      ] & /@ {None, "Initial", "Final", All},
+
       (** Boxes **)
 
       VerificationTest[
@@ -261,6 +278,22 @@
           4]["EventsCount"],
         15
       ],
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4]["EventsCount", "IncludeBoundaryEvents" -> #],
+        #2
+      ] & @@@ {{"Initial", 16}, {"Final", 16}, {All, 17}},
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}} -> {{1, 2}},
+          {{1, 1}},
+          0]["EventsCount", "IncludeBoundaryEvents" -> #],
+        #2
+      ] & @@@ {{None, 0}, {"Initial", 1}, {"Final", 1}, {All, 2}},
 
       VerificationTest[
         WolframModel[
@@ -657,6 +690,25 @@
 
       VerificationTest[
         WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4]["EventGenerations", "IncludeBoundaryEvents" -> #],
+        #2
+      ] & @@@ {
+        {"Initial", {0, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 4}},
+        {"Final", {1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 4, 5}},
+        {All, {0, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 4, 5}}},
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}} -> {{1, 2}},
+          {{1, 1}},
+          0]["EventGenerations", "IncludeBoundaryEvents" -> #],
+        #2
+      ] & @@@ {{None, {}}, {"Initial", {0}}, {"Final", {1}}, {All, {0, 1}}},
+
+      VerificationTest[
+        WolframModel[
           {{1, 2}} -> {},
           {{1, 2}, {2, 3}},
           2]["EventGenerations"],
@@ -780,7 +832,45 @@
             Partition[Range[17], 2, 1],
             2][type, VertexLabels -> "Name"]], VertexLabels],
           {VertexLabels -> {"Name"}}
-        ]
+        ],
+
+        VerificationTest[
+          Through[{VertexList, Rule @@@ EdgeList[#] &}[WolframModel[
+            {{1, 2}, {2, 3}} -> {{1, 3}},
+            {{1, 2}, {2, 3}, {3, 4}, {4, 5}},
+            2][type, "IncludeBoundaryEvents" -> #1]]],
+          {#2, #3}
+        ] & @@@ {
+          {None, {1, 2, 3}, {1 -> 3, 2 -> 3}},
+          {"Initial", {0, 1, 2, 3}, {0 -> 1, 0 -> 1, 0 -> 2, 0 -> 2, 1 -> 3, 2 -> 3}},
+          {"Final", {1, 2, 3, Infinity}, {1 -> 3, 2 -> 3, 3 -> Infinity}},
+          {All, {0, 1, 2, 3, Infinity}, {0 -> 1, 0 -> 1, 0 -> 2, 0 -> 2, 1 -> 3, 2 -> 3, 3 -> Infinity}}},
+
+        VerificationTest[
+          Through[{VertexList, Rule @@@ EdgeList[#] &}[WolframModel[
+            {{1, 2}} -> {{1, 3}, {3, 2}},
+            {{1, 2}},
+            2][type, "IncludeBoundaryEvents" -> #1]]],
+          {#2, #3}
+        ] & @@@ {
+          {None, {1, 2, 3}, {1 -> 2, 1 -> 3}},
+          {"Initial", {0, 1, 2, 3}, {0 -> 1, 1 -> 2, 1 -> 3}},
+          {"Final", {1, 2, 3, Infinity}, {1 -> 2, 1 -> 3, 2 -> Infinity, 2 -> Infinity, 3 -> Infinity, 3 -> Infinity}},
+          {All,
+            {0, 1, 2, 3, Infinity},
+            {0 -> 1, 1 -> 2, 1 -> 3, 2 -> Infinity, 2 -> Infinity, 3 -> Infinity, 3 -> Infinity}}},
+
+        VerificationTest[
+          Through[{VertexList, Rule @@@ EdgeList[#] &}[WolframModel[
+            {{1, 2}} -> {{1, 2}},
+            {{1, 2}},
+            0][type, "IncludeBoundaryEvents" -> #1]]],
+          {#2, #3}
+        ] & @@@ {
+          {None, {}, {}},
+          {"Initial", {0}, {}},
+          {"Final", {Infinity}, {}},
+          {All, {0, Infinity}, {0 -> Infinity}}}
       }], {type, {"CausalGraph", "LayeredCausalGraph"}}],
 
       VerificationTest[
@@ -789,6 +879,14 @@
           pathGraph17,
           4]["LayeredCausalGraph"]], VertexCoordinates]][[All, 2]]],
         Floor[Log2[16 - Range[15]]]
+      ],
+
+      VerificationTest[
+        Round[Replace[VertexCoordinates, FilterRules[AbsoluteOptions[WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4]["LayeredCausalGraph", "IncludeBoundaryEvents" -> All]], VertexCoordinates]][[All, 2]]],
+        Join[{5}, Floor[Log2[16 - Range[15]]] + 1, {0}]
       ]
     }]
   |>


### PR DESCRIPTION
## Changes

* Closes #134.
* Adds `"IncludeBoundaryEvents"` option for `WolframModel` and `WolframModelEvolutionObject`.
* Currently affects `"EventsCount"`, `"EventGenerations"`, `"CausalGraph"` and `"LayeredCausalGraph"`.
* The initial event is `0`, the final event is `Infinity`.
* The initial event's generation is `0`, the final event's generation is `1 + "GenerationsCount"`.

## Tests

* For large initial conditions causal graph might appear disconnected if there is no information passed between parts of the initial condition:
```
In[] := WolframModel[{{1, 2}} -> {{1, 3}, {3, 2}}, {{1, 2}, {2, 3}, {3, 
    4}, {4, 5}}, 3]["CausalGraph", VertexLabels -> Automatic]
```
![image](https://user-images.githubusercontent.com/1479325/71494421-2f3a5e00-2815-11ea-8e52-6c9ac2fde191.png)
* Use `"IncludeBoundaryEvents"` option to include the initial event (i.e., event that creates the initial condition):
```
In[] := WolframModel[{{1, 2}} -> {{1, 3}, {3, 2}}, {{1, 2}, {2, 3}, {3, 
    4}, {4, 5}}, 3]["CausalGraph", VertexLabels -> Automatic, 
 "IncludeBoundaryEvents" -> "Initial"]
```
![image](https://user-images.githubusercontent.com/1479325/71494437-4aa56900-2815-11ea-8b7c-7a6e7b8e0ed9.png)
* Although utility of that is not as obvious, one can include the final event as well:
```
In[] := WolframModel[{{1, 2}} -> {{1, 3}, {3, 2}}, {{1, 2}, {2, 3}, {3, 
    4}, {4, 5}}, 3]["CausalGraph", VertexLabels -> Automatic, 
 "IncludeBoundaryEvents" -> All]
```
![image](https://user-images.githubusercontent.com/1479325/71494449-601a9300-2815-11ea-8737-05ef88ea94c4.png)
* This affects other properties as well, such as `"EventsCount"`:
```
In[] := WolframModel[{{1, 2}} -> {{1, 3}, {3, 2}}, {{1, 2}, {2, 3}, {3, 
     4}, {4, 5}}, 3, "EventsCount", 
   "IncludeBoundaryEvents" -> #] & /@ {None, "Initial", "Final", All}
```
```
Out[] = {28, 29, 29, 30}
```