### PR TITLE
VertexNamingFunction

### DIFF
--- a/SetReplace/WolframModel.m
+++ b/SetReplace/WolframModel.m
@@ -51,7 +51,7 @@ SyntaxInformation[WolframModel] =
 
 
 Options[WolframModel] := Join[{
-	"NodeNamingFunction" -> Automatic,
+	"VertexNamingFunction" -> Automatic,
 	"EventOrderingFunction" -> "Sequential", (* Possible values are "Sequential" and "Random" *)
 	"IncludePartialGenerations" -> True,
 	"IncludeBoundaryEvents" -> None},
@@ -101,7 +101,7 @@ fromStepsSpec[spec_Association] := With[{
 (*renameNodes*)
 
 
-$nodeNamingFunctions = {Automatic, None, All};
+$vertexNamingFunctions = {Automatic, None, All};
 
 
 renameNodes[evolution_, _, None] := evolution
@@ -110,9 +110,7 @@ renameNodes[evolution_, _, None] := evolution
 renameNodesExceptExisting[
 		evolution_, patternRulesQ_, existing_List] := Module[{
 			evolutionAtoms, existingAtoms, atomsToName, newNames},
-	{evolutionAtoms, existingAtoms} = DeleteDuplicates @ If[patternRulesQ,
-			Cases[#, _ ? AtomQ, All],
-			Catenate[If[AtomQ[#], {#}, #] & /@ #]] & /@
+	{evolutionAtoms, existingAtoms} = (DeleteDuplicates @ Catenate[If[AtomQ[#], {#}, #] & /@ #]) & /@
 		{evolution[[1]][$atomLists], existing};
 	atomsToName = DeleteCases[evolutionAtoms, Alternatives @@ existingAtoms];
 	newNames = Take[
@@ -137,12 +135,12 @@ renameNodes[evolution_, False, Automatic] :=
 	renameNodesExceptExisting[evolution, False, evolution[0]]
 
 
-WolframModel::unknownNodeNamingFunction =
-	"NodeNamingFunction `1` should be one of `2`.";
+WolframModel::unknownVertexNamingFunction =
+	"VertexNamingFunction `1` should be one of `2`.";
 
 
 renameNodes[evolution_, _, func_] := (
-	Message[WolframModel::unknownNodeNamingFunction, func, $nodeNamingFunctions];
+	Message[WolframModel::unknownVertexNamingFunction, func, $vertexNamingFunctions];
 	$Failed
 )
 
@@ -178,7 +176,7 @@ WolframModel[
 				renameNodes[
 					evolution,
 					AssociationQ[rulesSpec],
-					OptionValue["NodeNamingFunction"]],
+					OptionValue["VertexNamingFunction"]],
 				$Failed],
 			$Failed];
 		propertyEvaluateWithOptions = propertyEvaluate[

--- a/SetReplace/WolframModel.wlt
+++ b/SetReplace/WolframModel.wlt
@@ -22,7 +22,7 @@
 
       testSymbolLeak[
         WolframModel[
-          {{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 5, "FinalState", Method -> #1, "NodeNamingFunction" -> #2]
+          {{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 5, "FinalState", Method -> #1, "VertexNamingFunction" -> #2]
       ] & @@@ Tuples[{$SetReplaceMethods, {Automatic, All}}],
 
       (* Argument checks *)
@@ -1158,7 +1158,7 @@
         {ConstantArray[{0, 0, 0}, 4]}
       ] & /@ $SetReplaceMethods,
 
-      (** NodeNamingFunction **)
+      (** VertexNamingFunction **)
 
       VerificationTest[
         WolframModel[
@@ -1171,7 +1171,7 @@
           {{0, 0}},
           2,
           "FinalState",
-          "NodeNamingFunction" -> Automatic]
+          "VertexNamingFunction" -> Automatic]
       ],
 
       VerificationTest[
@@ -1180,7 +1180,7 @@
           {{0, 0}},
           2,
           "FinalState",
-          "NodeNamingFunction" -> Automatic],
+          "VertexNamingFunction" -> Automatic],
         {{0, 2}, {2, 1}, {1, 3}, {3, 0}}
       ],
 
@@ -1190,7 +1190,7 @@
           {{2, 2}},
           2,
           "FinalState",
-          "NodeNamingFunction" -> Automatic],
+          "VertexNamingFunction" -> Automatic],
         {{2, 3}, {3, 1}, {1, 4}, {4, 2}}
       ],
 
@@ -1200,7 +1200,7 @@
           {{0, 0}},
           2,
           "FinalState",
-          "NodeNamingFunction" -> All],
+          "VertexNamingFunction" -> All],
         {{1, 3}, {3, 2}, {2, 4}, {4, 1}}
       ],
 
@@ -1210,7 +1210,7 @@
           {{0, 0}},
           2,
           "FinalState",
-          "NodeNamingFunction" -> None],
+          "VertexNamingFunction" -> None],
         {{0, x_Symbol}, {x_Symbol, y_Symbol}, {y_Symbol, z_Symbol}, {z_Symbol, 0}},
         SameTest -> MatchQ
       ],
@@ -1221,7 +1221,7 @@
           {{0, 0}},
           2,
           "FinalState",
-          "NodeNamingFunction" -> All],
+          "VertexNamingFunction" -> All],
         {{1, 3}, {3, 2}, {2, 4}, {4, 1}}
       ],
 
@@ -1231,7 +1231,7 @@
           {{0, 0}},
           2,
           "FinalState",
-          "NodeNamingFunction" -> #],
+          "VertexNamingFunction" -> #],
         {{0, x_Symbol}, {x_Symbol, y_Symbol}, {y_Symbol, z_Symbol}, {z_Symbol, 0}},
         SameTest -> MatchQ
       ] & /@ {Automatic, None},
@@ -1249,19 +1249,19 @@
       With[{namingTestModel = $namingTestModel}, {
         VerificationTest[
           # == Range[Length[#]] & @ Union @ Flatten[
-            WolframModel[##, "NodeNamingFunction" -> All] & @@
+            WolframModel[##, "VertexNamingFunction" -> All] & @@
               namingTestModel]
         ],
 
         VerificationTest[
           # == Range[0, Length[#] - 1] & @ Union @ Flatten[
-            WolframModel[##, "NodeNamingFunction" -> Automatic] & @@
+            WolframModel[##, "VertexNamingFunction" -> Automatic] & @@
               namingTestModel]
         ],
 
         VerificationTest[
           (#[[1]] /. Thread[Rule @@ Flatten /@ #]) == #[[2]] & @ (Table[
-            WolframModel[##, "NodeNamingFunction" -> namingFunction] & @@ namingTestModel,
+            WolframModel[##, "VertexNamingFunction" -> namingFunction] & @@ namingTestModel,
             {namingFunction, {All, None}}])
         ]
       }],
@@ -1273,7 +1273,7 @@
           {{s[1], s[2]}},
           1,
           "FinalState",
-          "NodeNamingFunction" -> All],
+          "VertexNamingFunction" -> All],
         {{1, 3}, {3, 2}}
       ],
 

--- a/SetReplace/performance.wlt
+++ b/SetReplace/performance.wlt
@@ -55,7 +55,7 @@
               init,
               <|"MaxEvents" -> 1000|>,
               "FinalState",
-              "NodeNamingFunction" -> All]],
+              "VertexNamingFunction" -> All]],
             List,
             TimeConstraint -> 10,
             MemoryConstraint -> 10*^6


### PR DESCRIPTION
## Changes
* Renames `"NodeNamingFunction"` to `"VertexNamingFunction"`.
* It now always renames vertices, not atoms, even for pattern rules.

## Tests
* Use `"VertexNamingFunction"` in the similar way as `"NodeNamingFunction"` was used before:
```
In[] := WolframModel[{{1, 2}} -> {{1, 3}, {3, 2}}, {{a, a}}, 2, 
    "AllExpressions", "VertexNamingFunction" -> #] & /@ {Automatic, 
   All} // Column
```
![image](https://user-images.githubusercontent.com/1479325/73132344-cc8cdb80-3fe7-11ea-82cd-3f216ed09a74.png)
* Vertices (i.e., level-2 expressions) are replaced instead of atoms:
```
In[] := WolframModel[<|"PatternRules" -> a_ :> a|>, {{{{{{{x}}}}}}}, 1, 
   "FinalState", "VertexNamingFunction" -> #] & /@ {None, All}
```
```
Out[] = {{{{{{{{x}}}}}}}, {{1}}}
```