### PR TITLE
Generalized grid graph edge styles

### DIFF
--- a/SetReplace/GeneralizedGridGraph.wlt
+++ b/SetReplace/GeneralizedGridGraph.wlt
@@ -21,6 +21,17 @@
       ],
 
       testUnevaluated[
+        GeneralizedGridGraph[{2, 3}, "$$$invalid$$$" -> 123],
+        {GeneralizedGridGraph::optx}
+      ],
+
+      (* same behavior as GridGraph *)
+      testUnevaluated[
+        GeneralizedGridGraph[{2, 3}, VertexCoordinates -> "$$$invalid$$$"],
+        {}
+      ],
+
+      testUnevaluated[
         GeneralizedGridGraph[1],
         {GeneralizedGridGraph::dimsNotList}
       ],
@@ -33,8 +44,12 @@
         {1 -> {"Directed", "Circular"}, 2, 3 -> x}},
 
       VerificationTest[
-        EmptyGraphQ[GeneralizedGridGraph[{0}]]
-      ],
+        EmptyGraphQ[#]
+      ] & /@ {
+        GeneralizedGridGraph[{0}],
+        GeneralizedGridGraph[{}],
+        GeneralizedGridGraph[{}, EdgeStyle -> {}],
+        GeneralizedGridGraph[{}, EdgeStyle -> {Red}]},
 
       VerificationTest[
         Through[{VertexList, EdgeList} @ GeneralizedGridGraph[#]],
@@ -115,7 +130,74 @@
               (UndirectedEdge | DirectedEdge) -> EuclideanDistance,
             0.999 < # < 1.001 &]
         ]
-      ] & /@ {{4, 6}, {6, 4}, {3, 3}, {45, 76}, {6 -> "Directed", 8}, {5, 8 -> "Directed"}, {7 -> "Directed", 2 -> "Directed"}}
+      ] & /@ {
+        {4, 6}, {6, 4}, {3, 3}, {45, 76}, {6 -> "Directed", 8}, {5, 8 -> "Directed"},
+        {7 -> "Directed", 2 -> "Directed"}},
+
+      VerificationTest[
+        Options[GeneralizedGridGraph[{3, 4, 5}, EdgeStyle -> Red], EdgeStyle],
+        {EdgeStyle -> {Red}}
+      ],
+
+      With[{edgeStyle = {
+          UndirectedEdge[1, 2] -> Red,
+          UndirectedEdge[3, 4] -> Blue,
+          UndirectedEdge[1, 3] -> Orange,
+          UndirectedEdge[2, 4] -> Black}},
+        VerificationTest[
+          Sort[EdgeStyle /. Options[GeneralizedGridGraph[{2, 2}, EdgeStyle -> edgeStyle], EdgeStyle][[1]]],
+          Sort[edgeStyle]
+        ]
+      ],
+
+      VerificationTest[
+        Options[GeneralizedGridGraph[{2}, EdgeStyle -> {UndirectedEdge[1, 2] -> Red}], EdgeStyle],
+        {EdgeStyle -> {UndirectedEdge[1, 2] -> Red}}
+      ],
+
+      VerificationTest[
+        Options[GeneralizedGridGraph[{2}, EdgeStyle -> {Red}], EdgeStyle],
+        {EdgeStyle -> {UndirectedEdge[1, 2] -> Red}}
+      ],
+
+      VerificationTest[
+        Sort[EdgeStyle /. Options[GeneralizedGridGraph[{3, 1}, EdgeStyle -> {Red, Blue}], EdgeStyle][[1]]],
+        Sort[{UndirectedEdge[1, 2] -> Red, UndirectedEdge[2, 3] -> Red}]
+      ],
+
+      VerificationTest[
+        Sort[EdgeStyle /. Options[
+          GeneralizedGridGraph[{1, 3}, EdgeStyle -> {UndirectedEdge[1, 2] -> Red, UndirectedEdge[2, 3] -> Blue}],
+          EdgeStyle][[1]]],
+        Sort[{UndirectedEdge[1, 2] -> Red, UndirectedEdge[2, 3] -> Blue}]
+      ],
+
+      VerificationTest[
+        Counts[
+            (EdgeStyle /.
+                Options[GeneralizedGridGraph[{3, 4, 5}, EdgeStyle -> {Red, Blue, Black}], EdgeStyle])[[All, 2]]] /@
+          {Red, Blue, Black},
+        {40, 45, 48}
+      ],
+
+      VerificationTest[
+        Sort[EdgeStyle /. Options[GeneralizedGridGraph[{2, 2}, EdgeStyle -> {Red, Blue}], EdgeStyle][[1]]],
+        Sort[{
+          UndirectedEdge[2, 4] -> Blue,
+          UndirectedEdge[1, 2] -> Red,
+          UndirectedEdge[3, 4] -> Red,
+          UndirectedEdge[1, 3] -> Blue}]
+      ],
+
+      VerificationTest[
+        Counts[
+            (EdgeStyle /. Options[
+              GeneralizedGridGraph[
+                {4 -> "Circular", 3 -> {"Circular", "Directed"}, 5}, EdgeStyle -> {Red, Blue, Green}],
+              EdgeStyle])[[All, 2]]] /@
+          {Red, Blue, Green},
+        {60, 60, 48}
+      ]
     }
   |>
 |>


### PR DESCRIPTION
## Changes
* Adds `Graph` options to `GeneralizedGridGraph`.
* Allows specifying different styles for edges in different directions.

## Tests
* Use `"SpringEmbedding"` for the graph:
```
In[] := GeneralizedGridGraph[{5, 5}, GraphLayout -> "SpringEmbedding"]
```
![image](https://user-images.githubusercontent.com/1479325/73708497-8b25bb80-46cc-11ea-9dd5-b70b774d0e77.png)
* Color all edges `Red`:
```
In[] := GeneralizedGridGraph[{5, 5}, EdgeStyle -> Red]
```
![image](https://user-images.githubusercontent.com/1479325/73708516-97aa1400-46cc-11ea-97c9-47c69f4dda64.png)
* Color edges in different directions `Red` and `Blue`:
```
In[] := GeneralizedGridGraph[{5, 5}, EdgeStyle -> {Red, Blue}]
```
![image](https://user-images.githubusercontent.com/1479325/73708559-bad4c380-46cc-11ea-9616-2e84229952fd.png)
* Make vertical lines dotted:
```
In[] := GeneralizedGridGraph[{5, 7 -> "Directed"}, 
 EdgeStyle -> {Directive[Red, Dotted], Blue}]
```
![image](https://user-images.githubusercontent.com/1479325/73708610-dfc93680-46cc-11ea-9a3a-c27b045f34e6.png)