### PR TITLE
Custom evaluation order in C++

### DIFF
--- a/SetReplace/libSetReplace/Match.cpp
+++ b/SetReplace/libSetReplace/Match.cpp
@@ -1,12 +1,48 @@
 #include "Match.hpp"
 
 #include <algorithm>
+#include <map>
 #include <random>
 #include <unordered_map>
 
 namespace SetReplace {
-    namespace {
-        int compareVectors(const std::vector<ExpressionID>& first, const std::vector<ExpressionID>& second) {
+    class MatchComparator {
+    private:
+        const Matcher::OrderingSpec orderingSpec_;
+        
+    public:
+        MatchComparator(const Matcher::OrderingSpec& orderingSpec) : orderingSpec_(orderingSpec) {}
+        
+        bool operator()(const MatchPtr a, const MatchPtr b) const {
+            for (const auto& ordering : orderingSpec_) {
+                int comparison = compare(a, b, ordering.first);
+                if (comparison != 0) {
+                    if (ordering.second == Matcher::OrderingDirection::Reverse) comparison = -comparison;
+                    return comparison < 0;
+                }
+            }
+            return false;
+        }
+        
+        static int compare(const MatchPtr a, const MatchPtr b, const Matcher::OrderingFunction ordering) {
+            switch (ordering) {
+                case Matcher::OrderingFunction::SortedExpressionIDs:
+                    return compareSortedIDs(a, b, false);
+                    
+                case Matcher::OrderingFunction::ReverseSortedExpressionIDs:
+                    return compareSortedIDs(a, b, true);
+                    
+                case Matcher::OrderingFunction::ExpressionIDs:
+                    return compareUnsortedIDs(a, b);
+                    
+                case Matcher::OrderingFunction::RuleID:
+                    if (a->rule < b->rule) return -1;
+                    else if (a->rule > b->rule) return +1;
+                    else return 0;
+            }
+        }
+        
+        static int compareVectors(const std::vector<ExpressionID>& first, const std::vector<ExpressionID>& second) {
             for (int i = 0; i < std::min(first.size(), second.size()); ++i) {
                 if (first[i] < second[i]) return -1;
                 else if (first[i] > second[i]) return +1;
@@ -17,37 +53,56 @@ namespace SetReplace {
             else return 0;
         }
         
-        int compareSortedIDs(const Match& first, const Match& second, bool reverseOrder = false) {
-            std::vector<ExpressionID> thisExpressions = first.inputExpressions;
-            std::sort(thisExpressions.begin(), thisExpressions.end());
+        static int compareSortedIDs(const MatchPtr a, const MatchPtr b, const bool reverseOrder) {
+            std::vector<ExpressionID> aExpressions = a->inputExpressions;
+            std::sort(aExpressions.begin(), aExpressions.end());
             
-            std::vector<ExpressionID> otherExpressions = second.inputExpressions;
-            std::sort(otherExpressions.begin(), otherExpressions.end());
+            std::vector<ExpressionID> bExpressions = b->inputExpressions;
+            std::sort(bExpressions.begin(), bExpressions.end());
             
             if (reverseOrder) {
-                std::reverse(thisExpressions.begin(), thisExpressions.end());
-                std::reverse(otherExpressions.begin(), otherExpressions.end());
+                std::reverse(aExpressions.begin(), aExpressions.end());
+                std::reverse(bExpressions.begin(), bExpressions.end());
             }
-            return compareVectors(thisExpressions, otherExpressions);
+            return compareVectors(aExpressions, bExpressions);
         }
         
-        int compareUnsortedIDs(const Match& first, const Match& second) {
-            return compareVectors(first.inputExpressions, second.inputExpressions);
+        static int compareUnsortedIDs(const MatchPtr a, const MatchPtr& b) {
+            return compareVectors(a->inputExpressions, b->inputExpressions);
         }
-    }
-    
-    bool Match::operator<(const Match& other) const {
-        // First, find which Match has oldest (lowest ID) expressions
-        int sortedComparison = compareSortedIDs(*this, other, true);
-        if (sortedComparison != 0) return sortedComparison < 0;
+    };
 
-        // Then, if sets of expressions are the same, use smaller permutation
-        int unsortedComparison = compareUnsortedIDs(*this, other);
-        if (unsortedComparison != 0) return unsortedComparison < 0;
+    // Hashes the values of the matches, not the pointer itself.
+    class MatchHasher {
+    public:
+        size_t operator()(MatchPtr ptr) const {
+            std::size_t result = 0;
+            hash_combine(result, ptr->rule);
+            for (const auto expression : ptr->inputExpressions) {
+                hash_combine(result, expression);
+            }
+            return result;
+        }
         
-        // Finally, first rule goes first
-        return rule < other.rule;
-    }
+    private:
+        // https://stackoverflow.com/a/2595226
+        template <class T>
+        static void hash_combine(std::size_t& seed, const T& value) {
+            std::hash<T> hasher;
+            seed ^= hasher(value) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+        }
+    };
+
+    class MatchEquality {
+    public:
+        size_t operator()(MatchPtr a, MatchPtr b) const {
+            if (a->rule != b->rule || a->inputExpressions.size() != b->inputExpressions.size()) return false;
+            for (int i = 0; i < a->inputExpressions.size(); ++i) {
+                if (a->inputExpressions[i] != b->inputExpressions[i]) return false;
+            }
+            return true;
+        }
+    };
     
     class Matcher::Implementation {
     private:
@@ -55,75 +110,82 @@ namespace SetReplace {
         AtomsIndex& atomsIndex_;
         const std::function<AtomsVector(ExpressionID)> getAtomsVector_;
         
-        std::set<Match> matches_; // sorted by priority, i.e., the first match is returned first.
+        // Matches are arranged in buckets. Each bucket contains matches that are equivalent in terms of the ordering
+        // function, however, buckets themselves are ordered according to that function.
+        // To select next match, we select a random element from the first bucket.
+        // That in particular means the random ordering function will automatically be used if ordering
+        // specification is incomplete.
         
-        struct IteratorHash {
-            size_t operator()(std::set<Match>::const_iterator it) const {
-                return std::hash<int64_t>()((int64_t)&(*it));
-            }
-        };
-        // Matches organized by expression IDs, useful for deleting matches for deleted expressions.
-        std::unordered_map<ExpressionID, std::unordered_set<std::set<Match>::const_iterator, IteratorHash>> matchesIndex_;
+        // We use MatchPtr instead of Match to save memory, however, they are hashed and sorted according to their
+        // dereferenced values in the corresponding classes above.
         
-        std::vector<std::set<Match>::const_iterator> allMatchIterators_;
-        std::unordered_map<std::set<Match>::const_iterator, int, IteratorHash> matchIteratorsToIndices_;
+        // We cannot directly select a random element from an unordered_map, which is why we use a vector here.
+        using Bucket = std::pair<std::unordered_map<MatchPtr, int, MatchHasher, MatchEquality>, std::vector<MatchPtr>>;
+        std::map<MatchPtr, Bucket, MatchComparator> matchQueue_;
+        std::unordered_map<ExpressionID, std::unordered_set<MatchPtr, MatchHasher, MatchEquality>> expressionToMatches_;
         
-        EvaluationType evaluationType_;
         std::mt19937 randomGenerator_;
-        size_t nextRandomMatchIndex_ = -1;
+        MatchPtr nextMatch_;
         
     public:
         Implementation(const std::vector<Rule>& rules,
                        AtomsIndex& atomsIndex,
                        const std::function<AtomsVector(ExpressionID)> getAtomsVector,
-                       const EvaluationType evaluationType,
+                       const OrderingSpec orderingSpec,
                        const unsigned int randomSeed) :
             rules_(rules),
             atomsIndex_(atomsIndex),
             getAtomsVector_(getAtomsVector),
-            evaluationType_(evaluationType),
+            matchQueue_(orderingSpec),
             randomGenerator_(randomSeed) {}
         
         void addMatchesInvolvingExpressions(const std::vector<ExpressionID>& expressionIDs, const std::function<bool()> shouldAbort) {
             for (int i = 0; i < rules_.size(); ++i) {
                 addMatchesForRule(expressionIDs, i, shouldAbort);
             }
-            
-            chooseNextRandomMatch();
+            chooseNextMatch();
         }
         
         // Note, deletion changes the ordering of allMatchIterators_, therefore
         // deletion should be done in deterministic order, otherwise, the random replacements will not be deterministic
         void removeMatchesInvolvingExpressions(const std::vector<ExpressionID>& expressionIDs) {
-            std::set<Match> matchesToDelete; // do not use unordered_set, as it will make order undeterministic
+            // do not use unordered_set, as it make order undeterministic
+            // any ordering spec works here, as long as it's complete.
+            OrderingSpec fullOrderingSpec = {
+                {OrderingFunction::ExpressionIDs, OrderingDirection::Normal},
+                {OrderingFunction::RuleID, OrderingDirection::Normal}};
+            std::set<MatchPtr, MatchComparator> matchesToDelete(fullOrderingSpec);
+            
             for (const auto& expression : expressionIDs) {
-                const auto& matches = matchesIndex_[expression];
-                for (const auto& matchIterator : matches) {
-                    matchesToDelete.insert(*matchIterator);
+                const auto& matches = expressionToMatches_[expression];
+                for (const auto& matchPtr : matches) {
+                    matchesToDelete.insert(matchPtr);
                 }
             }
             
             for (const auto& match : matchesToDelete) {
-                deleteMatch(matches_.find(match));
+                deleteMatch(match);
             }
             
-            chooseNextRandomMatch();
+            chooseNextMatch();
         }
         
-        int matchCount() const {
-            return static_cast<int>(matches_.size());
+        bool empty() const {
+            return matchQueue_.empty();
         }
         
-        Match nextMatch() const {
-            if (evaluationType_ == EvaluationType::Random) {
-                return *allMatchIterators_[nextRandomMatchIndex_];
-            } else {
-                return *matches_.begin();
+        MatchPtr nextMatch() const {
+            return nextMatch_;
+        }
+        
+        const std::vector<MatchPtr> allMatches() const {
+            std::vector<MatchPtr> result;
+            for (const auto& exampleAndBucket : matchQueue_) {
+                for (const auto& matchPtr : exampleAndBucket.second.second) {
+                    result.push_back(matchPtr);
+                }
             }
-        }
-        
-        const std::set<Match>& allMatches() {
-            return matches_;
+            return result;
         }
         
     private:
@@ -191,31 +253,38 @@ namespace SetReplace {
         }
         
         void insertMatch(const Match& newMatch) {
-            if (matches_.count(newMatch)) return;
-            
-            const auto iterator = matches_.insert(newMatch).first;
-            for (const auto& expression : newMatch.inputExpressions) {
-                matchesIndex_[expression].insert(iterator);
+            // careful, don't create different pointers to the same match!
+            const auto matchPtr = std::make_shared<Match>(newMatch);
+            if (!matchQueue_.count(matchPtr)) { // works because comparison is smart
+                matchQueue_[matchPtr] = {{}, {}};
             }
-            allMatchIterators_.push_back(iterator);
-            matchIteratorsToIndices_[iterator] = (int)allMatchIterators_.size() - 1;
-        }
-        
-        void deleteMatch(const std::set<Match>::const_iterator iterator) {
-            const int deletedIndex = matchIteratorsToIndices_[iterator];
-            matchIteratorsToIndices_.erase(iterator);
-            
-            std::swap(allMatchIterators_[deletedIndex], allMatchIterators_[allMatchIterators_.size() - 1]);
-            allMatchIterators_.pop_back();
-            matchIteratorsToIndices_[allMatchIterators_[deletedIndex]] = deletedIndex;
-            
-            for (const auto& expression : iterator->inputExpressions) {
-                matchesIndex_[expression].erase(iterator);
-                if (matchesIndex_[expression].empty()) {
-                    matchesIndex_.erase(expression);
+            auto& bucket = matchQueue_.at(matchPtr);
+            if (!bucket.first.count(matchPtr)) { // works because hashing is smart
+                bucket.second.push_back(matchPtr);
+                bucket.first[matchPtr] = static_cast<int>(bucket.second.size()) - 1;
+                
+                const auto& expressions = matchPtr->inputExpressions;
+                for (const auto expression : expressions) {
+                    expressionToMatches_[expression].insert(matchPtr);
                 }
             }
-            matches_.erase(iterator);
+        }
+        
+        void deleteMatch(const MatchPtr matchPtr) {
+            const auto& expressions = matchPtr->inputExpressions;
+            for (const auto expression : expressions) {
+                expressionToMatches_[expression].erase(matchPtr);
+                if (expressionToMatches_[expression].empty()) expressionToMatches_.erase(expression);
+            }
+            
+            auto& bucket = matchQueue_[matchPtr];
+            const auto bucketIndex = bucket.first.at(matchPtr);
+            // O(1) order-non-preserving deletion from a vector
+            std::swap(bucket.second[bucketIndex], bucket.second[bucket.second.size() - 1]);
+            bucket.first[bucket.second[bucketIndex]] = bucketIndex;
+            bucket.first.erase(bucket.second[bucket.second.size() - 1]);
+            bucket.second.pop_back();
+            if (bucket.first.empty()) matchQueue_.erase(matchPtr);
         }
         
         static bool isMatchComplete(const Match& match) {
@@ -285,24 +354,20 @@ namespace SetReplace {
         }
 
         // This should be called every time matches are updated.
-        void chooseNextRandomMatch() {
-            if (evaluationType_ == EvaluationType::Random) {
-                if (allMatchIterators_.size() == 0) {
-                    nextRandomMatchIndex_ = -1;
-                } else {
-                    auto distribution = std::uniform_int_distribution<size_t>(0, allMatchIterators_.size() - 1);
-                    nextRandomMatchIndex_ = distribution(randomGenerator_);
-                }
-            }
+        void chooseNextMatch() {
+            if (empty()) return;
+            const auto& allPossibleMatches = matchQueue_.begin()->second.second;
+            auto distribution = std::uniform_int_distribution<size_t>(0, allPossibleMatches.size() - 1);
+            nextMatch_ = allPossibleMatches[distribution(randomGenerator_)];
         }
     };
     
     Matcher::Matcher(const std::vector<Rule>& rules,
                      AtomsIndex& atomsIndex,
                      const std::function<AtomsVector(ExpressionID)> getAtomsVector,
-                     const EvaluationType evaluationType,
+                     const OrderingSpec orderingSpec,
                      const unsigned int randomSeed) {
-        implementation_ = std::make_shared<Implementation>(rules, atomsIndex, getAtomsVector, evaluationType, randomSeed);
+        implementation_ = std::make_shared<Implementation>(rules, atomsIndex, getAtomsVector, orderingSpec, randomSeed);
     }
     
     void Matcher::addMatchesInvolvingExpressions(const std::vector<ExpressionID>& expressionIDs, const std::function<bool()> shouldAbort) {
@@ -313,11 +378,11 @@ namespace SetReplace {
         implementation_->removeMatchesInvolvingExpressions(expressionIDs);
     }
     
-    int Matcher::matchCount() const {
-        return implementation_->matchCount();
+    bool Matcher::empty() const {
+        return implementation_->empty();
     }
     
-    Match Matcher::nextMatch() const {
+    MatchPtr Matcher::nextMatch() const {
         return implementation_->nextMatch();
     }
     
@@ -357,7 +422,7 @@ namespace SetReplace {
         return true;
     }
 
-    const std::set<Match>& Matcher::allMatches() const {
+    const std::vector<MatchPtr> Matcher::allMatches() const {
         return implementation_->allMatches();
     }
 }

--- a/SetReplace/libSetReplace/Set.hpp
+++ b/SetReplace/libSetReplace/Set.hpp
@@ -49,12 +49,12 @@ namespace SetReplace {
         /** @brief Creates a new set with a given set of evolution rules, and initial condition.
          * @param rules substittion rules used for evolution. Note, these rules cannot be changed.
          * @param initialExpressions initial condition. It will be lazily indexed before the first replacement.
-         * @param evaluationType whether to use sequential or random evaluation.
+         * @param orderingSpec in which order to apply events.
          * @param randomSeed the seed to use for selecting matches in random evaluation case.
          */
         Set(const std::vector<Rule>& rules,
             const std::vector<AtomsVector>& initialExpressions,
-            const Matcher::EvaluationType evaluationType,
+            const Matcher::OrderingSpec orderingSpec,
             const unsigned int randomSeed = 0);
         
         /** @brief Perform a single substitution, create the corresponding event, and output expressions.

--- a/SetReplace/setSubstitutionSystem$cpp.m
+++ b/SetReplace/setSubstitutionSystem$cpp.m
@@ -28,7 +28,7 @@ $cpp$setCreate = If[$libraryFile =!= $Failed,
 		"setCreate",
 		{{Integer, 1}, (* rules *)
 			{Integer, 1}, (* initial set *)
-			Integer, (* 0 -> sequential evaluation, 1 -> random evaluation *)
+			{Integer, 1}, (* ordering function index, forward / reverse, function, forward / reverse, ... *)
 			Integer}, (* random seed *)
 		Integer], (* set ptr *)
 	$Failed];
@@ -235,7 +235,7 @@ setSubstitutionSystem$cpp[rules_, set_, stepSpec_, returnOnAbortQ_, timeConstrai
 	setPtr = $cpp$setCreate[
 		encodeNestedLists[List @@@ mappedRules],
 		encodeNestedLists[mappedSet],
-		Replace[eventOrderingFunction, {$EventOrderingFunctionSequential -> 0, $EventOrderingFunctionRandom -> 1}],
+		Replace[eventOrderingFunction, {$EventOrderingFunctionSequential -> {1, 0, 2, 0, 3, 0}, $EventOrderingFunctionRandom -> {}}],
 		If[eventOrderingFunction === $EventOrderingFunctionRandom, RandomInteger[{0, $maxUnsignedInt}], 0]];
 	TimeConstrained[
 		CheckAbort[


### PR DESCRIPTION
## Changes
* Refactors C++ code to allow specification of multiple event ordering functions.
* Reorganizes data structure containing matches into a search tree (`std::map`) of buckets / hash tables (`std::unordered_map`). The search tree is arranged according to the (possibly partial) event ordering function, the hash tables contain the matches that are equivalent according to that function.
* This allows partially random evaluation orders, in which the first bucket is selected for the next event, but a specific match is chosen from that bucket at random.
* `SortedExpressionIDs` (oldest edge first), `ReverseSortedExpressionIDs` (least recent edge first), `ExpressionIDs` (greedy comparison of edge ages one at a time according to the rule ordering), `RuleID` (sort by rule index) are implemented so far. Forward and reverse order is available for each of them. {`ReverseSortedExpressionIDs`, `ExpressionIDs `, `RuleID `} is chosen by default in forward order (unambiguous, and the same as the previous hard-coded implementation).
* Fully random order can be specified as an empty list `{}`, because that puts all matches into a single bucket.
* Since binary tree is effectively no longer used in the random evolution case, it's time complexity has decreased by about ~O(log N), and it became ~2 times faster for typical examples.

## Caveats
* WL options for specifying orders will come in the next PR.
* A bug in `TimeConstrained` causes one of the tests to fail. It seems to occur randomly for very small time constraints, and the test may need to be disabled temporarily until the bug is fixed, WL bug is reported.

## Tests
* There are no public functionality changes, so no additional tests necessary.