### PR TITLE
HypergraphAutomorphismGroup

### DIFF
--- a/SetReplace/HypergraphAutomorphismGroup.m
+++ b/SetReplace/HypergraphAutomorphismGroup.m
@@ -1,0 +1,33 @@
+Package["SetReplace`"]
+
+PackageExport["HypergraphAutomorphismGroup"]
+
+(* Documentation *)
+
+HypergraphAutomorphismGroup::usage = usageString[
+  "HypergraphAutomorphismGroup[`e`] gives the authomorphism group of a list of hyperedges `e`."];
+
+SyntaxInformation[HypergraphAutomorphismGroup] = {"ArgumentsPattern" -> {_}};
+
+(* Implementation *)
+
+HypergraphAutomorphismGroup[e : {{Except[_List]...}...}] := With[{
+    binaryGraph = Graph[Catenate[toStructurePreservingBinaryEdges /@ e]]},
+  removeAuxiliaryElements[GraphAutomorphismGroup[binaryGraph], binaryGraph, e]
+]
+
+toStructurePreservingBinaryEdges[hyperedge_] := Module[{
+    edgeVertices = Table[edge[Unique[v, {Temporary}]], Length[hyperedge]]},
+  Join[
+    EdgeList[PathGraph[edgeVertices, DirectedEdges -> True]],
+    Thread[DirectedEdge[edgeVertices, hyperedge]]]
+]
+
+removeAuxiliaryElements[group_, graph_, hypergraph_] := Module[{
+    trueVertexIndices, binaryGraphIndexToVertex, vertexToHypergraphIndex},
+  trueVertexIndices = Position[VertexList[graph], Except[_edge], {1}, Heads -> False][[All, 1]];
+  binaryGraphIndexToVertex = Thread[trueVertexIndices -> VertexList[graph][[trueVertexIndices]]];
+  vertexToHypergraphIndex = Thread[vertexList[hypergraph] -> Range[Length[binaryGraphIndexToVertex]]];
+  DeleteCases[group, Except[Alternatives @@ trueVertexIndices, _Integer], All] /.
+    binaryGraphIndexToVertex /. vertexToHypergraphIndex /. Cycles[{}] -> Nothing
+]

--- a/SetReplace/HypergraphAutomorphismGroup.m
+++ b/SetReplace/HypergraphAutomorphismGroup.m
@@ -11,6 +11,11 @@ SyntaxInformation[HypergraphAutomorphismGroup] = {"ArgumentsPattern" -> {_}};
 
 (* Implementation *)
 
+(* Algorithm has 3 steps:
+    1. First, convert the hypergraph into a normal Graph preserving structure (but adding new vertices).
+    2. Then, compute the automorhpism group for that normal Graph.
+    3. Finally, remove added auxiliary vertices from the spec of that group. *)
+
 HypergraphAutomorphismGroup[e : {{Except[_List]...}...}] := With[{
     binaryGraph = Graph[Catenate[toStructurePreservingBinaryEdges /@ e]]},
   removeAuxiliaryElements[GraphAutomorphismGroup[binaryGraph], binaryGraph, e]
@@ -22,6 +27,13 @@ toStructurePreservingBinaryEdges[hyperedge_] := Module[{
     EdgeList[PathGraph[edgeVertices, DirectedEdges -> True]],
     Thread[DirectedEdge[edgeVertices, hyperedge]]]
 ]
+
+(* Note, auxiliary vertices cannot mix with original vertices in the same cycle, since auxiliary vertices have
+    out-degrees of at least 1, whereas original vertices always have out-degree 0.
+    Hence, here we are taking a subgroup by identifying permutations of auxiliary vertices.
+    In the original group there are either auxiliary-only generators (which would be turned into empty Cycles[{}]
+    and deleted), generators affecting both (which will be trimmed), and generators of original vertices only
+    (which will be preserved).*)
 
 removeAuxiliaryElements[group_, graph_, hypergraph_] := Module[{
     trueVertexIndices, binaryGraphIndexToVertex, vertexToHypergraphIndex},

--- a/SetReplace/HypergraphAutomorphismGroup.wlt
+++ b/SetReplace/HypergraphAutomorphismGroup.wlt
@@ -1,0 +1,99 @@
+<|
+  "HypergraphAutomorphismGroup" -> <|
+    "init" -> (
+      Attributes[Global`testUnevaluated] = Attributes[Global`testSymbolLeak] = {HoldAll};
+      Global`testUnevaluated[args___] := SetReplace`PackageScope`testUnevaluated[VerificationTest, args];
+      Global`testSymbolLeak[args___] := SetReplace`PackageScope`testSymbolLeak[VerificationTest, args];
+    ),
+    "tests" -> {
+      testSymbolLeak[
+        HypergraphAutomorphismGroup[{{1, 2}, {2, 3}, {3, 1}}]
+      ],
+      
+      testUnevaluated[
+        HypergraphAutomorphismGroup[],
+        {HypergraphAutomorphismGroup::argx}
+      ],
+
+      testUnevaluated[
+        HypergraphAutomorphismGroup[1, 2],
+        {HypergraphAutomorphismGroup::argx}
+      ],
+
+      testUnevaluated[
+        HypergraphAutomorphismGroup[#],
+        {HypergraphAutomorphismGroup::invalidHypergraph}
+      ] & /@ {1, {1}, {1, 2}, {{1, 2}, 3}, {{{1, 2}, {3, 4}}, {5, 6}}},
+
+      VerificationTest[
+        GroupOrder[HypergraphAutomorphismGroup[#]],
+        1
+      ] & /@ {{}, {{1}}, {{1, 2}}, {{1, 2}, {2, 3}}, {{1, 2, 3}, {1, 2, 3}}},
+
+      VerificationTest[
+        Sort[GroupElements[HypergraphAutomorphismGroup[#]]],
+        {Cycles[{}], Cycles[{{1, 2}}]}
+      ] & /@ {{{1, 2}, {2, 1}}, {{1}, {2}}, {{1}, {2}, {1, 2}, {2, 1}}, {{1, 1}, {2, 2}}},
+
+      VerificationTest[
+        Sort[GroupElements[HypergraphAutomorphismGroup[{{1, 2}, {2, 3}, {3, 1}}]]],
+        {Cycles[{}], Cycles[{{1, 2, 3}}], Cycles[{{1, 3, 2}}]}
+      ],
+
+      VerificationTest[
+        Sort[GroupElements[HypergraphAutomorphismGroup[{{1, 2, 3}, {3, 4, 1}}]]],
+        {Cycles[{}], Cycles[{{1, 3}, {2, 4}}]}
+      ],
+
+      VerificationTest[
+        Sort[GroupElements[HypergraphAutomorphismGroup[#]]],
+        {Cycles[{}], Cycles[{{1, 3}}]}
+      ] & /@ {{{1, 2, 3}, {3, 2, 1}}, {{1, 2, 4}, {3, 2, 4}}},
+
+      VerificationTest[
+        Sort[GroupElements[HypergraphAutomorphismGroup[{{7, 2, 3, 1}, {8, 5, 6, 4}, {2, 5}, {5, 2}}]]],
+        {Cycles[{}], Cycles[{{1, 4}, {2, 5}, {3, 6}, {7, 8}}]}
+      ],
+
+      VerificationTest[
+        Sort[GroupElements[HypergraphAutomorphismGroup[
+          {{1, 6, 5}, {2, 8, 7}, {3, 10, 9}, {4, 12, 11}, {6, 10}, {5, 7}, {8, 12}, {7, 5}, {10, 6}, {9, 11}, {12, 8},
+          {11, 9}}]]],
+        {Cycles[{}], 
+          Cycles[{{1, 2}, {3, 4}, {5, 7}, {6, 8}, {9, 11}, {10, 12}}], 
+          Cycles[{{1, 3}, {2, 4}, {5, 9}, {6, 10}, {7, 11}, {8, 12}}], 
+          Cycles[{{1, 4}, {2, 3}, {5, 11}, {6, 12}, {7, 9}, {8, 10}}]}
+      ],
+
+      VerificationTest[
+        Sort[GroupElements[HypergraphAutomorphismGroup[{{1, 2, 3, 4, 5}, {5, 6, 7, 8, 1}}]]],
+        {Cycles[{}], Cycles[{{1, 5}, {2, 6}, {3, 7}, {4, 8}}]}
+      ],
+
+      VerificationTest[
+        Sort[GroupElements[HypergraphAutomorphismGroup[
+          {{1, 2}, {1, 3}, {1, 4}, {2, 1}, {2, 3}, {2, 4}, {3, 1}, {3, 2}, {3, 4}, {4, 1}, {4, 2}, {4, 3}}]]],
+        {Cycles[{}], Cycles[{{1, 2}}], Cycles[{{1, 3}}], Cycles[{{1, 4}}], 
+          Cycles[{{2, 3}}], Cycles[{{2, 4}}], Cycles[{{3, 4}}], 
+          Cycles[{{1, 2, 3}}], Cycles[{{1, 2, 4}}], Cycles[{{1, 3, 2}}], 
+          Cycles[{{1, 3, 4}}], Cycles[{{1, 4, 2}}], Cycles[{{1, 4, 3}}], 
+          Cycles[{{2, 3, 4}}], Cycles[{{2, 4, 3}}], Cycles[{{1, 2, 3, 4}}], 
+          Cycles[{{1, 2, 4, 3}}], Cycles[{{1, 3, 2, 4}}], 
+          Cycles[{{1, 3, 4, 2}}], Cycles[{{1, 4, 2, 3}}], 
+          Cycles[{{1, 4, 3, 2}}], Cycles[{{1, 2}, {3, 4}}], 
+          Cycles[{{1, 3}, {2, 4}}], Cycles[{{1, 4}, {2, 3}}]}
+      ],
+
+      VerificationTest[
+        GroupOrder[HypergraphAutomorphismGroup[{{1, 2, 3}, {3, 4, 5}, {5, 6, 1}, {1, 7, 3}, {3, 8, 5}, {5, 9, 1}}]],
+        24
+      ],
+
+      SeedRandom[117];
+      VerificationTest[
+        Sort[GroupElements[GraphAutomorphismGroup[Graph[Union[Catenate[List @@@ EdgeList[#]]], EdgeList[#]]]]],
+        Sort[GroupElements[HypergraphAutomorphismGroup[Join[List @@@ EdgeList[#]]]]]
+      ] & /@ RandomGraph[{10, 10}, 100, DirectedEdges -> True]
+    }
+  |>
+|>


### PR DESCRIPTION
## Changes
* Implements `HypergraphAutomorphismGroup` function, which is similar to `GraphAutomorphismGroup`.
* Works by turning the hypergraph into a normal graph, and then taking subgroup of that graph's automorphism group.

## Caveats
* While `GraphAutomorphismGroup` is generally faster than the matching algorithm (particularly evident for torus graphs), adding vertices when converting hyper- to normal graph adds a significant performance hit. There might be a better approach to this which would avoid introducing new vertices, obtain an overly-symmetric group for the normal graph, and then take a subgroup of that based on which transformations are not allowed in the hypergraph.

## Tests
* Obtain automorphism group for a hyper-cycle:
```
In[] := HypergraphAutomorphismGroup[{{1, 2, 3}, {3, 4, 5}, {5, 6, 1}}]
```
```
Out[] = PermutationGroup[{Cycles[{{1, 3, 5}, {2, 4, 6}}]}]
```
```
In[] := CayleyGraph[%]
```
![image](https://user-images.githubusercontent.com/1479325/72626733-3129a580-3919-11ea-8e25-e7abb2349145.png)
* A more complicated example:
```
In[] := HypergraphAutomorphismGroup[
 EchoFunction[
   WolframModelPlot]@{{1, 2, 3}, {3, 4, 5}, {5, 6, 1}, {1, 7, 3}, {3, 
    8, 5}, {5, 9, 1}}]
```
![image](https://user-images.githubusercontent.com/1479325/72626851-6fbf6000-3919-11ea-93e3-a34526415608.png)
```
Out[] = PermutationGroup[{Cycles[{{6, 9}}], Cycles[{{4, 8}}], 
  Cycles[{{1, 3, 5}, {2, 4, 6}, {7, 8, 9}}]}]
```
```
In[] := GroupOrder[%]
```
```
Out[] = 24
```