### PR TITLE
Remove small time constraint test

### DIFF
--- a/SetReplace/WolframModel.wlt
+++ b/SetReplace/WolframModel.wlt
@@ -1295,7 +1295,8 @@
                 "MaxCompleteGeneration"} & /@ {timeConstrained, eventConstrained})
             ],
             100]
-        ]], {method, $SetReplaceMethods}, {time, {1.*^-100, 0.1}}],
+        (* small time constrained case temporarily removed due to Wolfram bug #387470 *)
+        ]], {method, $SetReplaceMethods}, {time, {(*1.*^-100, *)0.1}}],
 
         (*** This does not work with TimeConstrained though, $Aborted is returned in that case. ***)
         VerificationTest[


### PR DESCRIPTION
## Changes
* Workaround for Wolfram bug #387470.
* Removes small time `TimeConstrained` test to avoid bad memory access yielding wrong test results.
* This commit should be reverted once the bug is fixed.