### PR TITLE
GeneralizedGridGraph

### DIFF
--- a/SetReplace/GeneralizedGridGraph.m
+++ b/SetReplace/GeneralizedGridGraph.m
@@ -1,0 +1,71 @@
+Package["SetReplace`"]
+
+PackageExport["GeneralizedGridGraph"]
+
+(* Documentation *)
+
+GeneralizedGridGraph::usage = usageString[
+  "GeneralizedGridGraph[{\*SubscriptBox[`n`, `1`], \*SubscriptBox[`n`, `2`], `...`, \*SubscriptBox[`n`, `k`]}] ",
+  "gives the k-dimensional grid graph with \*SubscriptBox[`n`, `1`] \[Times] \*SubscriptBox[`n`, `2`] \[Times] `...` ",
+  "\[Times] \*SubscriptBox[`n`, `k`] vertices.\n",
+
+  "GeneralizedGridGraph[{`...`, \*SubscriptBox[`n`, `k`] -> \"Circular\", `...`}] makes the grid wrap around ",
+  "in k-th dimension.\n",
+
+  "GeneralizedGridGraph[{`...`, \*SubscriptBox[`n`, `k`] -> \"Directed\", `...`}] makes the edges directed ",
+  "in k-th dimension.\n",
+
+  "GeneralizedGridGraph[{`...`, \*SubscriptBox[`n`, `k`] -> {\"Circular\", \"Directed\"}, `...`}] makes the grid both ",
+  "circular and directed."];
+
+SyntaxInformation[GeneralizedGridGraph] = {"ArgumentsPattern" -> {_}};
+
+GeneralizedGridGraph::dimsNotList = "Dimensions specification `` should be a list.";
+
+GeneralizedGridGraph::invalidDimSpec = "Dimension specification `` is invalid.";
+
+(* Implementation *)
+
+GeneralizedGridGraph[args___] := Module[{result = Catch[generalizedGridGraph[args]]},
+  result /; result =!= $Failed
+]
+
+generalizedGridGraph[args___] /; !Developer`CheckArgumentCount[GeneralizedGridGraph[args], 1, 1] := Throw[$Failed]
+
+generalizedGridGraph[dimSpecs_List] := generalizedGridGraphExplicit[toExplicitDimSpec /@ dimSpecs]
+
+generalizedGridGraph[dimSpecs : Except[_List]] := (
+  Message[GeneralizedGridGraph::dimsNotList, dimSpecs];
+  Throw[$Failed];
+)
+
+toExplicitDimSpec[spec_] := toExplicitDimSpec[spec, spec]
+
+toExplicitDimSpec[originalSpec_, n_] := toExplicitDimSpec[originalSpec, n -> {}]
+
+toExplicitDimSpec[originalSpec_, n_ -> spec : Except[_List]] := toExplicitDimSpec[originalSpec, n -> {spec}]
+
+$circularString = "Circular";
+$directedString = "Directed";
+
+toExplicitDimSpec[_, n_Integer /; n >= 0 -> spec : {($circularString | $directedString)...}] := {
+  n,
+  If[MemberQ[spec, $circularString], $$circular, $$linear],
+  If[MemberQ[spec, $directedString], $$directed, $$undirected]}
+
+toExplicitDimSpec[originalSpec_, _ -> _List] := (
+  Message[GeneralizedGridGraph::invalidDimSpec, originalSpec];
+  Throw[$Failed];
+)
+
+generalizedGridGraphExplicit[dimSpecs_] := IndexGraph[Graph[
+  Flatten[Outer[v, ##] & @@ Range /@ dimSpecs[[All, 1]]],
+  Catenate[singleDimensionEdges[dimSpecs, #] & /@ Range[Length[dimSpecs]]]]]
+
+singleDimensionEdges[dimSpecs_, k_] := Catenate[
+  singleThreadEdges[dimSpecs[[k]], #] & /@
+    Flatten[Outer[v, ##] & @@ ReplacePart[Range /@ dimSpecs[[All, 1]], k -> {threadDim}]]]
+
+singleThreadEdges[{n_, wrapSpec_, dirSpec_}, thread_] :=
+  Replace[dirSpec, {$$directed -> DirectedEdge, $$undirected -> UndirectedEdge}] @@@
+    Partition[thread /. threadDim -> # & /@ Range[n], 2, 1, {1, Replace[wrapSpec, {$$linear -> -1, $$circular -> 1}]}]

--- a/SetReplace/GeneralizedGridGraph.m
+++ b/SetReplace/GeneralizedGridGraph.m
@@ -59,8 +59,13 @@ toExplicitDimSpec[originalSpec_, _ -> _List] := (
 )
 
 generalizedGridGraphExplicit[dimSpecs_] := IndexGraph[Graph[
-  Flatten[Outer[v, ##] & @@ Range /@ dimSpecs[[All, 1]]],
-  Catenate[singleDimensionEdges[dimSpecs, #] & /@ Range[Length[dimSpecs]]]]]
+  (* Reversal is needed to be consistent with "GridEmbedding" *)
+  Flatten[Outer[v @@ Reverse[{##}] &, ##] & @@ Reverse[Range /@ dimSpecs[[All, 1]]]],
+  Catenate[singleDimensionEdges[dimSpecs, #] & /@ Range[Length[dimSpecs]]]], GraphLayout -> graphLayout[dimSpecs]]
+
+graphLayout[{{n1_, $$linear, _}, {n2_, $$linear, _}}] := {"GridEmbedding", "Dimension" -> {n1, n2}}
+
+graphLayout[_] := "SpringElectricalEmbedding"
 
 singleDimensionEdges[dimSpecs_, k_] := Catenate[
   singleThreadEdges[dimSpecs[[k]], #] & /@

--- a/SetReplace/GeneralizedGridGraph.wlt
+++ b/SetReplace/GeneralizedGridGraph.wlt
@@ -1,0 +1,98 @@
+<|
+  "GeneralizedGridGraph" -> <|
+    "init" -> (
+      Attributes[Global`testUnevaluated] = Attributes[Global`testSymbolLeak] = {HoldAll};
+      Global`testUnevaluated[args___] := SetReplace`PackageScope`testUnevaluated[VerificationTest, args];
+      Global`testSymbolLeak[args___] := SetReplace`PackageScope`testSymbolLeak[VerificationTest, args];
+    ),
+    "tests" -> {
+      testSymbolLeak[
+        GeneralizedGridGraph[{4, 4 -> "Circular", 5 -> "Directed"}]
+      ],
+      
+      testUnevaluated[
+        GeneralizedGridGraph[],
+        {GeneralizedGridGraph::argx}
+      ],
+
+      testUnevaluated[
+        GeneralizedGridGraph[1, 2],
+        {GeneralizedGridGraph::argx}
+      ],
+
+      testUnevaluated[
+        GeneralizedGridGraph[1],
+        {GeneralizedGridGraph::dimsNotList}
+      ],
+
+      testUnevaluated[
+        GeneralizedGridGraph[#],
+        {GeneralizedGridGraph::invalidDimSpec}
+      ] & /@ {
+        {"x"}, {x}, {-1}, {1 -> x}, {1 -> "x"}, {1 -> 1}, {1 -> {"x"}}, {1 -> {"Directed", "x"}},
+        {1 -> {"Directed", "Circular"}, 2, 3 -> x}},
+
+      VerificationTest[
+        EmptyGraphQ[GeneralizedGridGraph[{0}]]
+      ],
+
+      VerificationTest[
+        GeneralizedGridGraph[#],
+        Graph[{1}, {}]
+      ] & /@ {{1}, {1 -> "Directed"}, {1 -> {"Directed"}}},
+
+      VerificationTest[
+        GeneralizedGridGraph[{1 -> "Circular"}],
+        Graph[UndirectedEdge[1, 1]]
+      ],
+
+      VerificationTest[
+        GeneralizedGridGraph[#],
+        Graph[DirectedEdge[1, 1]]
+      ] & /@ {{1 -> {"Circular", "Directed"}}, {1 -> {"Directed", "Circular", "Circular"}}},
+
+      VerificationTest[
+        EdgeCount[GeneralizedGridGraph[{1 -> {"Directed", "Circular"}, 2, 3 -> "Directed"}]],
+        13
+      ],
+
+      VerificationTest[
+        IsomorphicGraphQ[GeneralizedGridGraph[{10, 5, 2}], GridGraph[{10, 5, 2}]]
+      ],
+
+      VerificationTest[
+        IsomorphicGraphQ[GeneralizedGridGraph[{10}], GridGraph[{10}]]
+      ],
+
+      VerificationTest[
+        IsomorphicGraphQ[GeneralizedGridGraph[{10 -> "Circular"}], CycleGraph[10]]
+      ],
+
+      VerificationTest[
+        IsomorphicGraphQ[GeneralizedGridGraph[{10 -> {"Circular", "Directed"}}], CycleGraph[10, DirectedEdges -> True]]
+      ],
+
+      VerificationTest[
+        IsomorphicGraphQ[GeneralizedGridGraph[{10 -> "Directed"}], PathGraph[Range[10], DirectedEdges -> True]]
+      ],
+
+      VerificationTest[
+        GeneralizedGridGraph[{2 -> "Directed", 2 -> {"Circular", "Directed"}}],
+        Graph[Join[DirectedEdge @@@ {{1, 3}, {2, 4}, {1, 2}, {2, 1}, {3, 4}, {4, 3}}]],
+        SameTest -> IsomorphicGraphQ
+      ],
+
+      VerificationTest[
+        GroupOrder[GraphAutomorphismGroup[GeneralizedGridGraph[#1]]],
+        #2
+      ] & @@@ {
+        {{10, 9}, 4},
+        {{10 -> "Directed", 9 -> "Directed"}, 1},
+        {{10 -> "Circular", 9}, 40},
+        {{10 -> "Circular", 9 -> "Circular"}, 360},
+        {{10 -> {"Circular", "Directed"}, 9 -> {"Circular", "Directed"}}, 90},
+        {{10 -> {"Circular", "Directed"}, 9 -> {"Circular", "Directed"}, 3 -> {"Circular", "Directed"}}, 270}
+      }
+    }
+  |>
+|>

--- a/SetReplace/GeneralizedGridGraph.wlt
+++ b/SetReplace/GeneralizedGridGraph.wlt
@@ -37,18 +37,21 @@
       ],
 
       VerificationTest[
-        GeneralizedGridGraph[#],
-        Graph[{1}, {}]
+        Through[{VertexList, EdgeList} @ GeneralizedGridGraph[#]],
+        {{1}, {}},
+        SameTest -> MatchQ
       ] & /@ {{1}, {1 -> "Directed"}, {1 -> {"Directed"}}},
 
       VerificationTest[
-        GeneralizedGridGraph[{1 -> "Circular"}],
-        Graph[UndirectedEdge[1, 1]]
+        Through[{VertexList, EdgeList} @ GeneralizedGridGraph[{1 -> "Circular"}]],
+        {{1}, {UndirectedEdge[1, 1]}},
+        SameTest -> MatchQ
       ],
 
       VerificationTest[
-        GeneralizedGridGraph[#],
-        Graph[DirectedEdge[1, 1]]
+        Through[{VertexList, EdgeList} @ GeneralizedGridGraph[#]],
+        {{1}, {DirectedEdge[1, 1]}},
+        SameTest -> MatchQ
       ] & /@ {{1 -> {"Circular", "Directed"}}, {1 -> {"Directed", "Circular", "Circular"}}},
 
       VerificationTest[
@@ -92,7 +95,27 @@
         {{10 -> "Circular", 9 -> "Circular"}, 360},
         {{10 -> {"Circular", "Directed"}, 9 -> {"Circular", "Directed"}}, 90},
         {{10 -> {"Circular", "Directed"}, 9 -> {"Circular", "Directed"}, 3 -> {"Circular", "Directed"}}, 270}
-      }
+      },
+
+      VerificationTest[
+        Options[GeneralizedGridGraph[#1], GraphLayout],
+        {GraphLayout -> {"GridEmbedding", "Dimension" -> #2}}
+      ] & @@@ {{{4, 6}, {4, 6}}, {{4 -> "Directed", 6}, {4, 6}}, {{6, 4}, {6, 4}}},
+
+      VerificationTest[
+        Options[GeneralizedGridGraph[#], GraphLayout],
+        {GraphLayout -> "SpringElectricalEmbedding"}
+      ] & /@ {{3}, {3, 3, 3}, {3 -> "Circular", 5}},
+
+      VerificationTest[
+        With[{graph = GeneralizedGridGraph[#]},
+          AllTrue[
+            EdgeList[graph] /.
+              Thread[VertexList[graph] -> (VertexCoordinates /. AbsoluteOptions[graph, VertexCoordinates][[1]])] /.
+              (UndirectedEdge | DirectedEdge) -> EuclideanDistance,
+            0.999 < # < 1.001 &]
+        ]
+      ] & /@ {{4, 6}, {6, 4}, {3, 3}, {45, 76}, {6 -> "Directed", 8}, {5, 8 -> "Directed"}, {7 -> "Directed", 2 -> "Directed"}}
     }
   |>
 |>


### PR DESCRIPTION
## Changes
* Implements `GeneralizedGridGraph`, which is similar to `GridGraph`, but can make the graph `"Circular"` or / and `"Directed"` in each dimension.

## Tests
* Make an ordinary grid graph:
```
In[] := GeneralizedGridGraph[{10, 10}]
```
![image](https://user-images.githubusercontent.com/1479325/73700855-adf8a580-46b5-11ea-878f-09d814fb3aa3.png)
* Make it circular in one of the dimensions, and directed in another:
```
In[] := GeneralizedGridGraph[{10 -> "Circular", 10 -> "Directed"}]
```
![image](https://user-images.githubusercontent.com/1479325/73700871-bcdf5800-46b5-11ea-9821-051cd742cc61.png)
* Make the same dimension both circular and directed:
```
In[] := GeneralizedGridGraph[{10 -> {"Circular", "Directed"}, 5}]
```
![image](https://user-images.githubusercontent.com/1479325/73700879-c799ed00-46b5-11ea-8692-40c3ba61f6fa.png)
* Make a directed hypercube graph:
```
In[] := Graph[GeneralizedGridGraph[Thread[{2, 2, 2, 2} -> "Directed"]], 
 GraphLayout -> "SpringElectricalEmbedding"]
```
![image](https://user-images.githubusercontent.com/1479325/72638455-6e9a2d00-3931-11ea-94d7-47549dde71b5.png)