### PR TITLE
WolframModelPlot

### DIFF
--- a/SetReplace/RulePlot.m
+++ b/SetReplace/RulePlot.m
@@ -92,15 +92,14 @@ correctOptionsQ[args_, {opts___}] :=
   supportedOptionQ[RulePlot, Frame, {True, False}, {opts}] &&
   correctEdgeTypeQ[OptionValue[RulePlot, {opts}, "EdgeType"]] &&
   correctSpacingsQ[{opts}] &&
-  correctHypergraphPlotOptionsQ[
-    RulePlot, Defer[RulePlot[WolframModel[args], opts]], Automatic, FilterRules[{opts}, Options[HypergraphPlot]]]
+  correctWolframModelPlotOptionsQ[
+    RulePlot, Defer[RulePlot[WolframModel[args], opts]], Automatic, FilterRules[{opts}, Options[WolframModelPlot]]]
 
-correctEdgeTypeQ[edgeType : Alternatives @@ $edgeTypes] := True
-
-correctEdgeTypeQ[edgeType_] := (
+correctEdgeTypeQ[edgeType_] := If[MatchQ[edgeType, Alternatives @@ $edgeTypes],
+  True,
   Message[RulePlot::invalidEdgeType, edgeType, $edgeTypes];
   False
-)
+]
 
 correctSpacingsQ[opts_] := Module[{spacings, correctQ},
   spacings = OptionValue[RulePlot, opts, Spacings];
@@ -174,7 +173,7 @@ singleRulePlot[
   vertexCoordinateRules = Join[
     ruleCoordinateRules[edgeType, hyperedgeRendering, externalVertexCoordinateRules, rule],
     externalVertexCoordinateRules];
-  ruleSidePlots = HypergraphPlot[
+  ruleSidePlots = WolframModelPlot[
       #,
       edgeType,
       GraphHighlight -> sharedRuleElements[rule],

--- a/SetReplace/RulePlot.wlt
+++ b/SetReplace/RulePlot.wlt
@@ -263,7 +263,7 @@
 
       VerificationTest[
         First[Cases[RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}]], Disk[_, r_] :> r, All]] > 
-          First[Cases[HypergraphPlot[{{1, 2, 3}}], Disk[_, r_] :> r, All]]
+          First[Cases[WolframModelPlot[{{1, 2, 3}}], Disk[_, r_] :> r, All]]
       ],
 
       (** Consistent vertex sizes **)

--- a/SetReplace/WolframModelPlot.m
+++ b/SetReplace/WolframModelPlot.m
@@ -1,24 +1,24 @@
 Package["SetReplace`"]
 
-PackageExport["HypergraphPlot"]
+PackageExport["WolframModelPlot"]
 
-PackageScope["correctHypergraphPlotOptionsQ"]
+PackageScope["correctWolframModelPlotOptionsQ"]
 PackageScope["$edgeTypes"]
 PackageScope["hypergraphEmbedding"]
 
 (* Documentation *)
 
-HypergraphPlot::usage = usageString[
-	"HypergraphPlot[`s`, `opts`] plots a list of vertex lists `s` as a hypergraph."];
+WolframModelPlot::usage = usageString[
+	"WolframModelPlot[`s`, `opts`] plots a list of vertex lists `s` as a hypergraph."];
 
-SyntaxInformation[HypergraphPlot] = {"ArgumentsPattern" -> {_, _., OptionsPattern[]}};
+SyntaxInformation[WolframModelPlot] = {"ArgumentsPattern" -> {_, _., OptionsPattern[]}};
 
 $plotStyleAutomatic = <|
 	_ -> Hue[0.6, 0.2, 0.8], (* vertex style *)
 	_List -> Hue[0.6, 0.7, 0.5]|>; (* edge style *)
 
 (* Automatic style pickes up, and possibly modifies the style it inherits from. *)
-Options[HypergraphPlot] = Join[{
+Options[WolframModelPlot] = Join[{
 	"EdgePolygonStyle" -> Automatic, (* inherits from EdgeStyle, with specified small opacity *)
 	EdgeStyle -> Automatic, (* inherits from PlotStyle *)
 	GraphHighlight -> {},
@@ -40,7 +40,7 @@ $hyperedgeRenderings = {"Subgraphs", "Polygons"};
 (* Messages *)
 
 General::invalidEdges =
-	"First argument of HypergraphPlot must be list of lists, where elements represent vertices.";
+	"First argument of WolframModelPlot must be list of lists, where elements represent vertices.";
 
 General::invalidEdgeType =
 	"Edge type `1` should be one of `2`.";
@@ -48,7 +48,7 @@ General::invalidEdgeType =
 General::invalidCoordinates =
 	"Coordinates `1` should be a list of rules from vertices to pairs of numbers.";
 
-HypergraphPlot::invalidHighlight =
+WolframModelPlot::invalidHighlight =
 	"GraphHighlight value `1` should be a list of vertices and edges.";
 
 General::invalidHighlightStyle =
@@ -65,32 +65,32 @@ General::invalidStyleLength =
 
 (* Evaluation *)
 
-func : HypergraphPlot[args___] := Module[{result = hypergraphPlot$parse[args]},
+func : WolframModelPlot[args___] := Module[{result = wolframModelPlot$parse[args]},
 	result /; result =!= $Failed
 ]
 
 (* Arguments parsing *)
 
-hypergraphPlot$parse[args___] /; !Developer`CheckArgumentCount[HypergraphPlot[args], 1, 2] := $Failed
+wolframModelPlot$parse[args___] /; !Developer`CheckArgumentCount[WolframModelPlot[args], 1, 2] := $Failed
 
-hypergraphPlot$parse[edges : Except[{___List}], edgeType_ : $defaultEdgeType, o : OptionsPattern[]] := (
-	Message[HypergraphPlot::invalidEdges];
+wolframModelPlot$parse[edges : Except[{___List}], edgeType_ : $defaultEdgeType, o : OptionsPattern[]] := (
+	Message[WolframModelPlot::invalidEdges];
 	$Failed
 )
 
-hypergraphPlot$parse[
+wolframModelPlot$parse[
 		edges : {___List},
 		edgeType : Except[Alternatives[Alternatives @@ $edgeTypes, OptionsPattern[]]],
 		o : OptionsPattern[]] := (
-	Message[HypergraphPlot::invalidEdgeType, edgeType, $edgeTypes];
+	Message[WolframModelPlot::invalidEdgeType, edgeType, $edgeTypes];
 	$Failed
 )
 
-hypergraphPlot$parse[
+wolframModelPlot$parse[
 			edges : {___List}, edgeType : Alternatives @@ $edgeTypes : $defaultEdgeType, o : OptionsPattern[]] /;
-				correctHypergraphPlotOptionsQ[HypergraphPlot, Defer[HypergraphPlot[edges, o]], edges, {o}] := Module[{
+				correctWolframModelPlotOptionsQ[WolframModelPlot, Defer[WolframModelPlot[edges, o]], edges, {o}] := Module[{
 		optionValue, plotStyles, edgeStyle, styles},
-	optionValue[opt_] := OptionValue[HypergraphPlot, {o}, opt];
+	optionValue[opt_] := OptionValue[WolframModelPlot, {o}, opt];
 	vertices = vertexList[edges];
 	(* these are lists, one style for each vertex element *)
 	styles = <|
@@ -106,7 +106,7 @@ hypergraphPlot$parse[
 			Directive[#, Opacity[0.7]] &]),
 		$edgePoint -> edgeStyles,
 		$edgePolygon -> parseStyles[optionValue["EdgePolygonStyle"], edges, edgeStyles, Directive[#, Opacity[0.09]] &]|>;
-	hypergraphPlot[edges, edgeType, styles, ##, FilterRules[{o}, Options[Graphics]]] & @@
+	wolframModelPlot[edges, edgeType, styles, ##, FilterRules[{o}, Options[Graphics]]] & @@
 			(optionValue /@ {
 				GraphHighlight,
 				GraphHighlightStyle,
@@ -130,22 +130,22 @@ parseStyles[newSpec_, elements_, oldSpec_, oldToNewTransform_] :=
 		If[#2 === Automatic, #1, Replace[#1, Automatic -> oldToNewTransform[#2]]] &,
 		toListStyleSpec[#, elements] & /@ {newSpec, oldSpec}]
 
-hypergraphPlot$parse[___] := $Failed
+wolframModelPlot$parse[___] := $Failed
 
-correctHypergraphPlotOptionsQ[head_, expr_, edges_, opts_] :=
+correctWolframModelPlotOptionsQ[head_, expr_, edges_, opts_] :=
 	knownOptionsQ[head, expr, opts] &&
 	(And @@ (supportedOptionQ[head, ##, opts] & @@@ {
 			{"HyperedgeRendering", $hyperedgeRenderings}})) &&
-	correctCoordinateRulesQ[head, OptionValue[HypergraphPlot, opts, VertexCoordinateRules]] &&
-	correctHighlightQ[edges, OptionValue[HypergraphPlot, opts, GraphHighlight]] &&
-	correctHighlightStyleQ[head, OptionValue[HypergraphPlot, opts, GraphHighlightStyle]] &&
-	correctSizeQ[head, "Vertex size", OptionValue[HypergraphPlot, opts, VertexSize]] &&
-	correctSizeQ[head, "Arrowhead length", OptionValue[HypergraphPlot, opts, "ArrowheadLength"]] &&
-	correctPlotStyleQ[head, OptionValue[HypergraphPlot, opts, PlotStyle]] &&
+	correctCoordinateRulesQ[head, OptionValue[WolframModelPlot, opts, VertexCoordinateRules]] &&
+	correctHighlightQ[edges, OptionValue[WolframModelPlot, opts, GraphHighlight]] &&
+	correctHighlightStyleQ[head, OptionValue[WolframModelPlot, opts, GraphHighlightStyle]] &&
+	correctSizeQ[head, "Vertex size", OptionValue[WolframModelPlot, opts, VertexSize]] &&
+	correctSizeQ[head, "Arrowhead length", OptionValue[WolframModelPlot, opts, "ArrowheadLength"]] &&
+	correctPlotStyleQ[head, OptionValue[WolframModelPlot, opts, PlotStyle]] &&
 	correctStyleLengthQ[
-		head, "vertices", Length[vertexList[edges]], OptionValue[HypergraphPlot, opts, VertexStyle]] &&
+		head, "vertices", Length[vertexList[edges]], OptionValue[WolframModelPlot, opts, VertexStyle]] &&
 	And @@ (correctStyleLengthQ[
-		head, "edges", Length[edges], OptionValue[HypergraphPlot, opts, #]] & /@ {EdgeStyle, "EdgePolygonStyle"})
+		head, "edges", Length[edges], OptionValue[WolframModelPlot, opts, #]] & /@ {EdgeStyle, "EdgePolygonStyle"})
 
 correctCoordinateRulesQ[head_, coordinateRules_] :=
 	If[!MatchQ[coordinateRules,
@@ -160,7 +160,7 @@ correctHighlightQ[edges : Except[Automatic], highlight_] := Module[{
 		vertices, validQ},
 	vertices = vertexList[edges];
 	validQ = ListQ[highlight];
-	If[!validQ, Message[HypergraphPlot::invalidHighlight, highlight]];
+	If[!validQ, Message[WolframModelPlot::invalidHighlight, highlight]];
 	validQ
 ]
 
@@ -192,7 +192,7 @@ correctStyleLengthQ[__] := True
 
 (* Implementation *)
 
-hypergraphPlot[
+wolframModelPlot[
 		edges_,
 		edgeType_,
 		styles_,
@@ -372,7 +372,7 @@ drawEmbedding[
 		embedding,
 		{2}];
 	If[AnyTrue[highlightCounts, # > 0 &],
-		Message[HypergraphPlot::invalidHighlight, highlight];
+		Message[WolframModelPlot::invalidHighlight, highlight];
 		Throw[$Failed]];
 
 	vertexPoints = MapIndexed[

--- a/SetReplace/WolframModelPlot.wlt
+++ b/SetReplace/WolframModelPlot.wlt
@@ -1,5 +1,5 @@
 <|
-  "HypergraphPlot" -> <|
+  "WolframModelPlot" -> <|
     "init" -> (
       $edgeTypes = {"Ordered", "Cyclic"};
 
@@ -26,7 +26,7 @@
       };
 
       $selfLoopLength = FirstCase[
-        HypergraphPlot[{{1, 1}}, "HyperedgeRendering" -> "Subgraphs"],
+        WolframModelPlot[{{1, 1}}, "HyperedgeRendering" -> "Subgraphs"],
         Line[pts_] :> RegionMeasure[Line[pts]],
         Missing[],
         All];
@@ -48,7 +48,7 @@
         Outer[
           VerificationTest[
             With[{
-                plot = HypergraphPlot[set, #1, "HyperedgeRendering" -> #2, Sequence @@ opts]},
+                plot = WolframModelPlot[set, #1, "HyperedgeRendering" -> #2, Sequence @@ opts]},
               And @@ (If[shouldExistQ, Not, Identity][FreeQ[plot, #]] & /@ colors)
             ]
           ] &,
@@ -64,7 +64,7 @@
 
       testSymbolLeak[
         SeedRandom[123];
-        HypergraphPlot[RandomInteger[200, {100, 3}]]
+        WolframModelPlot[RandomInteger[200, {100, 3}]]
       ],
 
       (* Argument Checks *)
@@ -72,201 +72,201 @@
       (** Argument count **)
 
       testUnevaluated[
-        HypergraphPlot[],
-        {HypergraphPlot::argt}
+        WolframModelPlot[],
+        {WolframModelPlot::argt}
       ],
 
       testUnevaluated[
-        HypergraphPlot[{{1, 2}}, {{1, 2}}, {{1, 2}}],
-        {HypergraphPlot::argt}
+        WolframModelPlot[{{1, 2}}, {{1, 2}}, {{1, 2}}],
+        {WolframModelPlot::argt}
       ],
 
       (** Valid edges **)
 
       testUnevaluated[
-        HypergraphPlot[1],
-        {HypergraphPlot::invalidEdges}
+        WolframModelPlot[1],
+        {WolframModelPlot::invalidEdges}
       ],
 
       testUnevaluated[
-        HypergraphPlot[{1, 2}],
-        {HypergraphPlot::invalidEdges}
+        WolframModelPlot[{1, 2}],
+        {WolframModelPlot::invalidEdges}
       ],
 
       testUnevaluated[
-        HypergraphPlot[{{1, 3}, 2}],
-        {HypergraphPlot::invalidEdges}
+        WolframModelPlot[{{1, 3}, 2}],
+        {WolframModelPlot::invalidEdges}
       ],
 
       testUnevaluated[
-        HypergraphPlot[{{1, 3}, 6, {2, 4}}],
-        {HypergraphPlot::invalidEdges}
+        WolframModelPlot[{{1, 3}, 6, {2, 4}}],
+        {WolframModelPlot::invalidEdges}
       ],
 
       (** Valid EdgeType **)
 
       testUnevaluated[
-        HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, None],
-        {HypergraphPlot::invalidEdgeType}
+        WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, None],
+        {WolframModelPlot::invalidEdgeType}
       ],
 
       testUnevaluated[
-        HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "$$$Incorrect$$$"],
-        {HypergraphPlot::invalidEdgeType}
+        WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, "$$$Incorrect$$$"],
+        {WolframModelPlot::invalidEdgeType}
       ],
 
       testUnevaluated[
-        HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, {"$$$Incorrect$$$"}],
-        {HypergraphPlot::invalidEdgeType}
+        WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, {"$$$Incorrect$$$"}],
+        {WolframModelPlot::invalidEdgeType}
       ],
 
       testUnevaluated[
-        HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, {{1, 2, 3} -> "$$$Incorrect$$$"}],
-        {HypergraphPlot::invalidEdgeType}
+        WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, {{1, 2, 3} -> "$$$Incorrect$$$"}],
+        {WolframModelPlot::invalidEdgeType}
       ],
 
       testUnevaluated[
-        HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, {None, {1, 2, 3} -> "Ordered"}],
-        {HypergraphPlot::invalidEdgeType}
+        WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, {None, {1, 2, 3} -> "Ordered"}],
+        {WolframModelPlot::invalidEdgeType}
       ],
 
       testUnevaluated[
-        HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, {"$$$Incorrect$$$", {1, 2, 3} -> "Ordered"}],
-        {HypergraphPlot::invalidEdgeType}
+        WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, {"$$$Incorrect$$$", {1, 2, 3} -> "Ordered"}],
+        {WolframModelPlot::invalidEdgeType}
       ],
 
       testUnevaluated[
-        HypergraphPlot[
+        WolframModelPlot[
           {{1, 2, 3}, {3, 4, 5}},
           {{3, 4, 5} -> "Ordered", {1, 2, 3} -> "$$$Incorrect$$$"}],
-        {HypergraphPlot::invalidEdgeType}
+        {WolframModelPlot::invalidEdgeType}
       ],
 
       VerificationTest[
-        Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "Ordered"]],
+        Head[WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, "Ordered"]],
         Graphics
       ],
 
       VerificationTest[
-        Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "Cyclic"]],
+        Head[WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, "Cyclic"]],
         Graphics
       ],
 
       (* Valid options *)
 
       testUnevaluated[
-        HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "$$$InvalidOption###" -> True],
-        {HypergraphPlot::optx}
+        WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, "$$$InvalidOption###" -> True],
+        {WolframModelPlot::optx}
       ],
 
       testUnevaluated[
-        HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "Ordered", "$$$InvalidOption###" -> True],
-        {HypergraphPlot::optx}
+        WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, "Ordered", "$$$InvalidOption###" -> True],
+        {WolframModelPlot::optx}
       ],
 
       testUnevaluated[
-        HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "$$$Incorrect$$$", "$$$InvalidOption###" -> True],
-        {HypergraphPlot::invalidEdgeType}
+        WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, "$$$Incorrect$$$", "$$$InvalidOption###" -> True],
+        {WolframModelPlot::invalidEdgeType}
       ],
 
       (* Valid coordinates *)
 
       testUnevaluated[
-        HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, VertexCoordinateRules -> $$$invalid$$$],
-        {HypergraphPlot::invalidCoordinates}
+        WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, VertexCoordinateRules -> $$$invalid$$$],
+        {WolframModelPlot::invalidCoordinates}
       ],
 
       testUnevaluated[
-        HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, VertexCoordinateRules -> {{0, 0}}],
-        {HypergraphPlot::invalidCoordinates}
+        WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, VertexCoordinateRules -> {{0, 0}}],
+        {WolframModelPlot::invalidCoordinates}
       ],
 
       testUnevaluated[
-        HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, VertexCoordinateRules -> {1 -> {0}}],
-        {HypergraphPlot::invalidCoordinates}
+        WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, VertexCoordinateRules -> {1 -> {0}}],
+        {WolframModelPlot::invalidCoordinates}
       ],
 
       VerificationTest[
-        Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, VertexCoordinateRules -> {1 -> {0, 0}}]],
+        Head[WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, VertexCoordinateRules -> {1 -> {0, 0}}]],
         Graphics
       ],
 
       VerificationTest[
-        Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "Ordered", VertexCoordinateRules -> {1 -> {0, 0}}]],
+        Head[WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, "Ordered", VertexCoordinateRules -> {1 -> {0, 0}}]],
         Graphics
       ],
 
       (* Valid GraphHighlight *)
 
       testUnevaluated[
-        HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> $$$invalid$$$],
-        {HypergraphPlot::invalidHighlight}
+        WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> $$$invalid$$$],
+        {WolframModelPlot::invalidHighlight}
       ],
 
       testUnevaluated[
-        HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {6}],
-        {HypergraphPlot::invalidHighlight}
+        WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {6}],
+        {WolframModelPlot::invalidHighlight}
       ],
 
       testUnevaluated[
-        HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {1, 1}],
-        {HypergraphPlot::invalidHighlight}
+        WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {1, 1}],
+        {WolframModelPlot::invalidHighlight}
       ],
 
       testUnevaluated[
-        HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {{1, 2}}],
-        {HypergraphPlot::invalidHighlight}
+        WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {{1, 2}}],
+        {WolframModelPlot::invalidHighlight}
       ],
 
       VerificationTest[
-        Head[HypergraphPlot[{{1, 2, 3}, {1, 2, 3}}, GraphHighlight -> {{1, 2, 3}}]],
+        Head[WolframModelPlot[{{1, 2, 3}, {1, 2, 3}}, GraphHighlight -> {{1, 2, 3}}]],
         Graphics
       ],
 
       VerificationTest[
-        Head[HypergraphPlot[{{1, 2, 3}, {1, 2, 3}}, GraphHighlight -> {{1, 2, 3}, {1, 2, 3}}]],
+        Head[WolframModelPlot[{{1, 2, 3}, {1, 2, 3}}, GraphHighlight -> {{1, 2, 3}, {1, 2, 3}}]],
         Graphics
       ],
 
       testUnevaluated[
-        HypergraphPlot[{{1, 2, 3}, {1, 2, 3}}, GraphHighlight -> {{1, 2, 3}, {1, 2, 3}, {1, 2, 3}}],
-        {HypergraphPlot::invalidHighlight}
+        WolframModelPlot[{{1, 2, 3}, {1, 2, 3}}, GraphHighlight -> {{1, 2, 3}, {1, 2, 3}, {1, 2, 3}}],
+        {WolframModelPlot::invalidHighlight}
       ],
 
       VerificationTest[
-        Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {1}]],
+        Head[WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {1}]],
         Graphics
       ],
 
       VerificationTest[
-        Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {{1, 2, 3}}]],
+        Head[WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {{1, 2, 3}}]],
         Graphics
       ],
 
       VerificationTest[
-        Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {4, {1, 2, 3}}]],
+        Head[WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {4, {1, 2, 3}}]],
         Graphics
       ],
 
       (* Valid GraphHighlightStyle *)
 
       testUnevaluated[
-        HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {1}, GraphHighlightStyle -> None],
-        {HypergraphPlot::invalidHighlightStyle}
+        WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {1}, GraphHighlightStyle -> None],
+        {WolframModelPlot::invalidHighlightStyle}
       ],
 
       testUnevaluated[
-        HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {1}, GraphHighlightStyle -> 2],
-        {HypergraphPlot::invalidHighlightStyle}
+        WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {1}, GraphHighlightStyle -> 2],
+        {WolframModelPlot::invalidHighlightStyle}
       ],
 
       testUnevaluated[
-        HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {1}, GraphHighlightStyle -> "Dashed"],
-        {HypergraphPlot::invalidHighlightStyle}
+        WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {1}, GraphHighlightStyle -> "Dashed"],
+        {WolframModelPlot::invalidHighlightStyle}
       ],
 
       VerificationTest[
-        Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {1}, GraphHighlightStyle -> Black]],
+        Head[WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {1}, GraphHighlightStyle -> Black]],
         Graphics
       ],
 
@@ -274,17 +274,17 @@
 
       {
         testUnevaluated[
-          HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, # -> $$$invalid$$$],
-          {HypergraphPlot::invalidSize}
+          WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, # -> $$$invalid$$$],
+          {WolframModelPlot::invalidSize}
         ],
 
         testUnevaluated[
-          HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, # -> -1],
-          {HypergraphPlot::invalidSize}
+          WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, # -> -1],
+          {WolframModelPlot::invalidSize}
         ],
 
         VerificationTest[
-          Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, # -> 1]],
+          Head[WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, # -> 1]],
           Graphics
         ]
       } & /@ {VertexSize, "ArrowheadLength"},
@@ -294,14 +294,14 @@
       (** Simple examples **)
 
       Table[With[{hypergraph = hypergraph}, VerificationTest[
-        Head[HypergraphPlot[hypergraph, #]],
+        Head[WolframModelPlot[hypergraph, #]],
         Graphics
       ]] & /@ $edgeTypes, {hypergraph, $simpleHypergraphs}],
 
       (** Large graphs **)
 
       VerificationTest[
-        Head @ HypergraphPlot @ SetReplace[
+        Head @ WolframModelPlot @ SetReplace[
           {{0, 1}, {0, 2}, {0, 3}},
           ToPatternRules[
             {{0, 1}, {0, 2}, {0, 3}} ->
@@ -314,12 +314,12 @@
       (* EdgeType *)
 
       VerificationTest[
-        diskCoordinates[HypergraphPlot[#, "Ordered"]] != diskCoordinates[HypergraphPlot[#, "Cyclic"]]
+        diskCoordinates[WolframModelPlot[#, "Ordered"]] != diskCoordinates[WolframModelPlot[#, "Cyclic"]]
       ] & /@ $layoutTestHypergraphs,
 
       VerificationTest[
         Length[Union[Cases[
-          HypergraphPlot[#, "HyperedgeRendering" -> "Subgraphs"],
+          WolframModelPlot[#, "HyperedgeRendering" -> "Subgraphs"],
           Polygon[___],
           All]]],
         1
@@ -327,7 +327,7 @@
 
       VerificationTest[
         Length[Union[Cases[
-          HypergraphPlot[#, "HyperedgeRendering" -> "Polygons"],
+          WolframModelPlot[#, "HyperedgeRendering" -> "Polygons"],
           Polygon[___],
           All]]],
         1 + Length[#]
@@ -337,7 +337,7 @@
 
       VerificationTest[
         MissingQ[FirstCase[
-          HypergraphPlot[#, VertexLabels -> None],
+          WolframModelPlot[#, VertexLabels -> None],
           Text[___],
           Missing[],
           All]]
@@ -345,7 +345,7 @@
 
       VerificationTest[
         !MissingQ[FirstCase[
-          HypergraphPlot[#, VertexLabels -> Automatic],
+          WolframModelPlot[#, VertexLabels -> Automatic],
           Text[___],
           Missing[],
           All]]
@@ -354,12 +354,12 @@
       (* Single-vertex edges *)
 
       VerificationTest[
-        HypergraphPlot[{{1}, {1, 2}}] =!= HypergraphPlot[{{1, 2}}]
+        WolframModelPlot[{{1}, {1, 2}}] =!= WolframModelPlot[{{1, 2}}]
       ],
 
       VerificationTest[
         MissingQ[FirstCase[
-          HypergraphPlot[{{1, 2}}, VertexLabels -> None],
+          WolframModelPlot[{{1, 2}}, VertexLabels -> None],
           Circle[___],
           Missing[],
           All]]
@@ -367,7 +367,7 @@
 
       VerificationTest[
         !MissingQ[FirstCase[
-          HypergraphPlot[{{1}, {1, 2}}, VertexLabels -> Automatic],
+          WolframModelPlot[{{1}, {1, 2}}, VertexLabels -> Automatic],
           Circle[___],
           Missing[],
           All]]
@@ -377,7 +377,7 @@
 
       VerificationTest[
         And @@ (MemberQ[
-            diskCoordinates[HypergraphPlot[
+            diskCoordinates[WolframModelPlot[
               {{1, 2, 3}, {3, 4, 5}, {3, 3}},
               VertexCoordinateRules -> {1 -> {0, 0}, 2 -> {1, 0}}]],
             #] & /@
@@ -385,13 +385,13 @@
       ],
 
       VerificationTest[
-        Chop @ diskCoordinates[HypergraphPlot[
+        Chop @ diskCoordinates[WolframModelPlot[
           {{1, 2, 3}, {3, 4, 5}},
           VertexCoordinateRules -> {3 -> {0, 0}}]] != Table[{0, 0}, 5]
       ],
 
       VerificationTest[
-        Chop @ diskCoordinates[HypergraphPlot[
+        Chop @ diskCoordinates[WolframModelPlot[
           {{1, 2, 3}, {3, 4, 5}},
           VertexCoordinateRules -> {3 -> {1, 0}, 3 -> {0, 0}}]] != Table[{0, 0}, 5]
       ],
@@ -399,7 +399,7 @@
       (** Same coordinates should not produce any messages **)
       VerificationTest[
         And @@ Cases[
-          HypergraphPlot[{{1, 2, 3}}, VertexCoordinateRules -> {1 -> {1, 0}, 2 -> {1, 0}}],
+          WolframModelPlot[{{1, 2, 3}}, VertexCoordinateRules -> {1 -> {1, 0}, 2 -> {1, 0}}],
           Rotate[_, {v1_, v2_}] :> v1 != {0, 0} && v2 != {0, 0},
           All]
       ],
@@ -433,8 +433,8 @@
 
       With[{hypergraph = {{1}, {1, 2}, {2, 3, 4}, {4, 5, 6, 7}}}, {
         testUnevaluated[
-          HypergraphPlot[hypergraph, PlotStyle -> #],
-          {HypergraphPlot::invalidPlotStyle}
+          WolframModelPlot[hypergraph, PlotStyle -> #],
+          {WolframModelPlot::invalidPlotStyle}
         ] & /@ {{Red, Green, Blue, Yellow}, Table[Red, 7], {Red}},
 
         testColorAbsense[hypergraph, {PlotStyle -> <|_ -> color, _ -> color2|>}, {color}],
@@ -462,8 +462,8 @@
           ColorData[97] /@ Range[7]],
 
         testUnevaluated[
-          HypergraphPlot[hypergraph, EdgeStyle -> {RGBColor[1, 0, 0]}],
-          {HypergraphPlot::invalidStyleLength}
+          WolframModelPlot[hypergraph, EdgeStyle -> {RGBColor[1, 0, 0]}],
+          {WolframModelPlot::invalidStyleLength}
         ],
 
         testColorPresence[hypergraph, {PlotStyle -> <|_ -> color|>, EdgeStyle -> <|# -> color2|>}, {color, color2}] & /@
@@ -525,32 +525,32 @@
       testColorPresence[{{1}, {1, 2}, {2, 3, 4}}, {PlotStyle -> <|_List -> color|>}, {color}],
 
       VerificationTest[
-        Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, VertexSize -> 0.3]],
+        Head[WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, VertexSize -> 0.3]],
         Graphics
       ],
 
       VerificationTest[
-        Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "ArrowheadLength" -> 0.3]],
+        Head[WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, "ArrowheadLength" -> 0.3]],
         Graphics
       ],
 
       VerificationTest[
-        Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, VertexSize -> 0.4, "ArrowheadLength" -> 0.3]],
+        Head[WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, VertexSize -> 0.4, "ArrowheadLength" -> 0.3]],
         Graphics
       ],
 
       (* GraphHighlight *)
 
       VerificationTest[
-        Length[Union @ Cases[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {#}], _ ? ColorQ, All]] >
-          Length[Union @ Cases[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}], _ ? ColorQ, All]]
+        Length[Union @ Cases[WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {#}], _ ? ColorQ, All]] >
+          Length[Union @ Cases[WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}], _ ? ColorQ, All]]
       ] & /@ {4, {1, 2, 3}},
 
       (** Test multi-edge highlighting **)
       VerificationTest[
         Differences[
           Length[Union[Cases[#, _?ColorQ, All]]] & /@
-            (HypergraphPlot[{{1, 2}, {1, 2}}, "HyperedgeRendering" -> "Subgraphs", GraphHighlight -> #] &) /@
+            (WolframModelPlot[{{1, 2}, {1, 2}}, "HyperedgeRendering" -> "Subgraphs", GraphHighlight -> #] &) /@
             {{}, {{1, 2}}, {{1, 2}, {1, 2}}}],
         {1, -1}
       ],
@@ -560,7 +560,7 @@
       VerificationTest[
         With[{
             color = RGBColor[0.4, 0.6, 0.2]},
-          FreeQ[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> #, GraphHighlightStyle -> color], color] & /@
+          FreeQ[WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> #, GraphHighlightStyle -> color], color] & /@
             {{}, {4}, {{1, 2, 3}}}],
         {True, False, False}
       ],
@@ -570,20 +570,20 @@
 
       VerificationTest[
         SameQ @@ (
-          Union[Cases[HypergraphPlot[#], Disk[_, r_] :> r, All]] & /@
+          Union[Cases[WolframModelPlot[#], Disk[_, r_] :> r, All]] & /@
             {{{1}}, {{1, 2, 3}}, {{1, 2, 3}, {3, 4, 5}}, RandomInteger[10, {5, 5}]})
       ],
 
       VerificationTest[
         SameQ @@ (
-          Union[Cases[HypergraphPlot[#, "HyperedgeRendering" -> "Subgraphs"], p : Polygon[___] :> Area[p], All]] & /@
+          Union[Cases[WolframModelPlot[#, "HyperedgeRendering" -> "Subgraphs"], p : Polygon[___] :> Area[p], All]] & /@
             {{{1, 2}}, {{1, 2, 3}}, {{1, 2, 3}, {3, 4, 5}}, RandomInteger[10, {5, 5}]})
       ],
 
       VerificationTest[
         Equal @@ (
           Mean[Cases[
-              HypergraphPlot[#, "HyperedgeRendering" -> "Subgraphs"],
+              WolframModelPlot[#, "HyperedgeRendering" -> "Subgraphs"],
               Line[pts_] :> EuclideanDistance @@ pts,
               All]] & /@
             {{{1, 2}}, {{1, 2, 3}}, {{1, 2, 3}, {3, 4, 5}}, {{1, 2, 3}, {3, 4, 5}, {5, 6, 1}}, {{1, 2, 3, 4, 5, 1}}})
@@ -594,7 +594,7 @@
               First[
                 Nearest[
                   Cases[
-                    HypergraphPlot[#, "HyperedgeRendering" -> "Subgraphs"],
+                    WolframModelPlot[#, "HyperedgeRendering" -> "Subgraphs"],
                     Line[pts_] :> RegionMeasure[Line[pts]],
                     All],
                   $selfLoopLength]] -

--- a/SetReplace/performance.wlt
+++ b/SetReplace/performance.wlt
@@ -77,12 +77,12 @@
         TimeConstraint -> 3
       ],
 
-      (** HypergraphPlot **)
+      (** WolframModelPlot **)
 
       Table[
         With[{edgeType = edgeType, hyperedgeRendering = hyperedgeRendering, $largeSet = $largeSet}, VerificationTest[
           With[{largeSet = ReleaseHold[$largeSet]},
-          Head[HypergraphPlot[largeSet, edgeType, "HyperedgeRendering" -> hyperedgeRendering]]],
+          Head[WolframModelPlot[largeSet, edgeType, "HyperedgeRendering" -> hyperedgeRendering]]],
           Graphics,
           TimeConstraint -> (5 $normalPlotTiming),
           MemoryConstraint -> (10 $normalPlotMemory)] /. HoldPattern[ReleaseHold[Hold[set_]]] -> set],


### PR DESCRIPTION
## Changes
* Renames `HypergraphPlot` -> `WolframModelPlot`.

## Tests
* Use `WolframModelPlot` now to plot hypergraphs:
```
In[] := WolframModelPlot[{{1, 2, 3}, {3, 4, 5}, {5, 6, 1}}]
```
![image](https://user-images.githubusercontent.com/1479325/72214904-611c1780-34d9-11ea-9bb2-bd38a0759b8a.png)
* Arguments are options are the same as were previously in `HypergraphPlot`:
```
In[] := WolframModelPlot[{{1, 2, 3}, {3, 4, 5}, {5, 6, 1}}, 
 VertexLabels -> Automatic, GraphHighlight -> {{1, 2, 3}, 5}]
```
![image](https://user-images.githubusercontent.com/1479325/72214922-b5bf9280-34d9-11ea-8ac6-9af7c51abc72.png)