### PR TITLE
Automatic image size for small graphs

### DIFF
--- a/SetReplace/WolframModelPlot.m
+++ b/SetReplace/WolframModelPlot.m
@@ -202,6 +202,8 @@ correctStyleLengthQ[__] := True
 
 (* Implementation *)
 
+$imageSizeDefault = {{360}, {420}};
+
 wolframModelPlot[
 		edges_,
 		edgeType_,
@@ -213,11 +215,11 @@ wolframModelPlot[
 		vertexLabels_,
 		vertexSize_,
 		arrowheadLength_,
-		graphicsOptions_] := Catch[Show[
-	drawEmbedding[styles, vertexLabels, highlight, highlightColor, vertexSize, arrowheadLength] @
+		graphicsOptions_] := Catch[With[{
+	graphics = drawEmbedding[styles, vertexLabels, highlight, highlightColor, vertexSize, arrowheadLength] @
 		hypergraphEmbedding[edgeType, hyperedgeRendering, vertexCoordinates] @
-		edges,
-	graphicsOptions
+		edges},
+	Show[graphics, graphicsOptions, ImageSizeRaw -> $imageSizeDefault (Min[1, #[[2]] - #[[1]]] & /@ PlotRange[graphics])]
 ]]
 
 (** Embedding **)

--- a/SetReplace/WolframModelPlot.wlt
+++ b/SetReplace/WolframModelPlot.wlt
@@ -625,7 +625,14 @@
         {{1, 2, 3}, {1, 1}},
         {{1, 2, 3}, {3, 4, 5}, {5, 5}},
         {{1, 2, 3}, {3, 4, 5}, {5, 6, 1, 1}},
-        {{1, 2, 3, 4, 5, 5, 1}}}
+        {{1, 2, 3, 4, 5, 5, 1}}},
+
+      (* Automatic image size *)
+      VerificationTest[
+        Table[OrderedQ[(ImageSizeRaw /. AbsoluteOptions[WolframModelPlot[#], ImageSizeRaw])[[k, 1]] & /@
+          {{{1}}, {{1, 1}}, {{1, 2, 3}, {3, 4, 5}, {5, 6, 1}}, {{1, 2, 3}, {3, 4, 5}, {5, 6, 7}, {7, 8, 1}}}], {k, 2}],
+        {True, True}
+      ]
     }
   |>
 |>


### PR DESCRIPTION
## Changes
* Image size now scales automatically with the plot range for small hypergraphs (when plot range in either direction is smaller than 1).
* `ImageSizeRaw` is used so that images still become smaller if placed in lists etc.
* Nothing except for image size (i.e., graph layout etc) is affected.

## Tests
* Plot an evolution of a set substitution system and observe that the first plot has a smaller image size than the others:
```
In[] := WolframModelPlot /@ 
 WolframModel[{{{1, 2}} -> {{1, 3}, {1, 3}, {2, 3}}}, {{1, 1}}, 4, 
  "StatesList"]
```
![image](https://user-images.githubusercontent.com/1479325/73150396-2d71ed80-4094-11ea-82aa-7a2572398304.png)