### PR TITLE
Automatic init

### DIFF
--- a/SetReplace/WolframModel.m
+++ b/SetReplace/WolframModel.m
@@ -80,7 +80,24 @@ fromRulesSpec[<|"PatternRules" -> rules_|>] := rules
 (*Init*)
 
 
-fromInitSpec[initSpec_] := initSpec
+fromInitSpec[rulesSpec_, initSpec_List] := initSpec
+
+
+fromInitSpec[rulesSpec_Rule, Automatic] := fromInitSpec[{rulesSpec}, Automatic]
+
+
+fromInitSpec[rulesSpec_List, Automatic] := Catenate[
+	If[#2 === 0, ConstantArray[1, #1], ConstantArray[1, {##}]] & @@@
+		Reverse /@ Sort[Normal[Merge[Counts /@ Map[Length, If[ListQ[#], #, {#}] & /@ rulesSpec[[All, 1]], {2}], Max]]]]
+
+
+WolframModel::noPatternAutomatic = "Automatic initial state is not supported for pattern rules ``";
+
+
+fromInitSpec[rulesSpec_Association, Automatic] := (
+	Message[WolframModel::noPatternAutomatic, rulesSpec];
+	Throw[$Failed];
+)
 
 
 (* ::Subsubsection:: *)
@@ -158,17 +175,19 @@ WolframModel[
 	Module[{
 			patternRules, initialSet, evolution, renamedNodesEvolution, result},
 		patternRules = fromRulesSpec[rulesSpec];
-		initialSet = fromInitSpec[initSpec];
-		evolution = Check[
-			setSubstitutionSystem[
-				patternRules,
-				initialSet,
-				fromStepsSpec[stepsSpec],
-				WolframModel,
-				property === "EvolutionObject",
-				Method -> OptionValue[Method],
-				TimeConstraint -> OptionValue[TimeConstraint],
-				"EventOrderingFunction" -> OptionValue["EventOrderingFunction"]],
+		initialSet = Catch[fromInitSpec[rulesSpec, initSpec]];
+		evolution = If[initialSet =!= $Failed,
+			Check[
+				setSubstitutionSystem[
+					patternRules,
+					initialSet,
+					fromStepsSpec[stepsSpec],
+					WolframModel,
+					property === "EvolutionObject",
+					Method -> OptionValue[Method],
+					TimeConstraint -> OptionValue[TimeConstraint],
+					"EventOrderingFunction" -> OptionValue["EventOrderingFunction"]],
+				$Failed],
 			$Failed];
 		If[evolution === $Aborted, Return[$Aborted]];
 		renamedNodesEvolution = If[evolution =!= $Failed,
@@ -288,6 +307,9 @@ wolframModelRulesSpecQ[_] := False
 
 
 wolframModelInitSpecQ[init_ ? ListQ] := True
+
+
+wolframModelInitSpecQ[Automatic] := True
 
 
 wolframModelInitSpecQ[_] := False

--- a/SetReplace/WolframModel.wlt
+++ b/SetReplace/WolframModel.wlt
@@ -1584,7 +1584,41 @@
             Method -> method],
           {0, 2, 1, 2, 1, Infinity}
         ]
-      }], {method, DeleteCases[$SetReplaceMethods, Automatic]}]
+      }], {method, DeleteCases[$SetReplaceMethods, Automatic]}],
+
+      (** Automatic initial state **)
+
+      VerificationTest[
+        WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, Automatic][0],
+        {{1, 1}}
+      ],
+
+      VerificationTest[
+        WolframModel[
+          {{{1}, {1, 2}} -> {{1, 2}, {2}}, {{1, 2}} -> {{1, 3}, {3, 2}}, {{1, 2, 3}} -> {{1, 2}, {2, 3, 4}}},
+          Automatic][0],
+        {{1}, {1, 1}, {1, 1, 1}}
+      ],
+
+      VerificationTest[
+        WolframModel[{{1}, {1, 2}} -> {{1}, {1, 3}, {3, 2}}, Automatic][0],
+        {{1}, {1, 1}}
+      ],
+
+      testUnevaluated[
+        WolframModel[<|"PatternRules" -> {{a_, b_}} :> {{a, b}, {b, a}}|>, Automatic],
+        {WolframModel::noPatternAutomatic}
+      ],
+
+      VerificationTest[
+        WolframModel[1 -> 2, Automatic][0],
+        {1}
+      ],
+
+      VerificationTest[
+        WolframModel[{1, {2}} -> {2, {3}}, Automatic][0],
+        {1, {1}}
+      ]
     }
   |>,
 


### PR DESCRIPTION
## Changes
* Closes #133.
* Allows use of `Automatic` instead of the initial state.
* All anonymous rules are supported, but pattern rules are not.

## Tests
* Use "compactified" left-hand side of the rule as an initial condition:
```
In[] := WolframModel[{{1, 2}, {2, 3}} -> {{1, 2}, {2, 4}, {4, 1}, {4, 3}}, 
  Automatic][0]
```
```
Out[] = {{1, 1}, {1, 1}}
```
```
In[] := WolframModel[{{1, 2}, {2, 3}} -> {{1, 2}, {2, 4}, {4, 1}, {4, 
    3}}, Automatic, 10, "FinalStatePlot"]
```
![image](https://user-images.githubusercontent.com/1479325/74203502-e06a4b80-4c3d-11ea-98ab-b5c7ab6e01be.png)
* In the case of multiple rules, the minimal combination of both is used such that each rule can still be applied:
```
In[] := WolframModel[{{{1}, {1, 2}} -> {{1, 2}, {2}}, {{1, 2}, {2, 3}} -> {{1,
      3}, {3, 2}, {2, 4}}}, Automatic, 5, "StatesPlotsList"]
```
![image](https://user-images.githubusercontent.com/1479325/74203719-9170e600-4c3e-11ea-9493-654f7522c817.png)