### PR TITLE
Custom evaluation order

### DIFF
--- a/SetReplace/WolframModel.m
+++ b/SetReplace/WolframModel.m
@@ -52,7 +52,6 @@ SyntaxInformation[WolframModel] =
 
 Options[WolframModel] := Join[{
 	"VertexNamingFunction" -> Automatic,
-	"EventOrderingFunction" -> "Sequential", (* Possible values are "Sequential" and "Random" *)
 	"IncludePartialGenerations" -> True,
 	"IncludeBoundaryEvents" -> None},
 	Options[setSubstitutionSystem]];

--- a/SetReplace/WolframModel.wlt
+++ b/SetReplace/WolframModel.wlt
@@ -1471,7 +1471,7 @@
       (** EventOrderingFunction **)
 
       VerificationTest[
-        Head[WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 3, "EventOrderingFunction" -> "Sequential"]],
+        Head[WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 3, "EventOrderingFunction" -> Automatic]],
         WolframModelEvolutionObject
       ],
 
@@ -1482,17 +1482,17 @@
 
       testUnevaluated[
         WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 3, "EventOrderingFunction" -> "$$$invalid$$$"],
-        {WolframModel::invalidFiniteOption}
+        {WolframModel::invalidEventOrdering}
       ],
 
       testUnevaluated[
         WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 3, "EventOrderingFunction" -> $$$invalid$$$],
-        {WolframModel::invalidFiniteOption}
+        {WolframModel::invalidEventOrdering}
       ],
 
       testUnevaluated[
         WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 3, "EventOrderingFunction" -> 1],
-        {WolframModel::invalidFiniteOption}
+        {WolframModel::invalidEventOrdering}
       ],
 
       VerificationTest[
@@ -1500,7 +1500,7 @@
           {{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}},
           {{1, 1}},
           3,
-          "EventOrderingFunction" -> "Sequential",
+          "EventOrderingFunction" -> Automatic,
           Method -> "Symbolic"]],
         WolframModelEvolutionObject
       ],
@@ -1508,25 +1508,25 @@
       testUnevaluated[
         WolframModel[
           {{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 3, "EventOrderingFunction" -> "Random", Method -> "Symbolic"],
-        {WolframModel::symbolicRandomUnsupported}
+        {WolframModel::symbOrdering}
       ],
 
       testUnevaluated[
         WolframModel[
           {{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 3, "EventOrderingFunction" -> "$inv$", Method -> "Symbolic"],
-        {WolframModel::invalidFiniteOption}
+        {WolframModel::invalidEventOrdering}
       ],
 
       testUnevaluated[
         WolframModel[
           {{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 3, "EventOrderingFunction" -> $$inv$$, Method -> "Symbolic"],
-        {WolframModel::invalidFiniteOption}
+        {WolframModel::invalidEventOrdering}
       ],
 
       testUnevaluated[
         WolframModel[
           {{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 3, "EventOrderingFunction" -> 1, Method -> "Symbolic"],
-        {WolframModel::invalidFiniteOption}
+        {WolframModel::invalidEventOrdering}
       ],
 
       (** AllEventsRuleIndices **)

--- a/SetReplace/correctness.wlt
+++ b/SetReplace/correctness.wlt
@@ -373,6 +373,112 @@
         ]
       }],
 
+      VerificationTest[
+        WolframModel[
+          {{b, c}, {a, b}} -> {},
+          {{1, 2}, {3, 4}, {4, 5}, {2, 3}, {a, b}, {b, c}, {5, 6}},
+          <|"MaxEvents" -> 1|>,
+          "FinalState",
+          "EventOrderingFunction" -> #1],
+        #2
+      ] & @@@ {
+        {"OldestEdge", {{3, 4}, {4, 5}, {a, b}, {b, c}, {5, 6}}},
+        {"LeastOldEdge", {{1, 2}, {3, 4}, {4, 5}, {2, 3}, {5, 6}}},
+        {"LeastRecentEdge", {{1, 2}, {2, 3}, {a, b}, {b, c}, {5, 6}}},
+        {"NewestEdge", {{1, 2}, {3, 4}, {2, 3}, {a, b}, {b, c}}},
+        {"RuleOrdering", {{1, 2}, {4, 5}, {a, b}, {b, c}, {5, 6}}},
+        {"ReverseRuleOrdering", {{1, 2}, {3, 4}, {2, 3}, {a, b}, {b, c}}}
+      },
+
+      Function[{ordering, result}, VerificationTest[
+          WolframModel[
+              <|"PatternRules" -> {{{1, 2}, {2, 3}} -> {{R1}}, {{4, 5}, {5, 6}} -> {{R2}}}|>,
+              #,
+              <|"MaxEvents" -> 1|>,
+              "FinalState",
+              "EventOrderingFunction" -> ordering][[-1, 1]] & /@
+            Permutations[{{1, 2}, {2, 3}, {4, 5}, {5, 6}}],
+          result
+      ]] @@@ {
+        {"OldestEdge",
+          {R1, R1, R1, R1, R1, R1, R1, R1, R1, R1, R1, R1, R2, R2, R2, R2, R2, R2, R2, R2, R2, R2, R2, R2}},
+        {"LeastOldEdge",
+          {R2, R2, R2, R2, R2, R2, R2, R2, R2, R2, R2, R2, R1, R1, R1, R1, R1, R1, R1, R1, R1, R1, R1, R1}},
+        {"LeastRecentEdge",
+          {R1, R1, R1, R2, R1, R2, R1, R1, R1, R2, R1, R2, R1, R2, R1, R2, R2, R2, R1, R2, R1, R2, R2, R2}},
+        {"NewestEdge",
+          {R2, R2, R2, R1, R2, R1, R2, R2, R2, R1, R2, R1, R2, R1, R2, R1, R1, R1, R2, R1, R2, R1, R1, R1}},
+        {"RuleOrdering",
+          {R1, R1, R1, R1, R1, R1, R1, R1, R2, R2, R1, R2, R2, R2, R2, R2, R2, R2, R1, R1, R1, R2, R2, R2}},
+        {"ReverseRuleOrdering",
+          {R2, R2, R2, R2, R2, R2, R2, R2, R1, R1, R2, R1, R1, R1, R1, R1, R1, R1, R2, R2, R2, R1, R1, R1}},
+        {"RuleIndex",
+          {R1, R1, R1, R1, R1, R1, R1, R1, R1, R1, R1, R1, R1, R1, R1, R1, R1, R1, R1, R1, R1, R1, R1, R1}},
+        {"ReverseRuleIndex",
+          {R2, R2, R2, R2, R2, R2, R2, R2, R2, R2, R2, R2, R2, R2, R2, R2, R2, R2, R2, R2, R2, R2, R2, R2}}
+      },
+
+      Function[{ordering, result}, VerificationTest[
+        WolframModel[
+            <|"PatternRules" -> {{1, 2, x_}, {1, 2, z_}} :> {{x, z}}|>,
+            #,
+            <|"MaxEvents" -> 1|>,
+            "FinalState",
+            "EventOrderingFunction" -> ordering][[-1]] & /@
+          Permutations[{{1, 2, x}, {1, 2, y}, {1, 2, z}}],
+        result
+      ]] @@@ {
+        {{"OldestEdge", "RuleOrdering"}, {{x, y}, {x, z}, {y, x}, {y, z}, {z, x}, {z, y}}},
+        {"RuleOrdering", {{x, y}, {x, z}, {y, x}, {y, z}, {z, x}, {z, y}}},
+        {{"OldestEdge", "ReverseRuleOrdering"}, {{y, x}, {z, x}, {x, y}, {z, y}, {x, z}, {y, z}}}
+      },
+
+      Function[{ordering, result}, VerificationTest[
+        WolframModel[
+            <|"PatternRules" -> {{{1, 2, x_}, {1, 3, z_}} :> {{1, x, z}}, {{1, 2, x_}, {1, 2, z_}} :> {{2, x, z}}}|>,
+            #,
+            <|"MaxEvents" -> 1|>,
+            "FinalState",
+            "EventOrderingFunction" -> ordering][[-1]] & /@
+          Permutations[{{1, 2, x}, {1, 2, y}, {1, 3, z}}],
+        result
+      ]] @@@ {
+        {{"OldestEdge", "RuleOrdering"}, {{2, x, y}, {1, x, z}, {2, y, x}, {1, y, z}, {1, x, z}, {1, y, z}}},
+        {{"RuleIndex", "RuleOrdering"}, {{1, x, z}, {1, x, z}, {1, y, z}, {1, y, z}, {1, x, z}, {1, y, z}}},
+        {{"ReverseRuleIndex", "ReverseRuleOrdering"},
+          {{2, y, x}, {2, y, x}, {2, x, y}, {2, x, y}, {2, y, x}, {2, x, y}}}
+      },
+
+      VerificationTest[
+        WolframModel[
+          {{{1, 2}, {2, 3}} -> {{1, 3}, {2, 4}, {4, 3}}, {{1, 1}, {2, 1}} -> {{1, 1}}},
+          {{2, 2}, {1, 4}, {4, 2}, {1, 2}, {3, 5}, {5, 2}},
+          <|"MaxEvents" -> 1|>,
+          "FinalState",
+          "EventOrderingFunction" -> #1],
+        #2
+      ] & @@@ {
+        {{"OldestEdge", "RuleOrdering"}, {{1, 4}, {1, 2}, {3, 5}, {5, 2}, {2, 2}}},
+        {{"OldestEdge", "ReverseRuleOrdering"}, {{1, 4}, {1, 2}, {3, 5}, {5, 2}, {4, 2}, {2, 6}, {6, 2}}},
+        {"LeastOldEdge", {{2, 2}, {1, 4}, {4, 2}, {1, 2}, {3, 2}, {5, 6}, {6, 2}}},
+        {{"LeastRecentEdge", "RuleOrdering"}, {{1, 4}, {1, 2}, {3, 5}, {5, 2}, {2, 2}}}
+      },
+
+      VerificationTest[
+        Length[
+          Counts[
+            Table[
+              SeedRandom[k];
+              WolframModel[
+                {{1, 2}, {1, 3}} -> {{2, 3}},
+                {{1, 2}, {1, 3}, {1, 4}, {1, 5}, {1, 6}},
+                <|"MaxEvents" -> 1|>,
+                "FinalState",
+                "EventOrderingFunction" -> "OldestEdge"][[-1]],
+              {k, 100}]]],
+        2
+      ],
+
       (** Potential variable collision between different rule inputs and outputs **)
       VerificationTest[
         WolframModel[

--- a/SetReplace/setSubstitutionSystem$cpp.m
+++ b/SetReplace/setSubstitutionSystem$cpp.m
@@ -212,6 +212,16 @@ $terminationReasonCodes = <|
 |>;
 
 
+$orderingFunctionCodes = <|
+	$sortedExpressionIDs -> 0,
+	$reverseSortedExpressionIDs -> 1,
+	$expressionIDs -> 2,
+	$ruleIndex -> 3,
+	$forward -> 0,
+	$backward -> 1
+|>;
+
+
 setSubstitutionSystem$cpp[rules_, set_, stepSpec_, returnOnAbortQ_, timeConstraint_, eventOrderingFunction_] /;
 			$cppSetReplaceAvailable := Module[{
 		canonicalRules,
@@ -235,8 +245,8 @@ setSubstitutionSystem$cpp[rules_, set_, stepSpec_, returnOnAbortQ_, timeConstrai
 	setPtr = $cpp$setCreate[
 		encodeNestedLists[List @@@ mappedRules],
 		encodeNestedLists[mappedSet],
-		Replace[eventOrderingFunction, {$EventOrderingFunctionSequential -> {1, 0, 2, 0, 3, 0}, $EventOrderingFunctionRandom -> {}}],
-		If[eventOrderingFunction === $EventOrderingFunctionRandom, RandomInteger[{0, $maxUnsignedInt}], 0]];
+		Catenate[Replace[eventOrderingFunction, $orderingFunctionCodes, {2}]],
+		RandomInteger[{0, $maxUnsignedInt}]];
 	TimeConstrained[
 		CheckAbort[
 			$cpp$setReplace[

--- a/SetReplace/setSubstitutionSystem$wl.m
+++ b/SetReplace/setSubstitutionSystem$wl.m
@@ -321,17 +321,8 @@ vertexCount[$noIndex] := 0
 (*This function runs a modified version of the set replace system that also keeps track of metadata such as generations and events. It uses setReplace$wl to evaluate that modified system.*)
 
 
-General::symbolicRandomUnsupported =
-	"Random event ordering function is not supported in symbolic implementation. Use Method -> \"LowLevel\"";
-
-
 setSubstitutionSystem$wl[
-		caller_, rules_, set_, stepSpec_, returnOnAbortQ_, timeConstraint_, $EventOrderingFunctionRandom] :=
-	Message[caller::symbolicRandomUnsupported]
-
-
-setSubstitutionSystem$wl[
-			caller_, rules_, set_, stepSpec_, returnOnAbortQ_, timeConstraint_, $EventOrderingFunctionSequential] := Module[{
+			caller_, rules_, set_, stepSpec_, returnOnAbortQ_, timeConstraint_] := Module[{
 		setWithMetadata, renamedRules, rulesWithMetadata, outputWithMetadata, result,
 		nextExpressionID = 1, nextEventID = 1, expressionsCountsPerVertex, vertexIndex, nextExpression,
 		intermediateEvolution},


### PR DESCRIPTION
## Changes
* Closes #7 (oldest open issue!).
* Allows using different C++ evaluation orders in `"EventOrderingFunction"` options.
* Orders currently supported are: `"OldestEdge"`, `"LeastOldEdge"`, `"LeastRecentEdge"`, `"NewestEdge"`, `"RuleOrdering"`, `"ReverseRuleOrdering"`, `"RuleIndex"`, `"ReverseRuleIndex"`, `"Random"`.
* Lists of these are also supported, in which case the next one in the list is used in case of collisions.
* If the list of specified functions is not sufficient to determine priority, the random among smallest is chosen (hence, i.e., `{}` can be used instead of `"Random"`).

## Tests
* Evolve a `WolframModel` with all individual event ordering functions:
```
In[] := WolframModel[{{1, 2}, {1, 3}, {1, 4}} -> {{5, 6}, {6, 7}, {7, 5}, {5, 
      7}, {7, 6}, {6, 5}, {5, 2}, {6, 3}, {7, 4}, {2, 7}, {4, 
      5}}, {{1, 1}, {1, 1}, {1, 1}}, <|"MaxEvents" -> 100|>, 
   "FinalStatePlot", "EventOrderingFunction" -> #] & /@ {"OldestEdge",
   "LeastOldEdge", "LeastRecentEdge", "NewestEdge", "RuleOrdering", 
  "ReverseRuleOrdering", "RuleIndex", "ReverseRuleIndex", "Random"}
```
![image](https://user-images.githubusercontent.com/1479325/74090230-fd085700-4a76-11ea-9b8c-b0ca6b8285f0.png)
* Note, most of them are not deterministic by themselves:
```
In[] := WolframModel[{{1, 2}, {1, 3}, {1, 4}} -> {{5, 6}, {6, 7}, {7, 5}, {5, 
      7}, {7, 6}, {6, 5}, {5, 2}, {6, 3}, {7, 4}, {2, 7}, {4, 
      5}}, {{1, 1}, {1, 1}, {1, 1}}, <|"MaxEvents" -> 100|>, 
   "FinalStatePlot", "EventOrderingFunction" -> #] & /@ {"OldestEdge",
   "LeastOldEdge", "LeastRecentEdge", "NewestEdge", "RuleOrdering", 
  "ReverseRuleOrdering", "RuleIndex", "ReverseRuleIndex", "Random"}
```
![image](https://user-images.githubusercontent.com/1479325/74090237-0e516380-4a77-11ea-9acb-417f05c610bf.png)
* Use standard order in case of conflicts:
```
In[] := WolframModel[{{1, 2}, {1, 3}, {1, 4}} -> {{5, 6}, {6, 7}, {7, 5}, {5, 
      7}, {7, 6}, {6, 5}, {5, 2}, {6, 3}, {7, 4}, {2, 7}, {4, 
      5}}, {{1, 1}, {1, 1}, {1, 1}}, <|"MaxEvents" -> 100|>, 
   "FinalStatePlot", 
   "EventOrderingFunction" -> {#, "LeastRecentEdge", 
     "RuleOrdering"}] & /@ {"OldestEdge", "LeastOldEdge", 
  "LeastRecentEdge", "NewestEdge", "RuleOrdering", 
  "ReverseRuleOrdering", "RuleIndex", "ReverseRuleIndex", "Random"}
```
![image](https://user-images.githubusercontent.com/1479325/74090277-5f615780-4a77-11ea-9c83-0f5334b6e00a.png)
* Now, only `"Random"` is non-deterministic:
```
In[] := WolframModel[{{1, 2}, {1, 3}, {1, 4}} -> {{5, 6}, {6, 7}, {7, 5}, {5, 
      7}, {7, 6}, {6, 5}, {5, 2}, {6, 3}, {7, 4}, {2, 7}, {4, 
      5}}, {{1, 1}, {1, 1}, {1, 1}}, <|"MaxEvents" -> 100|>, 
   "FinalStatePlot", 
   "EventOrderingFunction" -> {#, "LeastRecentEdge", 
     "RuleOrdering"}] & /@ {"OldestEdge", "LeastOldEdge", 
  "LeastRecentEdge", "NewestEdge", "RuleOrdering", 
  "ReverseRuleOrdering", "RuleIndex", "ReverseRuleIndex", "Random"}
```
![image](https://user-images.githubusercontent.com/1479325/74090286-71db9100-4a77-11ea-8fc7-818462238127.png)