### PR TITLE
Causal boundary colors

### DIFF
--- a/SetReplace/WolframModelEvolutionObject.m
+++ b/SetReplace/WolframModelEvolutionObject.m
@@ -702,7 +702,7 @@ propertyEvaluate[True, includeBoundaryEvents : includeBoundaryEventsPattern][
 unicolorVertexStyle[color_] := Directive[color, EdgeForm[{color, Opacity[1]}]]
 $causalGraphVertexStyle = unicolorVertexStyle[Hue[0.11, 1, 0.97]];
 $causalGraphInitialVertexStyle = unicolorVertexStyle[RGBColor[{0.259, 0.576, 1}]];
-$causalGraphFinalVertexStyle = unicolorVertexStyle[Black];
+$causalGraphFinalVertexStyle = Directive[White, EdgeForm[{Hue[0.11, 1, 0.97], Opacity[1]}]];
 $causalGraphEdgeStyle = Hue[0, 1, 0.56];
 
 

--- a/SetReplace/WolframModelEvolutionObject.m
+++ b/SetReplace/WolframModelEvolutionObject.m
@@ -699,7 +699,10 @@ propertyEvaluate[True, includeBoundaryEvents : includeBoundaryEventsPattern][
 (*This produces a causal network for the system. This is a Graph with all events as vertices, and directed edges connecting them if the same event is a creator and a destroyer for the same expression (i.e., if two events are causally related).*)
 
 
-$causalGraphVertexStyle = Directive[Hue[0.11, 1, 0.97], EdgeForm[{Hue[0.11, 1, 0.97], Opacity[1]}]];
+unicolorVertexStyle[color_] := Directive[color, EdgeForm[{color, Opacity[1]}]]
+$causalGraphVertexStyle = unicolorVertexStyle[Hue[0.11, 1, 0.97]];
+$causalGraphInitialVertexStyle = unicolorVertexStyle[RGBColor[{0.259, 0.576, 1}]];
+$causalGraphFinalVertexStyle = unicolorVertexStyle[Black];
 $causalGraphEdgeStyle = Hue[0, 1, 0.56];
 
 
@@ -722,7 +725,8 @@ propertyEvaluate[True, includeBoundaryEvents : includeBoundaryEventsPattern][
 		DeleteCases[Union[data[$creatorEvents], data[$destroyerEvents]], $eventsToDelete],
 		Select[FreeQ[#, $eventsToDelete] &] @ Thread[data[$creatorEvents] \[DirectedEdge] data[$destroyerEvents]],
 		o,
-		VertexStyle -> $causalGraphVertexStyle,
+		VertexStyle -> Select[Head[#] =!= Rule || !MatchQ[#[[1]], $eventsToDelete] &] @ {
+			$causalGraphVertexStyle, 0 -> $causalGraphInitialVertexStyle, Infinity -> $causalGraphFinalVertexStyle},
 		EdgeStyle -> $causalGraphEdgeStyle]
 ]
 

--- a/SetReplace/WolframModelEvolutionObject.wlt
+++ b/SetReplace/WolframModelEvolutionObject.wlt
@@ -1179,6 +1179,22 @@
         Join[{5}, Floor[Log2[16 - Range[15]]] + 1, {0}]
       ],
 
+      VerificationTest[
+        Cases[VertexStyle /. Options[
+          WolframModel[{{1, 2}} -> {{1, 3}, {3, 2}}, {{1, 1}}, 4, #, "IncludeBoundaryEvents" -> "Initial"],
+          VertexStyle][[1]], _Rule, {1}],
+        {0 -> _},
+        SameTest -> MatchQ
+      ] & /@ {"CausalGraph", "LayeredCausalGraph"},
+
+      VerificationTest[
+        Sort[Cases[VertexStyle /. Options[
+          WolframModel[{{1, 2}} -> {{1, 3}, {3, 2}}, {{1, 1}}, 4, "CausalGraph", "IncludeBoundaryEvents" -> #],
+          VertexStyle][[1]], _Rule, {1}]],
+        #2,
+        SameTest -> MatchQ
+      ] & @@@ {{None, {}}, {"Final", {Infinity -> _}}, {All, {0 -> _, Infinity -> _}}},
+
       (* AllEventsList *)
 
       Table[With[{method = method}, {


### PR DESCRIPTION
## Changes
* Adds special colors for initial and final events in causal graphs.

## Tests
* It is now obvious which event is the initial event (since it's now blue):
```
In[] := WolframModel[{{1, 2}} -> {{1, 3}, {3, 2}}, {{1, 1}}, 4, "CausalGraph",
  "IncludeBoundaryEvents" -> "Initial"]
```
![image](https://user-images.githubusercontent.com/1479325/73870541-460f9f80-481a-11ea-906a-a3a85ea91fd2.png)
* This also works with `"LayeredCausalGraph"`:
```
In[] := WolframModel[{{1, 2}} -> {{1, 3}, {3, 2}}, {{1, 
   1}}, 4, "LayeredCausalGraph", "IncludeBoundaryEvents" -> "Initial"]
```
![image](https://user-images.githubusercontent.com/1479325/73870564-5293f800-481a-11ea-943d-8db185ce5c06.png)
* Final events are white:
```
In[] := WolframModel[{{1, 2}} -> {{1, 3}, {3, 2}}, {{1, 1}}, 3, "CausalGraph",
  "IncludeBoundaryEvents" -> All]
```
![image](https://user-images.githubusercontent.com/1479325/73876326-cfc46a80-4824-11ea-9585-43f066389d2e.png)