### PR TITLE
Restore HypergraphPlot

### DIFF
--- a/SetReplace/WolframModelPlot.m
+++ b/SetReplace/WolframModelPlot.m
@@ -1,5 +1,6 @@
 Package["SetReplace`"]
 
+PackageExport["HypergraphPlot"]
 PackageExport["WolframModelPlot"]
 
 PackageScope["correctWolframModelPlotOptionsQ"]
@@ -36,6 +37,12 @@ $edgeTypes = {"Ordered", "Cyclic"};
 $defaultEdgeType = "Ordered";
 $graphLayout = "SpringElectricalEmbedding";
 $hyperedgeRenderings = {"Subgraphs", "Polygons"};
+
+(* for compatibility reasons, we don't care for messages and unevaluated code to preserve HypergraphPlot *)
+HypergraphPlot::usage = usageString["HypergraphPlot is deprecated. Use WolframModelPlot."];
+SyntaxInformation[HypergraphPlot] = SyntaxInformation[WolframModelPlot];
+Options[HypergraphPlot] = Options[WolframModelPlot];
+HypergraphPlot = WolframModelPlot;
 
 (* Messages *)
 

--- a/SetReplace/WolframModelPlot.wlt
+++ b/SetReplace/WolframModelPlot.wlt
@@ -289,6 +289,18 @@
         ]
       } & /@ {VertexSize, "ArrowheadLength"},
 
+      (* HypergraphPlot can still be used *)
+
+      VerificationTest[
+        Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}]],
+        Graphics
+      ],
+
+      VerificationTest[
+        Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "Ordered"]],
+        Graphics
+      ],
+
       (* Implementation *)
 
       (** Simple examples **)


### PR DESCRIPTION
## Changes
* Brings back `HypergraphPlot` for compatibility.
* Its `OwnValue` is simply assigned to `HypergraphPlot`, together with `Options` and `SyntaxInformation`.

## Review comments
* Do you see any obvious problems with assigning the `OwnValue` in this way?

## Tests
* `HypergraphPlot` can be used again:
```
In[] := HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}]
```
![image](https://user-images.githubusercontent.com/1479325/72400450-33bcad00-3717-11ea-9f21-c197a5cf22d1.png)
* The usage message says it is deprecated:
```
In[] := ?HypergraphPlot
```
![image](https://user-images.githubusercontent.com/1479325/72400468-433bf600-3717-11ea-8d89-684bac1f6c27.png)