### PR TITLE
AllEventsRuleIndices & AllEventsList

### DIFF
--- a/SetReplace/SetReplace.xcodeproj/project.pbxproj
+++ b/SetReplace/SetReplace.xcodeproj/project.pbxproj
@@ -279,7 +279,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				EXECUTABLE_PREFIX = lib;
-				HEADER_SEARCH_PATHS = /Applications/Mathematica.app/Contents/SystemFiles/IncludeFiles/C;
+				HEADER_SEARCH_PATHS = "/Applications/Wolfram\\ Desktop.app/Contents/SystemFiles/IncludeFiles/C";
 				LIBRARY_SEARCH_PATHS = "";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -294,7 +294,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				EXECUTABLE_PREFIX = lib;
-				HEADER_SEARCH_PATHS = /Applications/Mathematica.app/Contents/SystemFiles/IncludeFiles/C;
+				HEADER_SEARCH_PATHS = "/Applications/Wolfram\\ Desktop.app/Contents/SystemFiles/IncludeFiles/C";
 				LIBRARY_SEARCH_PATHS = "";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/SetReplace/WolframModel.wlt
+++ b/SetReplace/WolframModel.wlt
@@ -1526,7 +1526,64 @@
         WolframModel[
           {{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 3, "EventOrderingFunction" -> 1, Method -> "Symbolic"],
         {WolframModel::invalidFiniteOption}
-      ]
+      ],
+
+      (** AllEventsRuleIndices **)
+
+      Table[With[{method = method}, {
+        VerificationTest[
+          WolframModel[{{{1}} -> {{1}}}, {{1}}, 4, "AllEventsRuleIndices", Method -> method],
+          {1, 1, 1, 1}
+        ],
+
+        VerificationTest[
+          WolframModel[{{{1}} -> {{1, 2}}, {{1, 2}} -> {{1}}}, {{1}}, 4, "AllEventsRuleIndices", Method -> method],
+          {1, 2, 1, 2}
+        ],
+
+        VerificationTest[
+          WolframModel[{{{1, 2}} -> {{1}}, {{1}} -> {{1, 2}}}, {{1}}, 4, "AllEventsRuleIndices", Method -> method],
+          {2, 1, 2, 1}
+        ],
+
+        VerificationTest[
+          WolframModel[{{{1, 2}} -> {{1}}, {{1}} -> {{1, 2}}}, {{1}}, 0, "AllEventsRuleIndices", Method -> method],
+          {}
+        ],
+
+        VerificationTest[
+          WolframModel[
+            {{{1, 2}} -> {{1}}, {{1}} -> {{1, 2}}},
+            {{1}},
+            4,
+            "AllEventsRuleIndices",
+            "IncludeBoundaryEvents" -> "Initial",
+            Method -> method],
+          {0, 2, 1, 2, 1}
+        ],
+
+        VerificationTest[
+          WolframModel[
+            {{{1, 2}} -> {{1}}, {{1}} -> {{1, 2}}},
+            {{1}},
+            4,
+            "AllEventsRuleIndices",
+            "IncludeBoundaryEvents" -> "Final",
+            Method -> method],
+          {2, 1, 2, 1, Infinity}
+        ],
+
+        VerificationTest[
+          WolframModel[
+            {{{1, 2}} -> {{1}}, {{1}} -> {{1, 2}}},
+            {{1}},
+            4,
+            "AllEventsRuleIndices",
+            "IncludeBoundaryEvents" -> All,
+            Method -> method],
+          {0, 2, 1, 2, 1, Infinity}
+        ]
+      }], {method, DeleteCases[$SetReplaceMethods, Automatic]}]
     }
   |>,
 

--- a/SetReplace/WolframModelEvolutionObject.m
+++ b/SetReplace/WolframModelEvolutionObject.m
@@ -31,6 +31,7 @@ PackageScope["$atomLists"]
 PackageScope["$rules"]
 PackageScope["$maxCompleteGeneration"]
 PackageScope["$terminationReason"]
+PackageScope["$eventRuleIDs"]
 
 
 (* ::Section:: *)
@@ -709,7 +710,8 @@ evolutionDataQ[data_Association] :=
 		Keys[data],
 		{$creatorEvents, $destroyerEvents, $generations, $atomLists, $rules}] &&
 	SubsetQ[
-		{$creatorEvents, $destroyerEvents, $generations, $atomLists, $rules, $maxCompleteGeneration, $terminationReason},
+		{$creatorEvents, $destroyerEvents, $generations, $atomLists, $rules, $maxCompleteGeneration, $terminationReason,
+			$eventRuleIDs},
 		Keys[data]
 	]
 

--- a/SetReplace/WolframModelEvolutionObject.m
+++ b/SetReplace/WolframModelEvolutionObject.m
@@ -182,7 +182,8 @@ deleteIncompleteGenerations[WolframModelEvolutionObject[data_]] := Module[{
 		$atomLists -> data[$atomLists][[expressionsToKeep]],
 		$rules -> data[$rules],
 		$maxCompleteGeneration -> data[$maxCompleteGeneration],
-		$terminationReason -> data[$terminationReason]
+		$terminationReason -> data[$terminationReason],
+		$eventRuleIDs -> data[$eventRuleIDs][[eventsToKeep]]
 	|>]
 ]
 

--- a/SetReplace/WolframModelEvolutionObject.wlt
+++ b/SetReplace/WolframModelEvolutionObject.wlt
@@ -887,6 +887,78 @@
           pathGraph17,
           4]["LayeredCausalGraph", "IncludeBoundaryEvents" -> All]], VertexCoordinates]][[All, 2]]],
         Join[{5}, Floor[Log2[16 - Range[15]]] + 1, {0}]
+      ],
+
+      (* AllEventsList *)
+
+      Table[With[{method = method}, {
+        VerificationTest[
+          WolframModel[{{{1}} -> {{1}}}, {{1}}, 4, Method -> method]["AllEventsList"],
+          {{1, {1} -> {2}}, {1, {2} -> {3}}, {1, {3} -> {4}}, {1, {4} -> {5}}}
+        ],
+
+        VerificationTest[
+          WolframModel[{{{1}} -> {{1, 2}}, {{1, 2}} -> {{1}}}, {{1}}, 4, Method -> method]["AllEventsList"],
+          {{1, {1} -> {2}}, {2, {2} -> {3}}, {1, {3} -> {4}}, {2, {4} -> {5}}}
+        ],
+
+        VerificationTest[
+          WolframModel[{{{1, 2}} -> {{1}}, {{1}} -> {{1, 2}}}, {{1}}, 4, Method -> method]["AllEventsList"],
+          {{2, {1} -> {2}}, {1, {2} -> {3}}, {2, {3} -> {4}}, {1, {4} -> {5}}}
+        ],
+
+        VerificationTest[
+          WolframModel[{{{1, 2}} -> {{1}, {2}}, {{1}} -> {{1, 2}}}, {{1}}, 4, Method -> method]["AllEventsList"],
+          {{2, {1} -> {2}}, {1, {2} -> {3, 4}}, {2, {3} -> {5}}, {2, {4} -> {6}}, {1, {5} -> {7, 8}}, {1, {6} -> {9, 10}}}
+        ],
+
+        VerificationTest[
+          WolframModel[{{{1, 2}} -> {}, {{1}} -> {{1, 2}}}, {{1}}, 4, Method -> method]["AllEventsList"],
+          {{2, {1} -> {2}}, {1, {2} -> {}}}
+        ],
+
+        VerificationTest[
+          WolframModel[{{{1, 2}} -> {{1}}, {{1}} -> {{1, 2}}}, {{1}}, 0, Method -> method]["AllEventsList"],
+          {}
+        ],
+
+        VerificationTest[
+          WolframModel[
+            {{{1, 2}} -> {{1}}, {{1}} -> {{1, 2}}},
+            {{1}},
+            4,
+            Method -> method][
+            "AllEventsList",
+            "IncludeBoundaryEvents" -> "Initial"],
+          {{0, {} -> {1}}, {2, {1} -> {2}}, {1, {2} -> {3}}, {2, {3} -> {4}}, {1, {4} -> {5}}}
+        ],
+
+        VerificationTest[
+          WolframModel[
+            {{{1, 2}} -> {{1}}, {{1}} -> {{1, 2}}},
+            {{1}},
+            4,
+            Method -> method][
+            "AllEventsList",
+            "IncludeBoundaryEvents" -> "Final"],
+          {{2, {1} -> {2}}, {1, {2} -> {3}}, {2, {3} -> {4}}, {1, {4} -> {5}}, {\[Infinity], {5} -> {}}}
+        ],
+
+        VerificationTest[
+          WolframModel[
+            {{{1, 2}} -> {{1}}, {{1}} -> {{1, 2}}},
+            {{1}},
+            4,
+            Method -> method][
+            "AllEventsList",
+            "IncludeBoundaryEvents" -> All],
+          {{0, {} -> {1}}, {2, {1} -> {2}}, {1, {2} -> {3}}, {2, {3} -> {4}}, {1, {4} -> {5}}, {\[Infinity], {5} -> {}}}
+        ]
+      }], {method, DeleteCases[$SetReplaceMethods, Automatic]}],
+
+      VerificationTest[
+        WolframModel[{{{1, 2}} -> {{}}, {{}} -> {{1, 2}}}, {{}}, 4]["AllEventsList"],
+        {{2, {1} -> {2}}, {1, {2} -> {3}}, {2, {3} -> {4}}, {1, {4} -> {5}}}
       ]
     }]
   |>

--- a/SetReplace/libSetReplace/Set.cpp
+++ b/SetReplace/libSetReplace/Set.cpp
@@ -18,10 +18,10 @@ namespace SetReplace {
         TerminationReason terminationReason_ = TerminationReason::NotTerminated;
         
         std::unordered_map<ExpressionID, SetExpression> expressions_;
+        std::vector<RuleID> eventRuleIDs_ = {-1};
         
         Atom nextAtom_ = 1;
         ExpressionID nextExpressionID_ = 0;
-        EventID nextEventID_ = 1;
         
         int destroyedExpressionsCount_ = 0;
         
@@ -52,7 +52,7 @@ namespace SetReplace {
         int replaceOnce(const std::function<bool()> shouldAbort) {
             terminationReason_ = TerminationReason::NotTerminated;
 
-            if (nextEventID_ > stepSpec_.maxEvents) {
+            if (eventRuleIDs_.size() > stepSpec_.maxEvents) {
                 terminationReason_ = TerminationReason::MaxEvents;
                 return 0;
             }
@@ -108,9 +108,10 @@ namespace SetReplace {
             }
             largestGeneration_ = std::max(largestGeneration_, outputGeneration);
             
-            const EventID eventID = nextEventID_++;
+            const EventID eventID = static_cast<int>(eventRuleIDs_.size());
             addExpressions(namedRuleOutputs, eventID, outputGeneration);
             assignDestroyerEvent(match.inputExpressions, eventID);
+            eventRuleIDs_.push_back(match.rule);
             
             return 1;
         }
@@ -151,6 +152,10 @@ namespace SetReplace {
         
         TerminationReason terminationReason() const {
             return terminationReason_;
+        }
+        
+        const std::vector<RuleID>& eventRuleIDs() const {
+            return eventRuleIDs_;
         }
 
     private:
@@ -357,5 +362,9 @@ namespace SetReplace {
 
     Set::TerminationReason Set::terminationReason() const {
         return implementation_->terminationReason();
+    }
+
+    const std::vector<RuleID>& Set::eventRuleIDs() const {
+        return implementation_->eventRuleIDs();
     }
 }

--- a/SetReplace/libSetReplace/Set.hpp
+++ b/SetReplace/libSetReplace/Set.hpp
@@ -81,6 +81,10 @@ namespace SetReplace {
         /** @brief Yields termination reason for the previous evaluation, or TerminationReason::NotTerminated if no evaluation was done yet.
          */
         TerminationReason terminationReason() const;
+        
+        /** @brief Yields rule IDs corresponding to each event.
+         */
+        const std::vector<RuleID>& eventRuleIDs() const;
 
     private:
         class Implementation;

--- a/SetReplace/libSetReplace/SetReplace.cpp
+++ b/SetReplace/libSetReplace/SetReplace.cpp
@@ -239,6 +239,33 @@ namespace SetReplace {
 
         return LIBRARY_NO_ERROR;
     }
+
+    int eventRuleIDs(WolframLibraryData libData, mint argc, MArgument *argv, MArgument result) {
+        if (argc != 1) {
+            return LIBRARY_FUNCTION_ERROR;
+        }
+        
+        auto setPtr = (Set*)MArgument_getInteger(argv[0]);
+        try {
+            const auto ruleIDs = setPtr->eventRuleIDs();
+            mint dimensions[1] = {static_cast<mint>(ruleIDs.size() - 1)};
+            MTensor output;
+            libData->MTensor_new(MType_Integer, 1, dimensions, &output);
+            
+            int writeIndex = 0;
+            mint position[1];
+            for (int event = 1; event < ruleIDs.size(); ++event) {
+                position[0] = ++writeIndex;
+                libData->MTensor_setInteger(output, position, ruleIDs[event] + 1);
+            }
+            
+            MArgument_setMTensor(result, output);
+        } catch (...) {
+            return LIBRARY_FUNCTION_ERROR;
+        }
+        
+        return LIBRARY_NO_ERROR;
+    }
 }
 
 EXTERN_C mint WolframLibrary_getVersion() {
@@ -275,4 +302,8 @@ EXTERN_C int maxCompleteGeneration(WolframLibraryData libData, mint argc, MArgum
 
 EXTERN_C int terminationReason(WolframLibraryData libData, mint argc, MArgument *argv, MArgument result) {
     return SetReplace::terminationReason(libData, argc, argv, result);
+}
+
+EXTERN_C int eventRuleIDs(WolframLibraryData libData, mint argc, MArgument *argv, MArgument result) {
+    return SetReplace::eventRuleIDs(libData, argc, argv, result);
 }

--- a/SetReplace/libSetReplace/SetReplace.hpp
+++ b/SetReplace/libSetReplace/SetReplace.hpp
@@ -38,4 +38,8 @@ EXTERN_C DLLEXPORT int maxCompleteGeneration(WolframLibraryData libData, mint ar
  */
 EXTERN_C DLLEXPORT int terminationReason(WolframLibraryData libData, mint argc, MArgument *argv, MArgument result);
 
+/** @brief Returns the list of indices of rules used for each event.
+ */
+EXTERN_C DLLEXPORT int eventRuleIDs(WolframLibraryData libData, mint argc, MArgument *argv, MArgument result);
+
 #endif /* SetReplace_hpp */

--- a/SetReplace/setSubstitutionSystem$cpp.m
+++ b/SetReplace/setSubstitutionSystem$cpp.m
@@ -80,6 +80,15 @@ $cpp$terminationReason = If[$libraryFile =!= $Failed,
 	$Failed];
 
 
+$cpp$eventRuleIDs = If[$libraryFile =!= $Failed,
+	LibraryFunctionLoad[
+		$libraryFile,
+		"eventRuleIDs",
+		{Integer}, (* set ptr *)
+		{Integer, 1}], (* ids *)
+	$Failed];
+
+
 (* ::Section:: *)
 (*Implementation*)
 
@@ -207,8 +216,8 @@ setSubstitutionSystem$cpp[rules_, set_, stepSpec_, returnOnAbortQ_, timeConstrai
 			$cppSetReplaceAvailable := Module[{
 		canonicalRules,
 		setAtoms, atomsInRules, globalAtoms, globalIndex,
-		mappedSet, localIndices, mappedRules, setPtr, cppOutput, maxCompleteGeneration, terminationReason, resultAtoms,
-		inversePartialGlobalMap, inverseGlobalMap},
+		mappedSet, localIndices, mappedRules, setPtr, cppOutput, maxCompleteGeneration, terminationReason, eventRuleIDs,
+		resultAtoms, inversePartialGlobalMap, inverseGlobalMap},
 	canonicalRules = toCanonicalRules[rules];
 	setAtoms = Hold /@ Union[Catenate[set]];
 	atomsInRules = ruleAtoms /@ canonicalRules;
@@ -244,6 +253,7 @@ setSubstitutionSystem$cpp[rules_, set_, stepSpec_, returnOnAbortQ_, timeConstrai
 	terminationReason = Replace[$terminationReasonCodes[$cpp$terminationReason[setPtr]], {
 		$Aborted -> terminationReason,
 		$notTerminated -> $timeConstraint}];
+	eventRuleIDs = $cpp$eventRuleIDs[setPtr];
 	$cpp$setDelete[setPtr];
 	resultAtoms = Union[Catenate[cppOutput[$atomLists]]];
 	inversePartialGlobalMap = Association[Reverse /@ Normal @ globalIndex];
@@ -255,6 +265,7 @@ setSubstitutionSystem$cpp[rules_, set_, stepSpec_, returnOnAbortQ_, timeConstrai
 				ReleaseHold @ Map[inverseGlobalMap, cppOutput[$atomLists], {2}],
 			$rules -> rules,
 			$maxCompleteGeneration -> maxCompleteGeneration,
-			$terminationReason -> terminationReason
+			$terminationReason -> terminationReason,
+			$eventRuleIDs -> eventRuleIDs
 		|>]]
 ]


### PR DESCRIPTION
## Changes
* Closes #83.
* Implements tracking of rule indices used for each replacement.
* Adds `"AllEventsRuleIndices"` and `"AllEventsList"` properties for the evolution object:
  * `"AllEventsRuleIndices"` yields a list of indices of the rules used for each update. `0` is used for the initial condition, and `Infinity` is used for the final state event.
  * `"AllEventsList"` yields a list of events which have the format `{ruleIndex, input -> output}`, where `input` and `output` are lists of indices of expressions in `"AllExpressions"`.

## Tests
* Consider a model which makes use of multiple rules:
```
In[] := obj = WolframModel[{{{1, 2}, {2, 3}} -> {{1, 3}, {1, 4}, {2, 4}, {4, 
      1}}, {{1, 2}, {3, 2}} -> {{1, 2}}}, {{1, 1}, {1, 1}}, 5]
```
![image](https://user-images.githubusercontent.com/1479325/71638054-867c6c00-2c23-11ea-83ad-1dcc931ba036.png)
* Check that both rules are used:
```
In[] := obj["AllEventsRuleIndices"]
```
```
Out[] = {1, 1, 1, 2, 1, 1, 1, 1, 2, 2, 1, 2, 1, 1, 1, 1, 2, 1, 1, 1}
```
* Check the events themselves including the expressions used:
```
In[] := obj["AllEventsList"]
```
```
Out[] = {{1, {1, 2} -> {3, 4, 5, 6}}, {1, {3, 4} -> {7, 8, 9, 10}}, {1, {5, 
    6} -> {11, 12, 13, 14}}, {2, {8, 9} -> {15}}, {1, {7, 10} -> {16, 
    17, 18, 19}}, {1, {11, 12} -> {20, 21, 22, 23}}, {1, {13, 
    14} -> {24, 25, 26, 27}}, {1, {15, 16} -> {28, 29, 30, 
    31}}, {2, {17, 18} -> {32}}, {2, {21, 22} -> {33}}, {1, {20, 
    23} -> {34, 35, 36, 37}}, {2, {25, 26} -> {38}}, {1, {24, 
    27} -> {39, 40, 41, 42}}, {1, {19, 30} -> {43, 44, 45, 
    46}}, {1, {28, 31} -> {47, 48, 49, 50}}, {1, {33, 34} -> {51, 52, 
    53, 54}}, {2, {35, 36} -> {55}}, {1, {29, 39} -> {56, 57, 58, 
    59}}, {1, {38, 40} -> {60, 61, 62, 63}}, {1, {41, 42} -> {64, 65, 
    66, 67}}}
```
* Highlight different rules with different colors in a `"CausalGraph"`:
```
In[] := obj["CausalGraph", 
 VertexStyle -> 
  Thread[Range[
     obj["EventsCount"]] -> (obj[
       "AllEventsRuleIndices"] /. {1 -> Blue, 2 -> Red})]]
```
![image](https://user-images.githubusercontent.com/1479325/71638077-fd196980-2c23-11ea-80ef-15e0dafc6fb1.png)