### PR TITLE
Sequential incomplete events

### DIFF
--- a/SetReplace/WolframModel.wlt
+++ b/SetReplace/WolframModel.wlt
@@ -1400,6 +1400,28 @@
         }] & @@@ models
       ], {method, DeleteCases[$SetReplaceMethods, Automatic]}],
 
+      VerificationTest[
+        SameQ @@ ((SeedRandom[2];
+          WolframModel[
+            {{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}},
+            {{1, 1}},
+            <|"MaxEvents" -> #|>,
+            "EventOrderingFunction" -> "Random",
+            "IncludePartialGenerations" -> False]) & /@ {200, 300})
+      ],
+
+      VerificationTest[
+        SeedRandom[2];
+          Sort[VertexList[WolframModel[
+            {{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}},
+            {{1, 1}},
+            <|"MaxEvents" -> 200|>,
+            "EventOrderingFunction" -> "Random",
+            "IncludePartialGenerations" -> False][
+            "CausalGraph"]]],
+        Range[13]
+      ],
+
       testUnevaluated[
         WolframModel[{{1, 2, 3}} -> {{1, 2, 3}}, {{1, 2, 3}}, 1, "IncludePartialGenerations" -> $$$invalid$$$],
         {WolframModel::invalidFiniteOption}


### PR DESCRIPTION
## Changes
* Closes #170.
* Event numbers are now sequential after removing incomplete generations.

## Tests
* Note that event numbers here are `Range[13]` instead of being large random numbers:
```
In[] := SeedRandom[2];
WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, <|
   "MaxEvents" -> 500|>, "EventOrderingFunction" -> "Random", 
  "IncludePartialGenerations" -> False]["CausalGraph", 
 VertexLabels -> Automatic]
```
![image](https://user-images.githubusercontent.com/1479325/71645864-8d9b8c80-2cac-11ea-8d5a-f40d5133f295.png)