### PR TITLE
Not allow List-vertices in WolframModelPlot

### DIFF
--- a/SetReplace/WolframModelPlot.m
+++ b/SetReplace/WolframModelPlot.m
@@ -74,7 +74,7 @@ func : WolframModelPlot[args___] := Module[{result = wolframModelPlot$parse[args
 wolframModelPlot$parse[args___] /; !Developer`CheckArgumentCount[WolframModelPlot[args], 1, 2] := $Failed
 
 (* allow composite vertices, but not list-vertices *)
-$hypergraphPattern = {{Except[_List] ..} ...};
+$hypergraphPattern = h_List /; AllTrue[h, ListQ[#] && Length[#] > 0 &] && AllTrue[h, Not @* ListQ, 2];
 
 wolframModelPlot$parse[edges : Except[$hypergraphPattern], edgeType_ : $defaultEdgeType, o : OptionsPattern[]] := (
 	Message[WolframModelPlot::invalidEdges];

--- a/SetReplace/WolframModelPlot.m
+++ b/SetReplace/WolframModelPlot.m
@@ -73,13 +73,16 @@ func : WolframModelPlot[args___] := Module[{result = wolframModelPlot$parse[args
 
 wolframModelPlot$parse[args___] /; !Developer`CheckArgumentCount[WolframModelPlot[args], 1, 2] := $Failed
 
-wolframModelPlot$parse[edges : Except[{___List}], edgeType_ : $defaultEdgeType, o : OptionsPattern[]] := (
+(* allow composite vertices, but not list-vertices *)
+$hypergraphPattern = {{Except[_List] ..} ...};
+
+wolframModelPlot$parse[edges : Except[$hypergraphPattern], edgeType_ : $defaultEdgeType, o : OptionsPattern[]] := (
 	Message[WolframModelPlot::invalidEdges];
 	$Failed
 )
 
 wolframModelPlot$parse[
-		edges : {___List},
+		edges : $hypergraphPattern,
 		edgeType : Except[Alternatives[Alternatives @@ $edgeTypes, OptionsPattern[]]],
 		o : OptionsPattern[]] := (
 	Message[WolframModelPlot::invalidEdgeType, edgeType, $edgeTypes];
@@ -87,7 +90,7 @@ wolframModelPlot$parse[
 )
 
 wolframModelPlot$parse[
-			edges : {___List}, edgeType : Alternatives @@ $edgeTypes : $defaultEdgeType, o : OptionsPattern[]] /;
+			edges : $hypergraphPattern, edgeType : Alternatives @@ $edgeTypes : $defaultEdgeType, o : OptionsPattern[]] /;
 				correctWolframModelPlotOptionsQ[WolframModelPlot, Defer[WolframModelPlot[edges, o]], edges, {o}] := Module[{
 		optionValue, plotStyles, edgeStyle, styles},
 	optionValue[opt_] := OptionValue[WolframModelPlot, {o}, opt];

--- a/SetReplace/WolframModelPlot.wlt
+++ b/SetReplace/WolframModelPlot.wlt
@@ -6,13 +6,11 @@
       $simpleHypergraphs = {
         {{1, 3}, {2, 4}},
         {},
-        {{}},
         {{1}},
         {{1}, {1}},
         {{1}, {2}},
         {{1}, {1}, {2}},
-        {{1, 2}, {1}},
-        {{1, 2}, {1}, {}}
+        {{1, 2}, {1}}
       };
 
       diskCoordinates[graphics_] := Sort[Cases[graphics, Disk[i_, ___] :> i, All]];
@@ -100,6 +98,16 @@
 
       testUnevaluated[
         WolframModelPlot[{{1, 3}, 6, {2, 4}}],
+        {WolframModelPlot::invalidEdges}
+      ],
+
+      testUnevaluated[
+        WolframModelPlot[{{}}],
+        {WolframModelPlot::invalidEdges}
+      ],
+
+      testUnevaluated[
+        WolframModelPlot[{{1, 3}, {}}],
         {WolframModelPlot::invalidEdges}
       ],
 


### PR DESCRIPTION
## Changes
* Disallows vertices that a lists in `WolframModelPlot`.
* This is a preparation for a later PR that is going to plot a sequence of hypergraphs.
* If we want to automatically distinguish between a single hypergraph and a list of hypergraphs, we have to disallow edges that are lists.

## Tests
* List-vertices no longer work:
```
In[] := WolframModelPlot[{{{1, 1}, 2, 3}, {3, 4, 5}}]
```
```
During evaluation of In[] := WolframModelPlot::invalidEdges: First argument of WolframModelPlot must be list of lists, where elements represent vertices.

Out[] = WolframModelPlot[{{{1, 1}, 2, 3}, {3, 4, 5}}]
```
* Use a custom head for composite vertices:
```
In[] := WolframModelPlot[{{v[1, 1], 2, 3}, {3, 4, 5}}, 
 VertexLabels -> Automatic]
```
![image](https://user-images.githubusercontent.com/1479325/72486565-426b9880-37d9-11ea-9beb-a9d7e93b6395.png)