### PR TITLE
New plot styles

### DIFF
--- a/SetReplace/RulePlot.m
+++ b/SetReplace/RulePlot.m
@@ -31,6 +31,8 @@ $arrowheadsLength = 0.3;
 $graphPadding = Scaled[0.1];
 $ruleSidesSpacing = 0.2;
 
+$eventColor = Hue[0.11, 1, 0.97];
+
 (* Messages *)
 
 RulePlot::patternRules =
@@ -211,13 +213,13 @@ combinedRuleParts[sides_, plotRange_, spacings_] := Module[{maxRange, xRange, yR
   maxRange = Max[plotRange[[1, 2]] - plotRange[[1, 1]], plotRange[[2, 2]] - plotRange[[2, 1]], 1];
   {xRange, yRange} = Mean[#] + maxRange * {-0.5, 0.5} & /@ plotRange;
   xDisplacement = 1.5 (xRange[[2]] - xRange[[1]]);
-  frame = {Gray, Dotted, Line[{
+  frame = {$eventColor, Dotted, Line[{
     {xRange[[1]], yRange[[1]]},
     {xRange[[2]], yRange[[1]]},
     {xRange[[2]], yRange[[2]]},
     {xRange[[1]], yRange[[2]]},
     {xRange[[1]], yRange[[1]]}}]};
-  separator = arrow[$ruleArrowShape, 0.15, 0][{{0.15, 0.5}, {0.85, 0.5}}];
+  separator = {$eventColor, arrow[$ruleArrowShape, 0.15, 0][{{0.15, 0.5}, {0.85, 0.5}}]};
   graphicsRiffle[
     Append[#, frame] & /@ sides,
     ConstantArray[{xRange, yRange}, 2],

--- a/SetReplace/WolframModel.wlt
+++ b/SetReplace/WolframModel.wlt
@@ -810,8 +810,8 @@
       (** Properties **)
 
       VerificationTest[
-        WolframModel[1 -> 2, {1}, 2, "CausalGraph"],
-        Graph[{1, 2}, {1 -> 2}]
+        EdgeList[WolframModel[1 -> 2, {1}, 2, "CausalGraph"]],
+        {DirectedEdge[1, 2]}
       ],
 
       testUnevaluated[
@@ -855,8 +855,8 @@
       ],
 
       VerificationTest[
-        WolframModel[1 -> 2, {1}, 2, {"CausalGraph", "CausalGraph"}],
-        ConstantArray[Graph[{1, 2}, {1 -> 2}], 2]
+        EdgeList /@ WolframModel[1 -> 2, {1}, 2, {"CausalGraph", "CausalGraph"}],
+        ConstantArray[{DirectedEdge[1, 2]}, 2]
       ],
 
       testUnevaluated[
@@ -897,8 +897,8 @@
       ],
 
       VerificationTest[
-        WolframModel[1 -> 2, {1}, "CausalGraph"],
-        Graph[{1}, {}]
+        Through[{VertexList, EdgeList}[WolframModel[1 -> 2, {1}, "CausalGraph"]]],
+        {{1}, {}}
       ],
 
       testUnevaluated[

--- a/SetReplace/WolframModelEvolutionObject.m
+++ b/SetReplace/WolframModelEvolutionObject.m
@@ -567,6 +567,10 @@ $causalGraphOptions = Options[Graph];
 $layeredCausalGraphOptions = Options[$causalGraphOptions];
 
 
+$causalGraphVertexStyle = Directive[Hue[0.11, 1, 0.97], EdgeForm[{Hue[0.11, 1, 0.97], Opacity[1]}]];
+$causalGraphEdgeStyle = Hue[0, 1, 0.56];
+
+
 (* ::Subsubsection:: *)
 (*Argument checks*)
 
@@ -618,7 +622,9 @@ propertyEvaluate[True, includeBoundaryEvents : includeBounaryEventsPattern][
 	Graph[
 		DeleteCases[Union[data[$creatorEvents], data[$destroyerEvents]], $eventsToDelete],
 		Select[FreeQ[#, $eventsToDelete] &] @ Thread[data[$creatorEvents] \[DirectedEdge] data[$destroyerEvents]],
-		o]
+		o,
+		VertexStyle -> $causalGraphVertexStyle,
+		EdgeStyle -> $causalGraphEdgeStyle]
 ]
 
 
@@ -640,7 +646,9 @@ propertyEvaluate[True, includeBoundaryEvents : includeBounaryEventsPattern][
 			"LayeredDigraphEmbedding",
 			"VertexLayerPosition" ->
 				(propertyEvaluate[True, includeBoundaryEvents][evolution, caller, "GenerationsCount"] -
-						propertyEvaluate[True, includeBoundaryEvents][evolution, caller, "EventGenerations"])}
+						propertyEvaluate[True, includeBoundaryEvents][evolution, caller, "EventGenerations"])},
+		VertexStyle -> $causalGraphVertexStyle,
+		EdgeStyle -> $causalGraphEdgeStyle
 	]
 
 


### PR DESCRIPTION
## Changes
* Changes plot styles for `WolframModelPlot`, causal graph properties, and partially `RulePlot`.
* Reduces arrow sizes in `WolframModelPlot`.

## Review points
* Edge styles are different in `WolframModelPlot` and causal graphs, even though they both correspond to the same edges (shared edges define causal relations between events in causal graphs). This is done according to the design document, but it's not clear why the colors are chosen that way.
* `FrameStyle` and highlight color are still missing in `RulePlot` (they are not done in the design document).

## Tests
* `WolframModelPlot` now looks different:
```
In[] := WolframModelPlot /@ 
 WolframModel[{{x, y}, {y, z}} -> {{w, y}, {y, z}, {z, w}, {x, 
     w}}, {{0, 0}, {0, 0}}, 10, "StatesList"]
```
![image](https://user-images.githubusercontent.com/1479325/73213107-9baec280-411d-11ea-95ac-03d0da17b594.png)
```
In[] := WolframModelPlot[
 WolframModel[{{x, y}, {y, z}} -> {{w, y}, {y, z}, {z, w}, {x, w}},
  {{0, 0}, {0, 0}}, 14, "FinalState"]]
```
![image](https://user-images.githubusercontent.com/1479325/73213159-b6813700-411d-11ea-9e06-b7560c241070.png)
```
In[] := WolframModelPlot[
 WolframModel[{{x, y}, {y, z}} -> {{w, y}, {y, z}, {z, w}, {x, 
     w}}, {{0, 0}, {0, 0}}, 5, "FinalState"]]
```
![image](https://user-images.githubusercontent.com/1479325/73213188-c39e2600-411d-11ea-89e2-824a31536076.png)
```
In[] := WolframModelPlot[
 WolframModel[{{1, 2, 1}, {1, 3, 4}} -> {{4, 5, 4}, {5, 4, 3}, {1, 2, 
     5}}, {{0, 0, 0}, {0, 0, 0}}, 2000, "FinalState"]]
```
![image](https://user-images.githubusercontent.com/1479325/73213211-d31d6f00-411d-11ea-9839-c482a1e8ebc0.png)
* Changes highlight style as well:
```
In[] := WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, 
 GraphHighlight -> {{1, 2, 3}, 2}]
```
![image](https://user-images.githubusercontent.com/1479325/73213345-03650d80-411e-11ea-977b-9e22ab0fbde1.png)
* So as causal graphs:
```
In[] := WolframModel[{{1, 2}, {1, 3}, {1, 4}} -> {{5, 6}, {6, 7}, {7, 5}, {5, 
    7}, {7, 6}, {6, 5}, {5, 2}, {6, 3}, {7, 4}, {2, 7}, {4, 5}}, {{1, 
   1}, {1, 1}, {1, 1}}, 5, "CausalGraph"]
```
![image](https://user-images.githubusercontent.com/1479325/73213493-4c1cc680-411e-11ea-934a-4abc988cfbc0.png)
```
In[] := WolframModel[{{1, 2}, {1, 3}, {1, 4}} -> {{5, 6}, {6, 7}, {7, 5}, {5, 
    7}, {7, 6}, {6, 5}, {5, 2}, {6, 3}, {7, 4}, {2, 7}, {4, 5}}, {{1, 
   1}, {1, 1}, {1, 1}}, 3, "LayeredCausalGraph"]
```
![image](https://user-images.githubusercontent.com/1479325/73213512-550d9800-411e-11ea-8a47-5defb60796c2.png)
* Also, `RulePlot` frame colors now correspond to vertex colors from the causal graphs:
```
In[] := RulePlot[WolframModel[{{1, 2}, {1, 3}, {1, 4}} -> {{5, 6}, {6, 7}, {7,
      5}, {5, 7}, {7, 6}, {6, 5}, {5, 2}, {6, 3}, {7, 4}, {2, 7}, {4, 
     5}}]]
```
![image](https://user-images.githubusercontent.com/1479325/73213604-79697480-411e-11ea-945f-688ead2dbf1e.png)