### PR TITLE
VertexNamingFunction for GeneralizedGridGraph

### DIFF
--- a/SetReplace/GeneralizedGridGraph.wlt
+++ b/SetReplace/GeneralizedGridGraph.wlt
@@ -32,6 +32,11 @@
       ],
 
       testUnevaluated[
+        GeneralizedGridGraph[{4, 5}, "VertexNamingFunction" -> "$$$invalid$$$"],
+        {GeneralizedGridGraph::invalidFiniteOption}
+      ],
+
+      testUnevaluated[
         GeneralizedGridGraph[1],
         {GeneralizedGridGraph::dimsNotList}
       ],
@@ -135,9 +140,9 @@
         {7 -> "Directed", 2 -> "Directed"}},
 
       VerificationTest[
-        Options[GeneralizedGridGraph[{3, 4, 5}, EdgeStyle -> Red], EdgeStyle],
+        Options[GeneralizedGridGraph[{3, 4, 5}, EdgeStyle -> Red, "VertexNamingFunction" -> #], EdgeStyle],
         {EdgeStyle -> {Red}}
-      ],
+      ] & /@ {Automatic, "Coordinates"},
 
       With[{edgeStyle = {
           UndirectedEdge[1, 2] -> Red,
@@ -175,10 +180,12 @@
       VerificationTest[
         Counts[
             (EdgeStyle /.
-                Options[GeneralizedGridGraph[{3, 4, 5}, EdgeStyle -> {Red, Blue, Black}], EdgeStyle])[[All, 2]]] /@
+              Options[
+                GeneralizedGridGraph[{3, 4, 5}, EdgeStyle -> {Red, Blue, Black}, "VertexNamingFunction" -> #],
+                EdgeStyle])[[All, 2]]] /@
           {Red, Blue, Black},
         {40, 45, 48}
-      ],
+      ] & /@ {Automatic, "Coordinates"},
 
       VerificationTest[
         Sort[EdgeStyle /. Options[GeneralizedGridGraph[{2, 2}, EdgeStyle -> {Red, Blue}], EdgeStyle][[1]]],
@@ -197,6 +204,26 @@
               EdgeStyle])[[All, 2]]] /@
           {Red, Blue, Green},
         {60, 60, 48}
+      ],
+
+      VerificationTest[
+        Sort[VertexList[GeneralizedGridGraph[{3, 4 -> "Directed", 5 -> "Circular"}]]],
+        Range[60]
+      ],
+
+      VerificationTest[
+        Sort[VertexList[GeneralizedGridGraph[{3}, "VertexNamingFunction" -> "Coordinates"]]],
+        {{1}, {2}, {3}}
+      ],
+
+      VerificationTest[
+        Sort[VertexList[GeneralizedGridGraph[{3, 4 -> "Directed"}, "VertexNamingFunction" -> "Coordinates"]]],
+        Tuples[{Range[3], Range[4]}]
+      ],
+
+      VerificationTest[
+        Sort[VertexList[GeneralizedGridGraph[{3, 4, 5 -> "Circular"}, "VertexNamingFunction" -> "Coordinates"]]],
+        Tuples[{Range[3], Range[4], Range[5]}]
       ]
     }
   |>


### PR DESCRIPTION
## Changes
* Adds an option to name vertices in `GeneralizedGridGraph` with their coordinates.

## Tests
* Use `"VertexNamingFunction" -> "Coordinates"` to name vertices according to their coordinates:
```
In[] := GeneralizedGridGraph[{3, 4}, "VertexNamingFunction" -> "Coordinates", 
 VertexLabels -> Automatic]
```
![image](https://user-images.githubusercontent.com/1479325/73750417-22b9f700-472b-11ea-99c9-e7a687e9c6cb.png)
* That works with other types of grids as well:
```
In[] := GeneralizedGridGraph[{3 -> "Circular", 4 -> "Directed"}, 
 "VertexNamingFunction" -> "Coordinates", VertexLabels -> Automatic]
```
![image](https://user-images.githubusercontent.com/1479325/73750462-36fdf400-472b-11ea-9497-388119ed93aa.png)
* And in arbitrary dimension:
```
In[] := GeneralizedGridGraph[{3, 4, 2}, 
 "VertexNamingFunction" -> "Coordinates", VertexLabels -> Automatic]
```
![image](https://user-images.githubusercontent.com/1479325/73750598-74628180-472b-11ea-8900-f4e3c8923e70.png)
* Default value is `Automatic`, in which case an `IndexGraph` is produced:
```
In[] := GeneralizedGridGraph[{3, 4}, VertexLabels -> Automatic]
```
![image](https://user-images.githubusercontent.com/1479325/73750512-4ed57800-472b-11ea-8e80-5144bc0be020.png)