### PR TITLE
New property names

### DIFF
--- a/SetReplace/WolframModel.wlt
+++ b/SetReplace/WolframModel.wlt
@@ -271,7 +271,7 @@
       (*** Generations and Events ***)
 
       VerificationTest[
-        WolframModel[1 -> 2, {1}, 2]["GenerationsCount"],
+        WolframModel[1 -> 2, {1}, 2]["TotalGenerationsCount"],
         2
       ],
 
@@ -301,38 +301,38 @@
       ],
 
       VerificationTest[
-        WolframModel[{{0, 1}} -> {{0, 2}, {2, 1}}, {{0, 1}}, 3] /@ {"GenerationsCount", "EventsCount"},
+        WolframModel[{{0, 1}} -> {{0, 2}, {2, 1}}, {{0, 1}}, 3] /@ {"TotalGenerationsCount", "EventsCount"},
         {3, 7}
       ],
 
       VerificationTest[
         WolframModel[{{0, 1}} -> {{0, 2}, {2, 1}}, {{0, 1}}, <|"MaxGenerations" -> 3|>] /@
-          {"GenerationsCount", "EventsCount", "TerminationReason"},
+          {"TotalGenerationsCount", "EventsCount", "TerminationReason"},
         {3, 7, "MaxGenerations"}
       ],
 
       VerificationTest[
         WolframModel[{{0, 1}} -> {{0, 2}, {2, 1}}, {{0, 1}}, <|"MaxEvents" -> 6|>] /@
-          {"GenerationsCount", "EventsCount", "TerminationReason"},
+          {"TotalGenerationsCount", "EventsCount", "TerminationReason"},
         {3, 6, "MaxEvents"}
       ],
 
       VerificationTest[
         WolframModel[{{0, 1}} -> {{0, 2}, {2, 1}}, {{0, 1}}, <|"MaxGenerations" -> 3, "MaxEvents" -> 6|>] /@
-          {"GenerationsCount", "EventsCount", "TerminationReason"},
+          {"TotalGenerationsCount", "EventsCount", "TerminationReason"},
         {3, 6, "MaxGenerations" | "MaxEvents"},
         SameTest -> MatchQ
       ],
 
       VerificationTest[
         WolframModel[{{0, 1}} -> {{0, 2}, {2, 1}}, {{0, 1}}, <|"MaxGenerations" -> 2, "MaxEvents" -> 6|>] /@
-          {"GenerationsCount", "EventsCount", "TerminationReason"},
+          {"TotalGenerationsCount", "EventsCount", "TerminationReason"},
         {2, 3, "MaxGenerations"}
       ],
 
       VerificationTest[
         WolframModel[{{0, 1}, {1, 2}} -> {{0, 2}}, {{0, 1}, {1, 2}, {2, 3}, {3, 4}}, <||>] /@
-          {"GenerationsCount", "EventsCount", "TerminationReason"},
+          {"TotalGenerationsCount", "EventsCount", "TerminationReason"},
         {2, 3, "FixedPoint"}
       ],
 
@@ -351,7 +351,7 @@
 
       VerificationTest[
         WolframModel[{{0, 1}} -> {{0, 2}, {2, 1}}, {{0, 1}}, <|"MaxGenerations" -> \[Infinity], "MaxEvents" -> 12|>] /@
-          {"GenerationsCount", "EventsCount", "TerminationReason"},
+          {"TotalGenerationsCount", "EventsCount", "TerminationReason"},
         {4, 12, "MaxEvents"}
       ],
 
@@ -765,7 +765,7 @@
           WolframModel[
             model,
             <|"MaxGenerations" -> 5, "MaxEvents" -> 41, "MaxVertices" -> 42, "MaxEdges" -> 84, "MaxVertexDegree" -> 9|>,
-            {"GenerationsCount", "TerminationReason"},
+            {"TotalGenerationsCount", "TerminationReason"},
             Method -> method],
           {5, "MaxGenerations"}
         ],
@@ -946,7 +946,7 @@
       ],
 
       VerificationTest[
-        WolframModel[<|"PatternRules" -> {2 -> 5, 3 :> 6}|>, {1, 2, 3}, 2]["GenerationsCount"],
+        WolframModel[<|"PatternRules" -> {2 -> 5, 3 :> 6}|>, {1, 2, 3}, 2]["TotalGenerationsCount"],
         1
       ],
 
@@ -1053,7 +1053,7 @@
       ],
 
       VerificationTest[
-        WolframModel[{{1, 2}} -> {{1, 3}, {3, 2}}, {{1, 2}}, 10]["GenerationsCount"],
+        WolframModel[{{1, 2}} -> {{1, 3}, {3, 2}}, {{1, 2}}, 10]["TotalGenerationsCount"],
         10
       ],
 
@@ -1063,7 +1063,7 @@
       ],
 
       VerificationTest[
-        WolframModel[{{1}} -> {}, {{1}, {2}, {3}, {4}, {5}}, Infinity]["GenerationsCount"],
+        WolframModel[{{1}} -> {}, {{1}, {2}, {3}, {4}, {5}}, Infinity]["TotalGenerationsCount"],
         1
       ],
 
@@ -1078,7 +1078,7 @@
       ],
 
       VerificationTest[
-        WolframModel[{{1}} -> {{1}}, {{1}, {2}, {3}, {4}, {5}}, 0]["GenerationsCount"],
+        WolframModel[{{1}} -> {{1}}, {{1}, {2}, {3}, {4}, {5}}, 0]["TotalGenerationsCount"],
         0
       ],
 
@@ -1091,7 +1091,7 @@
         WolframModel[
           {{{1}} -> {}, {{1, 2}} -> {{1}}},
           {{1, 2}, {2}, {3}, {4}, {5}},
-          2]["GenerationsCount"],
+          2]["TotalGenerationsCount"],
         2
       ],
 

--- a/SetReplace/WolframModel.wlt
+++ b/SetReplace/WolframModel.wlt
@@ -825,13 +825,13 @@
       ],
 
       VerificationTest[
-        WolframModel[1 -> 2, {1}, 2, #] & /@ $WolframModelProperties // Length,
+        WolframModel[{{1}} -> {{2}}, {{1}}, 2, #] & /@ $WolframModelProperties // Length,
         Length[$WolframModelProperties]
       ],
 
       VerificationTest[
-        WolframModel[1 -> 2, {1}, 2, $WolframModelProperties] // Length,
-        WolframModel[1 -> 2, {1}, 2, #] & /@ $WolframModelProperties // Length
+        WolframModel[{{1}} -> {{2}}, {{1}}, 2, $WolframModelProperties] // Length,
+        WolframModel[{{1}} -> {{2}}, {{1}}, 2, #] & /@ $WolframModelProperties // Length
       ],
 
       testUnevaluated[

--- a/SetReplace/WolframModelEvolutionObject.m
+++ b/SetReplace/WolframModelEvolutionObject.m
@@ -157,7 +157,7 @@ $oldToNewPropertyNames = <|
 	"AtomsCountTotal" -> "AllEventsDistinctElementsCount",
 	"ExpressionsCountFinal" -> "FinalEdgeCount",
 	"ExpressionsCountTotal" -> "AllEventsEdgesCount",
-  "SetAfterEvent" -> "StateAfterEvent"
+	"SetAfterEvent" -> "StateAfterEvent"
 |>;
 
 

--- a/SetReplace/WolframModelEvolutionObject.m
+++ b/SetReplace/WolframModelEvolutionObject.m
@@ -44,7 +44,7 @@ WolframModelEvolutionObject::usage = usageString[
 	"\n",
 	"WolframModelEvolutionObject[`...`][`g`] yields the set at generation `g`.",
 	"\n",
-	"WolframModelEvolutionObject[`...`][\"SetAfterEvent\", `s`] yields the state ",
+	"WolframModelEvolutionObject[`...`][\"StateAfterEvent\", `s`] yields the state ",
 	"after `s` substitution events.",
 	"\n",
 	"WolframModelEvolutionObject[`...`][\"Properties\"] yields the list of all ",
@@ -115,7 +115,7 @@ $propertyArgumentCounts = Join[
 		"StatesPlotsList" -> {0, Infinity},
 		"AllEventsStatesList" -> {0, 0},
 		"Generation" -> {1, 1},
-		"SetAfterEvent" -> {1, 1},
+		"StateAfterEvent" -> {1, 1},
 		"Rules" -> {0, 0},
 		"TotalGenerationsCount" -> {0, 0},
 		"PartialGenerationsCount" -> {0, 0},
@@ -156,7 +156,8 @@ $oldToNewPropertyNames = <|
 	"AtomsCountFinal" -> "FinalDistinctElementsCount",
 	"AtomsCountTotal" -> "AllEventsDistinctElementsCount",
 	"ExpressionsCountFinal" -> "FinalEdgeCount",
-	"ExpressionsCountTotal" -> "AllEventsEdgesCount"
+	"ExpressionsCountTotal" -> "AllEventsEdgesCount",
+  "SetAfterEvent" -> "StateAfterEvent"
 |>;
 
 
@@ -423,7 +424,7 @@ propertyEvaluate[True, includeBoundaryEventsPattern][
 
 
 (* ::Subsection:: *)
-(*SetAfterEvent*)
+(*StateAfterEvent*)
 
 
 (* ::Subsubsection:: *)
@@ -451,7 +452,7 @@ toPositiveStep[total_, requested : Except[_Integer], caller_, name_] :=
 propertyEvaluate[True, includeBoundaryEventsPattern][
 			obj : WolframModelEvolutionObject[data_ ? evolutionDataQ],
 			caller_,
-			"SetAfterEvent",
+			"StateAfterEvent",
 			s_] := With[{
 		positiveEvent = toPositiveStep[propertyEvaluate[True, None][obj, caller, "AllEventsCount"], s, caller, "Event"]},
 	data[$atomLists][[Intersection[
@@ -467,7 +468,7 @@ propertyEvaluate[True, includeBoundaryEventsPattern][
 propertyEvaluate[True, includeBoundaryEventsPattern][
 		WolframModelEvolutionObject[data_ ? evolutionDataQ],
 		caller_,
-		"FinalState"] := WolframModelEvolutionObject[data]["SetAfterEvent", -1]
+		"FinalState"] := WolframModelEvolutionObject[data]["StateAfterEvent", -1]
 
 
 (* ::Subsection:: *)
@@ -490,7 +491,7 @@ propertyEvaluate[True, includeBoundaryEventsPattern][
 		WolframModelEvolutionObject[data_ ? evolutionDataQ],
 		caller_,
 		"AllEventsStatesList"] :=
-	WolframModelEvolutionObject[data]["SetAfterEvent", #] & /@
+	WolframModelEvolutionObject[data]["StateAfterEvent", #] & /@
 		Range[0, WolframModelEvolutionObject[data]["AllEventsCount"]]
 
 
@@ -573,7 +574,7 @@ propertyEvaluate[True, includeBoundaryEventsPattern][
 		"FinalDistinctElementsCount"] :=
 	Length[Union @ Cases[
 		propertyEvaluate[True, None][
-			WolframModelEvolutionObject[data], caller, "SetAfterEvent", -1],
+			WolframModelEvolutionObject[data], caller, "StateAfterEvent", -1],
 		_ ? AtomQ,
 		All]]
 
@@ -620,7 +621,7 @@ propertyEvaluate[True, includeBoundaryEventsPattern][
 		caller_,
 		"FinalEdgeCount"] :=
 	Length[propertyEvaluate[True, None][
-		WolframModelEvolutionObject[data], caller, "SetAfterEvent", -1]]
+		WolframModelEvolutionObject[data], caller, "StateAfterEvent", -1]]
 
 
 (* ::Subsection:: *)

--- a/SetReplace/WolframModelEvolutionObject.m
+++ b/SetReplace/WolframModelEvolutionObject.m
@@ -161,7 +161,10 @@ $oldToNewPropertyNames = <|
 |>;
 
 
-$propertiesParameterless = Keys @ Select[#[[1]] == 0 &] @ $propertyArgumentCounts;
+$propertiesParameterless = Join[
+  Keys @ Select[#[[1]] == 0 &] @ $propertyArgumentCounts,
+  Select[First[$propertyArgumentCounts[$oldToNewPropertyNames[#]]] == 0 &] @ Keys[$oldToNewPropertyNames]
+];
 
 
 (* ::Subsection:: *)

--- a/SetReplace/WolframModelEvolutionObject.m
+++ b/SetReplace/WolframModelEvolutionObject.m
@@ -478,12 +478,20 @@ propertyEvaluate[True, includeBoundaryEventsPattern][
 (*FinalStatePlot*)
 
 
+General::nonHypergraphPlot = "`1` is only supported for states that are hypergraphs.";
+
+
 propertyEvaluate[True, includeBoundaryEventsPattern][
 		obj : WolframModelEvolutionObject[_ ? evolutionDataQ],
 		caller_,
-		"FinalStatePlot",
+		property : "FinalStatePlot",
 		o : OptionsPattern[] /; (Complement[{o}, FilterRules[{o}, Options[WolframModelPlot]]] == {})] :=
-	WolframModelPlot[obj["FinalState"], o]
+	Quiet[
+		Check[
+			WolframModelPlot[obj["FinalState"], o],
+			Message[caller::nonHypergraphPlot, property],
+			WolframModelPlot::invalidEdges],
+		WolframModelPlot::invalidEdges]
 
 
 (* ::Subsection:: *)
@@ -562,9 +570,18 @@ propertyEvaluate[True, includeBoundaryEventsPattern][
 propertyEvaluate[True, includeBoundaryEventsPattern][
 		obj : WolframModelEvolutionObject[_ ? evolutionDataQ],
 		caller_,
-		"StatesPlotsList",
+		property : "StatesPlotsList",
 		o : OptionsPattern[] /; (Complement[{o}, FilterRules[{o}, Options[WolframModelPlot]]] == {})] :=
-	WolframModelPlot[#, o] & /@ obj["StatesList"]
+	Catch @ Quiet[
+		Map[
+			Check[
+				Check[
+					WolframModelPlot[#, o],
+					Message[caller::nonHypergraphPlot, property],
+					WolframModelPlot::invalidEdges],
+				Throw[$Failed]] &,
+			obj["StatesList"]],
+		WolframModelPlot::invalidEdges]
 
 
 (* ::Subsection:: *)

--- a/SetReplace/WolframModelEvolutionObject.m
+++ b/SetReplace/WolframModelEvolutionObject.m
@@ -786,7 +786,7 @@ $masterOptions = {
 
 WolframModelEvolutionObject[
 		data_ ? evolutionDataQ][
-		property___ ? (Not[MatchQ[#, OptionsPattern[]]] &),
+		property__ ? (Not[MatchQ[#, OptionsPattern[]]] &),
 		opts : OptionsPattern[]] := Module[{prunedObject, result},
 	result = Check[
 		(propertyEvaluate @@
@@ -814,6 +814,10 @@ WolframModelEvolutionObject[
 
 WolframModelEvolutionObject[args___] := 0 /;
 	!Developer`CheckArgumentCount[WolframModelEvolutionObject[args], 1, 1] && False
+
+
+WolframModelEvolutionObject[data_][opts : OptionsPattern[]] := 0 /;
+  Message[WolframModelEvolutionObject::argm, Defer[WolframModelEvolutionObject[data][opts]], 0, 1]
 
 
 (* ::Subsection:: *)

--- a/SetReplace/WolframModelEvolutionObject.m
+++ b/SetReplace/WolframModelEvolutionObject.m
@@ -111,6 +111,7 @@ $propertyArgumentCounts = Join[
 		"EvolutionObject" -> {0, 0},
 		"FinalState" -> {0, 0},
 		"StatesList" -> {0, 0},
+    "StatesPlotsList" -> {0, Infinity},
 		"UpdatedStatesList" -> {0, 0},
 		"Generation" -> {1, 1},
 		"SetAfterEvent" -> {1, 1},
@@ -482,6 +483,35 @@ propertyEvaluate[True, includeBounaryEventsPattern][
 
 
 (* ::Subsection:: *)
+(*StatesPlotsList*)
+
+
+propertyEvaluate[True, includeBounaryEventsPattern][
+    obj : WolframModelEvolutionObject[_ ? evolutionDataQ],
+    caller_,
+    "StatesPlotsList",
+    o : OptionsPattern[] /; (Complement[{o}, FilterRules[{o}, Options[WolframModelPlot]]] == {})] :=
+  WolframModelPlot[#, o] & /@ obj["StatesList"]
+
+
+propertyEvaluate[True, includeBounaryEventsPattern][
+    obj : WolframModelEvolutionObject[_ ? evolutionDataQ],
+    caller_,
+    property : "StatesPlotsList",
+    o : OptionsPattern[]] := Message[
+      caller::optx,
+      Last[Complement[{o}, FilterRules[{o}, Options[WolframModelPlot]]]],
+      Defer[obj[property, o]]]
+
+
+propertyEvaluate[True, includeBounaryEventsPattern][
+    WolframModelEvolutionObject[_ ? evolutionDataQ],
+    caller_,
+    property : "StatesPlotsList",
+    o___] := makeMessage[caller, "nonopt", property, Last[{o}]]
+
+
+(* ::Subsection:: *)
 (*AtomsCountFinal*)
 
 
@@ -578,10 +608,10 @@ $layeredCausalGraphOptions = Options[$causalGraphOptions];
 propertyEvaluate[True, includeBounaryEventsPattern][
 		WolframModelEvolutionObject[data_ ? evolutionDataQ],
 		caller_,
-		"CausalGraph" | "LayeredCausalGraph",
+		property : "CausalGraph" | "LayeredCausalGraph",
 		o___] := 0 /;
 	!MatchQ[{o}, OptionsPattern[]] &&
-	makeMessage[caller, "nonopt", Last[{o}]]
+	makeMessage[caller, "nonopt", property, Last[{o}]]
 
 
 propertyEvaluate[True, includeBounaryEventsPattern][

--- a/SetReplace/WolframModelEvolutionObject.wlt
+++ b/SetReplace/WolframModelEvolutionObject.wlt
@@ -45,6 +45,26 @@
         WolframModel[
           {{1, 2}, {2, 3}} -> {{1, 3}},
           pathGraph17,
+          4][],
+        WolframModelEvolutionObject[___][],
+        {WolframModelEvolutionObject::argm},
+        SameTest -> MatchQ
+      ],
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4]["$opt$" -> 3],
+        WolframModelEvolutionObject[___]["$opt$" -> 3],
+        {WolframModelEvolutionObject::argm},
+        SameTest -> MatchQ
+      ],
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
           4]["$$$UnknownProperty$$$,,,"],
         WolframModelEvolutionObject[___]["$$$UnknownProperty$$$,,,"],
         {WolframModelEvolutionObject::unknownProperty},
@@ -269,15 +289,125 @@
         1
       ],
 
+      (* PartialGenerationsCount *)
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}} -> {{1, 3}, {3, 2}},
+          {{1, 1}},
+          <|"MaxEvents" -> 30|>]["PartialGenerationsCount"],
+        1
+      ],
+
+      VerificationTest[
+        SeedRandom[123]; 
+        WolframModel[
+          {{1, 2}} -> {{1, 3}, {3, 2}},
+          {{1, 1}},
+          <|"MaxEvents" -> 30|>,
+          "EventOrderingFunction" -> "Random"][
+          "PartialGenerationsCount"],
+        8
+      ],
+
+      (* CompleteGenerationsCount *)
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}} -> {{1, 3}, {3, 2}},
+          {{1, 1}},
+          <|"MaxEvents" -> 30|>][#],
+        4
+      ] & /@ {"CompleteGenerationsCount", "MaxCompleteGeneration"},
+
+      VerificationTest[
+        SeedRandom[123]; 
+        WolframModel[
+          {{1, 2}} -> {{1, 3}, {3, 2}},
+          {{1, 1}},
+          <|"MaxEvents" -> 30|>,
+          "EventOrderingFunction" -> "Random"][
+          "CompleteGenerationsCount"],
+        2
+      ],
+
+      (* GenerationsCount *)
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}} -> {{1, 3}, {3, 2}},
+          {{1, 1}},
+          <|"MaxEvents" -> 30|>]["GenerationsCount"],
+        {4, 1}
+      ],
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}} -> {{1, 3}, {3, 2}},
+          {{1, 1}},
+          0]["GenerationsCount"],
+        {0, 0}
+      ],
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}} -> {{1, 3}, {3, 2}},
+          {{1, 1}, {1, 1}},
+          <|"MaxEvents" -> #|>]["GenerationsCount"] & /@ {1, 2},
+        {{0, 1}, {1, 0}}
+      ],
+
+      VerificationTest[
+        SeedRandom[123]; 
+        WolframModel[
+          {{1, 2}} -> {{1, 3}, {3, 2}},
+          {{1, 1}},
+          <|"MaxEvents" -> 30|>,
+          "EventOrderingFunction" -> "Random"][
+          "GenerationsCount"],
+        {2, 8}
+      ],
+
+      (* GenerationComplete *)
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}} -> {{1, 3}, {3, 2}},
+          {{1, 1}},
+          <|"MaxEvents" -> 30|>]["GenerationComplete"],
+        False
+      ],
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}} -> {{1, 3}, {3, 2}},
+          {{1, 1}},
+          4]["GenerationComplete"],
+        True
+      ],
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}} -> {{1, 3}, {3, 2}},
+          {{1, 1}},
+          <|"MaxEvents" -> 30|>]["GenerationComplete", #] & /@ {-6, -5, -1, 0, 1, 4, 5, 10},
+        {True, True, False, True, True, True, False, False}
+      ],
+
+      With[{evo = WolframModel[{{1, 2}} -> {{1, 3}, {3, 2}}, {{1, 1}}, <|"MaxEvents" -> 30|>]}, testUnevaluated[
+        evo["GenerationComplete", #],
+        {WolframModelEvolutionObject::stepTooLarge}
+      ] & /@ {-10, -7}],
+
       (* EventsCount *)
 
       VerificationTest[
         WolframModel[
           {{1, 2}, {2, 3}} -> {{1, 3}},
           pathGraph17,
-          4]["EventsCount"],
+          4][#],
         15
-      ],
+      ] & /@ {"EventsCount", "AllEventsCount"},
 
       VerificationTest[
         WolframModel[
@@ -303,6 +433,76 @@
         2
       ],
 
+      (* GenerationEventsCountList *)
+
+      VerificationTest[
+        WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 4]["GenerationEventsCountList"],
+        {1, 3, 9, 27}
+      ],
+
+      VerificationTest[
+        WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 0]["GenerationEventsCountList"],
+        {}
+      ],
+
+      VerificationTest[
+        WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 4][
+          "GenerationEventsCountList", "IncludeBoundaryEvents" -> #] & /@ {None, "Initial", "Final", All},
+        {{1, 3, 9, 27}, {1, 1, 3, 9, 27}, {1, 3, 9, 27, 1}, {1, 1, 3, 9, 27, 1}}
+      ],
+
+      (* GenerationEventsList *)
+
+      VerificationTest[
+        WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 2]["GenerationEventsList"],
+        {{{1, {1} -> {2, 3, 4}}}, {{1, {2} -> {5, 6, 7}}, {1, {3} -> {8, 9, 10}}, {1, {4} -> {11, 12, 13}}}}
+      ],
+
+      VerificationTest[
+        WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 0]["GenerationEventsList"],
+        {}
+      ],
+
+      VerificationTest[
+        WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 2][
+          "GenerationEventsList", "IncludeBoundaryEvents" -> All],
+        {
+          {{0, {} -> {1}}},
+          {{1, {1} -> {2, 3, 4}}},
+          {{1, {2} -> {5, 6, 7}}, {1, {3} -> {8, 9, 10}}, {1, {4} -> {11, 12, 13}}},
+          {{DirectedInfinity[1], {5, 6, 7, 8, 9, 10, 11, 12, 13} -> {}}}
+        }
+      ],
+
+      (* VertexCountList *)
+
+      VerificationTest[
+        WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 4]["VertexCountList"],
+        {1, 2, 5, 14, 41}
+      ],
+
+      VerificationTest[
+        WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 0]["VertexCountList"],
+        {1}
+      ],
+
+      VerificationTest[
+        WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{f[1, x, y], f[1, x, y]}}, 4]["VertexCountList"],
+        {1, 2, 5, 14, 41}
+      ],
+
+      (* EdgeCountList *)
+
+      VerificationTest[
+        WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 4]["EdgeCountList"],
+        {1, 3, 9, 27, 81}
+      ],
+
+      VerificationTest[
+        WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 0]["EdgeCountList"],
+        {1}
+      ],
+
       (* SetAfterEvent *)
 
       VerificationTest[
@@ -317,9 +517,9 @@
         WolframModel[
           {{1, 2}, {2, 3}} -> {{1, 3}},
           pathGraph17,
-          4]["SetAfterEvent", 1],
+          4][#, 1],
         Join[Partition[Range[3, 17], 2, 1], {{1, 3}}]
-      ],
+      ] & /@ {"SetAfterEvent", "StateAfterEvent"},
 
       VerificationTest[
         WolframModel[
@@ -404,6 +604,30 @@
         {}
       ],
 
+      (* FinalStatePlot *)
+
+      VerificationTest[
+        Head[WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 3]["FinalStatePlot"]],
+        Graphics
+      ],
+
+      With[{evo = WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 3]}, testUnevaluated[
+        evo["FinalStatePlot", "$$$invalid$$$"],
+        {WolframModelEvolutionObject::nonopt}
+      ]],
+
+      With[{evo = WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 3]}, testUnevaluated[
+        evo["FinalStatePlot", "$$$invalid$$$" -> 3],
+        {WolframModelEvolutionObject::optx}
+      ]],
+
+      VerificationTest[
+        AbsoluteOptions[
+          WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 3]["FinalStatePlot", ImageSize -> 123.],
+          ImageSize],
+        {ImageSize -> 123.}
+      ],
+
       (* UpdatedStatesList *)
 
       VerificationTest[
@@ -429,9 +653,9 @@
         WolframModel[
           {{1, 2}} -> {},
           {{1, 2}, {2, 3}},
-          2]["UpdatedStatesList"],
+          2][#],
         {{{1, 2}, {2, 3}}, {{2, 3}}, {}}
-      ],
+      ] & /@ {"UpdatedStatesList", "AllEventsStatesList"},
 
       (* Generation *)
 
@@ -534,15 +758,38 @@
         {{{1, 2}, {2, 3}}, {}}
       ],
 
+      (* StatesPlotsList *)
+
+      VerificationTest[
+        Head /@ WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 3]["StatesPlotsList"],
+        ConstantArray[Graphics, 4]
+      ],
+
+      With[{evo = WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 3]}, testUnevaluated[
+        evo["StatesPlotsList", "$$$invalid$$$"],
+        {WolframModelEvolutionObject::nonopt}
+      ]],
+
+      With[{evo = WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 3]}, testUnevaluated[
+        evo["StatesPlotsList", "$$$invalid$$$" -> 3],
+        {WolframModelEvolutionObject::optx}
+      ]],
+
+      VerificationTest[
+        AbsoluteOptions[#, ImageSize] & /@
+          WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 3]["StatesPlotsList", ImageSize -> 123.],
+        ConstantArray[{ImageSize -> 123.}, 4]
+      ],
+
       (* AtomsCountFinal *)
 
       VerificationTest[
         WolframModel[
           {{1, 2}, {2, 3}} -> {{1, 3}},
           pathGraph17,
-          4]["AtomsCountFinal"],
+          4][#],
         2
-      ],
+      ] & /@ {"AtomsCountFinal", "FinalDistinctElementsCount"},
 
       VerificationTest[
         WolframModel[
@@ -574,9 +821,9 @@
         WolframModel[
           {{1, 2}, {2, 3}} -> {{1, 3}},
           pathGraph17,
-          4]["AtomsCountTotal"],
+          4][#],
         17
-      ],
+      ] & /@ {"AtomsCountTotal", "AllEventsDistinctElementsCount"},
 
       VerificationTest[
         WolframModel[
@@ -608,9 +855,9 @@
         WolframModel[
           {{1, 2}, {2, 3}} -> {{1, 3}},
           pathGraph17,
-          4]["ExpressionsCountFinal"],
+          4][#],
         1
-      ],
+      ] & /@ {"ExpressionsCountFinal", "FinalEdgeCount"},
 
       VerificationTest[
         WolframModel[
@@ -626,9 +873,9 @@
         WolframModel[
           {{1, 2}, {2, 3}} -> {{1, 3}},
           pathGraph17,
-          4]["ExpressionsCountTotal"],
+          4][#],
         16 + 8 + 4 + 2 + 1
-      ],
+      ] & /@ {"ExpressionsCountTotal", "AllEventsEdgesCount"},
 
       VerificationTest[
         WolframModel[
@@ -644,9 +891,9 @@
         WolframModel[
           {{1, 2}, {2, 3}} -> {{1, 3}},
           pathGraph17,
-          4]["CreatorEvents"],
+          4][#],
         Join[Table[0, 16], Range[15]]
-      ],
+      ] & /@ {"CreatorEvents", "EdgeCreatorEventIndices"},
 
       (* DestroyerEvents *)
 
@@ -654,9 +901,9 @@
         WolframModel[
           {{1, 2}, {2, 3}} -> {{1, 3}},
           pathGraph17,
-          4]["DestroyerEvents"],
+          4][#],
         Append[Riffle @@ ConstantArray[Range[15], 2], Infinity]
-      ],
+      ] & /@ {"DestroyerEvents", "EdgeDestroyerEventIndices"},
 
       (* ExpressionGenerations *)
 
@@ -664,9 +911,9 @@
         WolframModel[
           {{1, 2}, {2, 3}} -> {{1, 3}},
           pathGraph17,
-          4]["ExpressionGenerations"],
+          4][#],
         Catenate[Table[Table[k, 2^(4 - k)], {k, 0, 4}]]
-      ],
+      ] & /@ {"ExpressionGenerations", "EdgeGenerationsList"},
 
       (* AllExpressions *)
 
@@ -674,9 +921,9 @@
         WolframModel[
           {{1, 2}, {2, 3}} -> {{1, 3}},
           pathGraph17,
-          4]["AllExpressions"],
+          4][#],
         Catenate[Table[Partition[Range[1, 17, 2^k], 2, 1], {k, 0, 4}]]
-      ],
+      ] & /@ {"AllExpressions", "AllEventsEdgesList"},
 
       (* EventGenerations *)
 
@@ -684,9 +931,9 @@
         WolframModel[
           {{1, 2}, {2, 3}} -> {{1, 3}},
           pathGraph17,
-          4]["EventGenerations"],
+          4][#],
         {1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 4}
-      ],
+      ] & /@ {"EventGenerations", "EventGenerationsList", "AllEventsGenerationsList"},
 
       VerificationTest[
         WolframModel[
@@ -893,9 +1140,9 @@
 
       Table[With[{method = method}, {
         VerificationTest[
-          WolframModel[{{{1}} -> {{1}}}, {{1}}, 4, Method -> method]["AllEventsList"],
+          WolframModel[{{{1}} -> {{1}}}, {{1}}, 4, Method -> method][#],
           {{1, {1} -> {2}}, {1, {2} -> {3}}, {1, {3} -> {4}}, {1, {4} -> {5}}}
-        ],
+        ] & /@ {"AllEventsList", "EventsList"},
 
         VerificationTest[
           WolframModel[{{{1}} -> {{1, 2}}, {{1, 2}} -> {{1}}}, {{1}}, 4, Method -> method]["AllEventsList"],
@@ -959,6 +1206,21 @@
       VerificationTest[
         WolframModel[{{{1, 2}} -> {{}}, {{}} -> {{1, 2}}}, {{}}, 4]["AllEventsList"],
         {{2, {1} -> {2}}, {1, {2} -> {3}}, {2, {3} -> {4}}, {1, {4} -> {5}}}
+      ],
+
+      (* EventsStatesList *)
+
+      VerificationTest[
+        WolframModel[{{1, 2}} -> {{1, 3}, {3, 2}}, {{1, 1}}, 2]["EventsStatesList"],
+        {
+          {{1, 1}},
+          {1, {1} -> {2, 3}},
+          {{1, 2}, {2, 1}},
+          {1, {2} -> {4, 5}},
+          {{2, 1}, {1, 3}, {3, 2}},
+          {1, {3} -> {6, 7}},
+          {{1, 3}, {3, 2}, {2, 4}, {4, 1}}
+        }
       ]
     }]
   |>

--- a/SetReplace/WolframModelEvolutionObject.wlt
+++ b/SetReplace/WolframModelEvolutionObject.wlt
@@ -55,8 +55,8 @@
         WolframModel[
           {{1, 2}, {2, 3}} -> {{1, 3}},
           pathGraph17,
-          4]["GenerationsCount", 3],
-        WolframModelEvolutionObject[___]["GenerationsCount", 3],
+          4]["TotalGenerationsCount", 3],
+        WolframModelEvolutionObject[___]["TotalGenerationsCount", 3],
         {WolframModelEvolutionObject::pargx},
         SameTest -> MatchQ
       ],
@@ -65,8 +65,8 @@
         WolframModel[
           {{1, 2}, {2, 3}} -> {{1, 3}},
           pathGraph17,
-          4]["GenerationsCount", 3, 3],
-        WolframModelEvolutionObject[___]["GenerationsCount", 3, 3],
+          4]["TotalGenerationsCount", 3, 3],
+        WolframModelEvolutionObject[___]["TotalGenerationsCount", 3, 3],
         {WolframModelEvolutionObject::pargx},
         SameTest -> MatchQ
       ],
@@ -109,7 +109,7 @@
           pathGraph17,
           4]["SetAfterEvent", 16],
         WolframModelEvolutionObject[___]["SetAfterEvent", 16],
-        {WolframModelEvolutionObject::eventTooLarge},
+        {WolframModelEvolutionObject::stepTooLarge},
         SameTest -> MatchQ
       ],
 
@@ -119,7 +119,7 @@
           pathGraph17,
           4]["SetAfterEvent", -17],
         WolframModelEvolutionObject[___]["SetAfterEvent", -17],
-        {WolframModelEvolutionObject::eventTooLarge},
+        {WolframModelEvolutionObject::stepTooLarge},
         SameTest -> MatchQ
       ],
 
@@ -129,7 +129,7 @@
           pathGraph17,
           4]["SetAfterEvent", 1.2],
         WolframModelEvolutionObject[___]["SetAfterEvent", 1.2],
-        {WolframModelEvolutionObject::eventNotInteger},
+        {WolframModelEvolutionObject::stepNotInteger},
         SameTest -> MatchQ
       ],
 
@@ -139,7 +139,7 @@
           pathGraph17,
           4]["SetAfterEvent", "good"],
         WolframModelEvolutionObject[___]["SetAfterEvent", "good"],
-        {WolframModelEvolutionObject::eventNotInteger},
+        {WolframModelEvolutionObject::stepNotInteger},
         SameTest -> MatchQ
       ],
 
@@ -151,7 +151,7 @@
           pathGraph17,
           4]["Generation", 5],
         WolframModelEvolutionObject[___]["Generation", 5],
-        {WolframModelEvolutionObject::generationTooLarge},
+        {WolframModelEvolutionObject::stepTooLarge},
         SameTest -> MatchQ
       ],
 
@@ -161,7 +161,7 @@
           pathGraph17,
           4]["Generation", -6],
         WolframModelEvolutionObject[___]["Generation", -6],
-        {WolframModelEvolutionObject::generationTooLarge},
+        {WolframModelEvolutionObject::stepTooLarge},
         SameTest -> MatchQ
       ],
 
@@ -171,7 +171,7 @@
           pathGraph17,
           4]["Generation", 2.3],
         WolframModelEvolutionObject[___]["Generation", 2.3],
-        {WolframModelEvolutionObject::generationNotInteger},
+        {WolframModelEvolutionObject::stepNotInteger},
         SameTest -> MatchQ
       ],
 
@@ -188,7 +188,7 @@
         WolframModel[
           {{1, 2}} -> {{1, 2}},
           {{1, 1}},
-          1]["GenerationsCount", "IncludeBoundaryEvents" -> #],
+          1]["TotalGenerationsCount", "IncludeBoundaryEvents" -> #],
         1
       ] & /@ {None, "Initial", "Final", All},
 
@@ -251,13 +251,13 @@
         1 -> 2
       ],
 
-      (* GenerationsCount *)
+      (* TotalGenerationsCount *)
 
       VerificationTest[
         WolframModel[
           {{1, 2}, {2, 3}} -> {{1, 3}},
           pathGraph17,
-          4]["GenerationsCount"],
+          4]["TotalGenerationsCount"],
         4
       ],
 
@@ -265,7 +265,7 @@
         WolframModel[
           {{1, 2}} -> {},
           {{1, 2}, {2, 3}},
-          2]["GenerationsCount"],
+          2]["TotalGenerationsCount"],
         1
       ],
 
@@ -769,7 +769,7 @@
   
           VerificationTest[
             GraphDistance[ReleaseHold[largeEvolution[type]], 1, ReleaseHold[largeEvolution["EventsCount"]]],
-            ReleaseHold[largeEvolution["GenerationsCount"]] - 1
+            ReleaseHold[largeEvolution["TotalGenerationsCount"]] - 1
           ]
         }] /. HoldPattern[ReleaseHold[Hold[expr_]]] :> expr,
   

--- a/SetReplace/WolframModelEvolutionObject.wlt
+++ b/SetReplace/WolframModelEvolutionObject.wlt
@@ -300,14 +300,12 @@
       ],
 
       VerificationTest[
-        SeedRandom[123]; 
         WolframModel[
           {{1, 2}} -> {{1, 3}, {3, 2}},
           {{1, 1}},
-          <|"MaxEvents" -> 30|>,
-          "EventOrderingFunction" -> "Random"][
+          <|"MaxEvents" -> 30|>][
           "PartialGenerationsCount"],
-        8
+        1
       ],
 
       (* CompleteGenerationsCount *)
@@ -321,14 +319,12 @@
       ] & /@ {"CompleteGenerationsCount", "MaxCompleteGeneration"},
 
       VerificationTest[
-        SeedRandom[123]; 
         WolframModel[
           {{1, 2}} -> {{1, 3}, {3, 2}},
           {{1, 1}},
-          <|"MaxEvents" -> 30|>,
-          "EventOrderingFunction" -> "Random"][
+          <|"MaxEvents" -> 30|>][
           "CompleteGenerationsCount"],
-        2
+        4
       ],
 
       (* GenerationsCount *)
@@ -358,14 +354,12 @@
       ],
 
       VerificationTest[
-        SeedRandom[123]; 
         WolframModel[
           {{1, 2}} -> {{1, 3}, {3, 2}},
           {{1, 1}},
-          <|"MaxEvents" -> 30|>,
-          "EventOrderingFunction" -> "Random"][
+          <|"MaxEvents" -> 30|>][
           "GenerationsCount"],
-        {2, 8}
+        {4, 1}
       ],
 
       (* GenerationComplete *)
@@ -628,6 +622,16 @@
         {ImageSize -> 123.}
       ],
 
+      testUnevaluated[
+        WolframModel[1 -> 2, {1}, 2, "FinalStatePlot"],
+        {WolframModel::nonHypergraphPlot}
+      ],
+
+      With[{evo = WolframModel[{{1, 2}} -> {{1, 3}, {3, 2}}, {{1, 1}}, <|"MaxEvents" -> 30|>]}, testUnevaluated[
+        evo["FinalStatePlot", VertexSize -> x],
+        {WolframModelPlot::invalidSize}
+      ]],
+
       (* UpdatedStatesList *)
 
       VerificationTest[
@@ -780,6 +784,16 @@
           WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 3]["StatesPlotsList", ImageSize -> 123.],
         ConstantArray[{ImageSize -> 123.}, 4]
       ],
+
+      testUnevaluated[
+        WolframModel[1 -> 2, {1}, 2, "StatesPlotsList"],
+        {WolframModel::nonHypergraphPlot}
+      ],
+
+      With[{evo = WolframModel[{{1, 2}} -> {{1, 3}, {3, 2}}, {{1, 1}}, <|"MaxEvents" -> 30|>]}, testUnevaluated[
+        evo["StatesPlotsList", VertexSize -> x],
+        {WolframModelPlot::invalidSize}
+      ]],
 
       (* AtomsCountFinal *)
 

--- a/SetReplace/WolframModelEvolutionObject.wlt
+++ b/SetReplace/WolframModelEvolutionObject.wlt
@@ -661,6 +661,35 @@
         {{{1, 2}, {2, 3}}, {{2, 3}}, {}}
       ] & /@ {"UpdatedStatesList", "AllEventsStatesList"},
 
+      (* AllEventsStatesEdgeIndicesList *)
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4]["AllEventsStatesEdgeIndicesList"],
+        WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4]["StateEdgeIndicesAfterEvent", #] & /@ Range[0, 15]
+      ],
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          0]["AllEventsStatesEdgeIndicesList"],
+        {Range[Length[pathGraph17]]}
+      ],
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}} -> {},
+          {{1, 2}, {2, 3}},
+          2]["AllEventsStatesEdgeIndicesList"],
+        {{1, 2}, {2}, {}}
+      ],
+
       (* Generation *)
 
       VerificationTest[
@@ -1226,14 +1255,40 @@
 
       VerificationTest[
         WolframModel[{{1, 2}} -> {{1, 3}, {3, 2}}, {{1, 1}}, 2]["EventsStatesList"],
+        {{{1, {1} -> {2, 3}}, {2, 3}}, {{1, {2} -> {4, 5}}, {3, 4, 5}}, {{1, {3} -> {6, 7}}, {4, 5, 6, 7}}}
+      ],
+
+      VerificationTest[
+        WolframModel[{{1, 2}} -> {{1, 3}, {3, 2}}, {{1, 1}}, 2][
+          "EventsStatesList", "IncludeBoundaryEvents" -> "Initial"],
         {
-          {{1, 1}},
-          {1, {1} -> {2, 3}},
-          {{1, 2}, {2, 1}},
-          {1, {2} -> {4, 5}},
-          {{2, 1}, {1, 3}, {3, 2}},
-          {1, {3} -> {6, 7}},
-          {{1, 3}, {3, 2}, {2, 4}, {4, 1}}
+          {{0, {} -> {1}}, {1}},
+          {{1, {1} -> {2, 3}}, {2, 3}},
+          {{1, {2} -> {4, 5}}, {3, 4, 5}},
+          {{1, {3} -> {6, 7}}, {4, 5, 6, 7}}
+        }
+      ],
+
+      VerificationTest[
+        WolframModel[{{1, 2}} -> {{1, 3}, {3, 2}}, {{1, 1}}, 2][
+          "EventsStatesList", "IncludeBoundaryEvents" -> "Final"],
+        {
+          {{1, {1} -> {2, 3}}, {2, 3}},
+          {{1, {2} -> {4, 5}}, {3, 4, 5}},
+          {{1, {3} -> {6, 7}}, {4, 5, 6, 7}},
+          {{DirectedInfinity[1], {4, 5, 6, 7} -> {}}, {}}
+        }
+      ],
+
+      VerificationTest[
+        WolframModel[{{1, 2}} -> {{1, 3}, {3, 2}}, {{1, 1}}, 2][
+          "EventsStatesList", "IncludeBoundaryEvents" -> All],
+        {
+          {{0, {} -> {1}}, {1}},
+          {{1, {1} -> {2, 3}}, {2, 3}},
+          {{1, {2} -> {4, 5}}, {3, 4, 5}},
+          {{1, {3} -> {6, 7}}, {4, 5, 6, 7}},
+          {{DirectedInfinity[1], {4, 5, 6, 7} -> {}}, {}}
         }
       ]
     }]

--- a/SetReplace/correctness.wlt
+++ b/SetReplace/correctness.wlt
@@ -178,7 +178,8 @@
 
       VerificationTest[
         SeedRandom[1655];
-          WolframModel[#1, #2, #6, {"GenerationsCount", "MaxCompleteGeneration"}, "EventOrderingFunction" -> "Random"],
+          WolframModel[
+            #1, #2, #6, {"TotalGenerationsCount", "MaxCompleteGeneration"}, "EventOrderingFunction" -> "Random"],
         {#6, #6}
       ] & @@@ $systemsToTest,
 

--- a/SetReplace/makeMessage.m
+++ b/SetReplace/makeMessage.m
@@ -79,20 +79,12 @@ messageTemplate["pargx"] =
 	"`5``6``7``8` argument`9` `10` expected.";
 
 
-messageTemplate["eventTooLarge"] =
-	"Event `2` requested out of `3` total.";
+messageTemplate["stepTooLarge"] =
+	"`2` `3` requested out of `4` total.";
 
 
-messageTemplate["eventNotInteger"] =
-	"Event `2` must be an integer.";
-
-
-messageTemplate["generationTooLarge"] =
-	"Generation `2` requested out of `3` total.";
-
-
-messageTemplate["generationNotInteger"] =
-	"Generation `2` must be an integer.";
+messageTemplate["stepNotInteger"] =
+	"`2` `3` must be an integer.";
 
 
 messageTemplate["nonopt"] =

--- a/SetReplace/makeMessage.m
+++ b/SetReplace/makeMessage.m
@@ -96,8 +96,8 @@ messageTemplate["generationNotInteger"] =
 
 
 messageTemplate["nonopt"] =
-	"Options expected (instead of `2`) " <>
-	"beyond position 1 for \"CausalGraph\" property. " <>
+	"Options expected (instead of `3`) " <>
+	"beyond position 1 for `2` property. " <>
 	"An option must be a rule or a list of rules.";
 
 

--- a/SetReplace/setSubstitutionSystem$wl.m
+++ b/SetReplace/setSubstitutionSystem$wl.m
@@ -388,11 +388,11 @@ setSubstitutionSystem$wl[
 					possibleInfinityResult = intermediateEvolution[[1, Key[$maxCompleteGeneration]]]},
 				If[MissingQ[possibleInfinityResult],
 					possibleInfinityResult,
-					Min[possibleInfinityResult, intermediateEvolution["GenerationsCount"]]]],
+					Min[possibleInfinityResult, intermediateEvolution["TotalGenerationsCount"]]]],
 			$terminationReason -> Replace[
 				intermediateEvolution[[1, Key[$terminationReason]]],
 				$fixedPoint ->
-					If[intermediateEvolution["GenerationsCount"] == Lookup[stepSpec, $maxGenerationsLocal, Infinity],
+					If[intermediateEvolution["TotalGenerationsCount"] == Lookup[stepSpec, $maxGenerationsLocal, Infinity],
 						$maxGenerationsLocal,
 						$fixedPoint]]|>]]
 ]


### PR DESCRIPTION
## Changes
* Closes #85.
* Implemented new properties for `WolframModelEvolutionObject`:
  * `"FinalStatePlot"`: `WolframModelPlot`s the last state,
  * `"StatesPlotsList"`: yields a list of `WolframModelPlot`s,
  * `"PartialGenerationsCount"`: total - complete generations,
  * `"GenerationComplete"`: yields true/false depending whether the last (or specified) generation is complete,
  * `"GenerationEventsCountList"`: event counts in between generations,
  * `"GenerationEventsList"`: events grouped by generation,
  * `"VertexCountList"`: counts of vertices at each generation,
  * `"EdgeCountList"`: counts of edges at each generation,
  * `"EventsStatesList"`: riffled states and events.
* Changed behavior of `"GenerationsCount"`, which now returns a list `{"CompleteGenerationsCount", "PartialGenerationsCount"}`.
* Renamed properties (old names are still allowed):
  * `"UpdatedStatesList"` -> `"AllEventsStatesList"`,
  * `"AllExpressions"` -> `"AllEventsEdgesList"`,
  * `"CreatorEvents"` -> `"EdgeCreatorEventIndices"`,
  * `"DestroyerEvents"` -> `"EdgeDestroyerEventIndices"`,
  * `"MaxCompleteGeneration"` -> `"CompleteGenerationsCount"`,
  * `"EventGenerations"` -> `"AllEventsGenerationsList"`,
  * `"ExpressionGenerations"` -> `"EdgeGenerationsList"`,
  * `"EventsCount"` -> `"AllEventsCount"`,
  * `"EventsList"` -> `"AllEventsList"`,
  * `"AtomsCountFinal"` -> `"FinalDistinctElementsCount"`,
  * `"AtomsCountTotal"` -> `"AllEventsDistinctElementsCount"`,
  * `"ExpressionsCountFinal"` -> `"FinalEdgeCount"`,
  * `"ExpressionsCountTotal"` -> `"AllEventsEdgesCount"`,
  * `"SetAfterEvent"` -> `"StateAfterEvent"`

## Review questions
* The events in the output of `"EventsStatesList"` refer to indices of expressions in “AllExpressions” rather than to the states that surround them, which make it rather confusing to read and unusable without additional information. Do you think it would be better to reindex them so that they refer to the indices in surrounding states? Or is it better to keep events spec consistent for all properties? Another alternative would be to return states as well as lists of indices in “EventsStatesList”.
* Please look at the new property names, and comment if it's clear from the names what they do. Some of these names are quite confusing to me.
* @sskini2: This is the largest piece needed to make `WolframModel` consistent with documentation.

## Tests
* Plot final state directly without calling `WolframModelPlot`:
```
In[] := WolframModel[{{1, 1}} -> {{1, 2}, {2, 2}, {2, 2}}, {{1, 
   1}}, 6, "FinalStatePlot"]
```
![image](https://user-images.githubusercontent.com/1479325/73128669-d63f2080-3fa0-11ea-8dff-f97eaa495a38.png)
* Label vertices:
```
In[] := WolframModel[{{1, 1}} -> {{1, 2}, {2, 2}, {2, 2}}, {{1, 1}}, 
  3]["FinalStatePlot", VertexLabels -> Automatic]
```
![image](https://user-images.githubusercontent.com/1479325/73128674-e6570000-3fa0-11ea-8d94-4a38dd23f555.png)
* Plot all generations:
```
In[] := WolframModel[{{1, 1}} -> {{1, 2}, {2, 2}, {2, 2}}, {{1, 
   1}}, 5, "StatesPlotsList"]
```
![image](https://user-images.githubusercontent.com/1479325/73128681-fc64c080-3fa0-11ea-950b-1e3529fb02be.png)
* See how the number of incomplete generations increases with the events count:
```
In[] := ListPlot[WolframModel[{{1, 1}} -> {{1, 2}, {2, 2}, {2, 2}}, {{1, 
      1}}, <|"MaxEvents" -> #|>, "PartialGenerationsCount", 
    "EventOrderingFunction" -> "Random"] & /@ Range[200]]
```
![image](https://user-images.githubusercontent.com/1479325/73128697-42218900-3fa1-11ea-86c3-96aea802ff71.png)
* Check if a given generation is complete:
```
In[] := WolframModel[{{1, 1}} -> {{1, 2}, {2, 2}, {2, 2}}, {{1, 1}}, <|
  "MaxEvents" -> 1000|>, "EventOrderingFunction" -> "Random"]
```
![image](https://user-images.githubusercontent.com/1479325/73128719-99275e00-3fa1-11ea-87b8-afb0a14a9e3b.png)
```
In[] := %["GenerationComplete", 4]
```
```
Out[] = False
```
* Check how many events occur in between generations:
```
In[] := WolframModel[{{1, 1}} -> {{1, 2}, {2, 2}, {2, 2}}, {{1, 
   1}}, 10, "GenerationEventsCountList"]
```
```
Out[] = {1, 2, 4, 8, 16, 32, 64, 128, 256, 512}
```
* Show events grouped by generation:
```
In[] := WolframModel[{{1, 1}} -> {{1, 2}, {2, 2}, {2, 2}}, {{1, 1}}, 3, 
  "GenerationEventsList"] // Column
```
![image](https://user-images.githubusercontent.com/1479325/73128740-ddb2f980-3fa1-11ea-94ad-c1a96b2abf61.png)
* Check how the number of vertices grows with generations:
```
In[] := WolframModel[{{1, 1}} -> {{1, 2}, {2, 2}, {2, 2}}, {{1, 
   1}}, 10, "VertexCountList"]
```
```
Out[] = {1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024}
```
* Same for the number of edges:
```
In[] := WolframModel[{{1, 1}} -> {{1, 2}, {2, 2}, {2, 2}}, {{1, 
   1}}, 10, "EdgeCountList"]
```
```
Out[] = {1, 3, 7, 15, 31, 63, 127, 255, 511, 1023, 2047}
```
* Show events and states in the same list (edge indices are given in terms of `"AllEventsEdgesList"`):
```
In[] := WolframModel[{{1, 1}} -> {{1, 2}, {2, 2}, {2, 2}}, {{1, 1}}, 3, 
  "EventsStatesList"] // Grid
```
![image](https://user-images.githubusercontent.com/1479325/73204731-744ff980-410d-11ea-86e5-907555beacf5.png)