### PR TITLE
New frame and arrow for RulePlot

### DIFF
--- a/SetReplace/RulePlot.m
+++ b/SetReplace/RulePlot.m
@@ -92,7 +92,7 @@ hypergraphRulesSpecQ[rulesSpec_] := (
 
 correctOptionsQ[args_, {opts___}] :=
   knownOptionsQ[RulePlot, Defer[RulePlot[WolframModel[args], opts]], {opts}, $allowedOptions] &&
-  supportedOptionQ[RulePlot, Frame, {True, False}, {opts}] &&
+  supportedOptionQ[RulePlot, Frame, {True, False, Automatic}, {opts}] &&
   correctEdgeTypeQ[OptionValue[RulePlot, {opts}, "EdgeType"]] &&
   correctSpacingsQ[{opts}] &&
   correctWolframModelPlotOptionsQ[
@@ -158,7 +158,15 @@ rulePlot[
     spacings_,
     graphicsOpts_] :=
   Graphics[
-      First[graphicsRiffle[#[[All, 1]], #[[All, 2]], {}, {{0, 1}, {0, 1}}, 0, 0.01, If[frameQ, frameStyle, None]]],
+      First[
+        graphicsRiffle[
+          #[[All, 1]],
+          #[[All, 2]],
+          {},
+          {{0, 1}, {0, 1}},
+          0,
+          0.01,
+          If[frameQ === True || (frameQ === Automatic && Length[rules] > 1), frameStyle, None]]],
       graphicsOpts] & @
     (singleRulePlot[edgeType, graphHighlightStyle, hyperedgeRendering, vertexCoordinateRules, vertexLabels, spacings] /@
         rules)

--- a/SetReplace/RulePlot.m
+++ b/SetReplace/RulePlot.m
@@ -31,7 +31,8 @@ $arrowheadsLength = 0.3;
 $graphPadding = Scaled[0.1];
 $ruleSidesSpacing = 0.2;
 
-$eventColor = Hue[0.11, 1, 0.97];
+$arrowStyle = Directive[Thick, GrayLevel[0.5]];
+$rulePartsFrameStyle = GrayLevel[0.5]
 
 (* Messages *)
 
@@ -213,13 +214,13 @@ combinedRuleParts[sides_, plotRange_, spacings_] := Module[{maxRange, xRange, yR
   maxRange = Max[plotRange[[1, 2]] - plotRange[[1, 1]], plotRange[[2, 2]] - plotRange[[2, 1]], 1];
   {xRange, yRange} = Mean[#] + maxRange * {-0.5, 0.5} & /@ plotRange;
   xDisplacement = 1.5 (xRange[[2]] - xRange[[1]]);
-  frame = {$eventColor, Dotted, Line[{
+  frame = {$rulePartsFrameStyle, Line[{
     {xRange[[1]], yRange[[1]]},
     {xRange[[2]], yRange[[1]]},
     {xRange[[2]], yRange[[2]]},
     {xRange[[1]], yRange[[2]]},
     {xRange[[1]], yRange[[1]]}}]};
-  separator = {$eventColor, arrow[$ruleArrowShape, 0.15, 0][{{0.15, 0.5}, {0.85, 0.5}}]};
+  separator = {$arrowStyle, arrow[$ruleArrowShape, 0.15, 0][{{0.15, 0.5}, {0.85, 0.5}}]};
   graphicsRiffle[
     Append[#, frame] & /@ sides,
     ConstantArray[{xRange, yRange}, 2],

--- a/SetReplace/RulePlot.m
+++ b/SetReplace/RulePlot.m
@@ -29,10 +29,12 @@ Protect[RulePlot];
 $vertexSize = 0.1;
 $arrowheadsLength = 0.3;
 $graphPadding = Scaled[0.1];
-$ruleSidesSpacing = 0.2;
+$ruleSidesSpacing = 0.13;
 
-$arrowStyle = Directive[Thick, GrayLevel[0.5]];
-$rulePartsFrameStyle = GrayLevel[0.5]
+$arrowStyle = GrayLevel[0.65];
+$rulePartsFrameStyle = GrayLevel[0.7];
+
+$imageSizeScale = 128;
 
 (* Messages *)
 
@@ -156,20 +158,24 @@ rulePlot[
     frameQ_,
     frameStyle_,
     spacings_,
-    graphicsOpts_] :=
+    graphicsOpts_] := Module[{singlePlots, shapes, plotRange},
+  singlePlots =
+    singleRulePlot[edgeType, graphHighlightStyle, hyperedgeRendering, vertexCoordinateRules, vertexLabels, spacings] /@
+      rules;
+  {shapes, plotRange} = graphicsRiffle[
+    singlePlots[[All, 1]],
+    singlePlots[[All, 2]],
+    {},
+    {{0, 1}, {0, 1}},
+    0,
+    0.01,
+    If[frameQ === True || (frameQ === Automatic && Length[rules] > 1), frameStyle, None]];
   Graphics[
-      First[
-        graphicsRiffle[
-          #[[All, 1]],
-          #[[All, 2]],
-          {},
-          {{0, 1}, {0, 1}},
-          0,
-          0.01,
-          If[frameQ === True || (frameQ === Automatic && Length[rules] > 1), frameStyle, None]]],
-      graphicsOpts] & @
-    (singleRulePlot[edgeType, graphHighlightStyle, hyperedgeRendering, vertexCoordinateRules, vertexLabels, spacings] /@
-        rules)
+    shapes,
+    graphicsOpts,
+    PlotRange -> plotRange,
+    ImageSizeRaw -> $imageSizeScale (plotRange[[1, 2]] - plotRange[[1, 1]])]
+]
 
 (* returns {shapes, plotRange} *)
 singleRulePlot[
@@ -215,7 +221,12 @@ ruleCoordinateRules[edgeType_, hyperedgeRendering_, externalVertexCoordinateRule
 
 sharedRuleElements[in_ -> out_] := multisetIntersection @@ (Join[vertexList[#], #] & /@ {in, out})
 
-$ruleArrowShape = {Line[{{-1, 0.7}, {0, 0}, {-1, -0.7}}], Line[{{-1, 0}, {0, 0}}]};
+$arrow = FilledCurve[
+  {{{0, 2, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}}},
+  {{{-1., 0.1848}, {0.2991, 0.1848}, {-0.1531, 0.6363}, {0.109, 0.8982}, {1., 0.0034}, {0.109, -0.8982},
+    {-0.1531, -0.6363}, {0.2991, -0.1848}, {-1., -0.1848}, {-1., 0.1848}}}];
+$arrowLength = 0.22;
+$arrowPadding = 0.4;
 
 (* returns {shapes, plotRange} *)
 combinedRuleParts[sides_, plotRange_, spacings_] := Module[{maxRange, xRange, yRange, xDisplacement, frame, separator},
@@ -228,13 +239,13 @@ combinedRuleParts[sides_, plotRange_, spacings_] := Module[{maxRange, xRange, yR
     {xRange[[2]], yRange[[2]]},
     {xRange[[1]], yRange[[2]]},
     {xRange[[1]], yRange[[1]]}}]};
-  separator = {$arrowStyle, arrow[$ruleArrowShape, 0.15, 0][{{0.15, 0.5}, {0.85, 0.5}}]};
+  separator = {$arrowStyle, $arrow};
   graphicsRiffle[
     Append[#, frame] & /@ sides,
     ConstantArray[{xRange, yRange}, 2],
     separator,
-    {{0, 1}, {0, 1}},
-    0.5,
+    {{-1, 1}, {-1, 1}} (1 + $arrowPadding),
+    $arrowLength (1 + $arrowPadding),
     Replace[spacings, Automatic -> $ruleSidesSpacing],
     None]
 ]
@@ -243,7 +254,7 @@ aspectRatio[{{xMin_, xMax_}, {yMin_, yMax_}}] := (yMax - yMin) / (xMax - xMin)
 
 frame[{{xMin_, xMax_}, {yMin_, yMax_}}] := Line[{{xMin, yMin}, {xMax, yMin}, {xMax, yMax}, {xMin, yMax}, {xMin, yMin}}]
 
-$defaultGridColor = GrayLevel[0.8];
+$defaultGridColor = GrayLevel[0.85];
 
 (* returns {shapes, plotRange} *)
 graphicsRiffle[

--- a/SetReplace/RulePlot.wlt
+++ b/SetReplace/RulePlot.wlt
@@ -190,7 +190,7 @@
       VerificationTest[
         Head[RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], Frame -> #]],
         Graphics
-      ] & /@ {False, True},
+      ] & /@ {False, True, Automatic},
 
       testUnevaluated[
         RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], Frame -> "Invalid"],


### PR DESCRIPTION
## Changes
* Changes colors for the frame around `RulePlot` parts and the arrow.
* Changes the shape of the arrow.
* Adds support for `Frame -> Automatic`, which only draws a frame for multiple rules.
* Add proportional scaling of `ImageSizeRaw` with plot range.

## Caveats
* We need an official design color for the arrow, the frame, and the shared vertex/edge highlight as well.
* `Frame -> Automatic` is not the default for `RulePlot`, and we cannot change it without overwriting the whole system. It needs to be changed upstream.

## Tests
* New look for `RulePlot`:
```
In[] := RulePlot[WolframModel[{{{1, 1, 2}} -> {{1, 2, 3}, {2, 2, 1}, {2, 3, 
      2}}, {{1, 2, 1}, {3, 4, 2}} -> {{4, 3, 2}}}]]
```
![image](https://user-images.githubusercontent.com/1479325/74464782-33bce380-4e62-11ea-8d52-7d35d146d70a.png)
* New look with `Frame -> Automatic`:
```
In[] := RulePlot[WolframModel[{{1, 2, 3}, {4, 5, 6}, {1, 4}} -> {{2, 7, 
     8}, {9, 3, 10}, {5, 11, 12}, {13, 14, 6}, {7, 14}, {9, 11}, {8, 
     12}, {13, 10}}], Frame -> Automatic]
```
![image](https://user-images.githubusercontent.com/1479325/74464795-39b2c480-4e62-11ea-8b93-e248ef5de02f.png)
* All possible values of `Frame`:
```
In[] := Grid[{#, RulePlot[WolframModel[{{x, y}} -> {{x, z}, {x, z}, {y, z}}], 
     Frame -> #, ImageSize -> 150], 
    RulePlot[
     WolframModel[{{{x, y}} -> {{x, z}, {x, z}, {y, z}}, {{x, y}, {y, 
          z}, {z, x}} -> {}}], Frame -> #, 
     ImageSize -> 300]} & /@ {False, Automatic, True}, Frame -> All, 
 FrameStyle -> Directive[Dotted, LightGray]]
```
![image](https://user-images.githubusercontent.com/1479325/74464818-3f100f00-4e62-11ea-8d33-2637ead8076c.png)
* The image size is now chosen based on the number of rules, which allows for consistent look across output cells:
![image](https://user-images.githubusercontent.com/1479325/74464957-7f6f8d00-4e62-11ea-9316-d952fb5d2d10.png)