### PR TITLE
"ArrowheadLength" -> 0.15

### DIFF
--- a/SetReplace/WolframModelPlot.m
+++ b/SetReplace/WolframModelPlot.m
@@ -32,7 +32,7 @@ Options[WolframModelPlot] = Join[{
 	VertexCoordinateRules -> {},
 	VertexLabels -> None,
 	VertexSize -> 0.06,
-	"ArrowheadLength" -> 0.1,
+	"ArrowheadLength" -> 0.15,
 	VertexStyle -> Automatic, (* inherits from PlotStyle *)
 	"MaxImageSize" -> Automatic},
 	Options[Graphics]];


### PR DESCRIPTION
## Changes
* Increases default `"ArrowheadLength"` to `0.15`.
* While we are trying to figure out the strategy to scale arrowheads for all possible plot ranges and images sizes (if it's even possible), I think the constant value of `0.15` works better than the current `0.10`.

## Tests
* The new default:
```
In[] := WolframModelPlot[Partition[Range[16], 3, 2, 1]]
```
![image](https://user-images.githubusercontent.com/1479325/73875049-968afb00-4822-11ea-83cb-9c6f7af54ba8.png)
* Comparison (old on the left, new on the right):
```
In[] := Table[WolframModelPlot[Partition[Range[size], 3, 2, 1], 
     "ArrowheadLength" -> #] & /@ {0.1, 0.15}, {size, {6, 10, 
    16}}] // Grid
```
![image](https://user-images.githubusercontent.com/1479325/73875119-b91d1400-4822-11ea-91e9-697537dd0c6d.png)