### PR TITLE
Quiet nonexistent GraphHighlight

### DIFF
--- a/SetReplace/WolframModelPlot.m
+++ b/SetReplace/WolframModelPlot.m
@@ -181,13 +181,10 @@ correctCoordinateRulesQ[head_, coordinateRules_] :=
 		True
 	]
 
-correctHighlightQ[edges : Except[Automatic], highlight_] := Module[{
-		vertices, validQ},
-	vertices = vertexList[edges];
-	validQ = ListQ[highlight];
-	If[!validQ, Message[WolframModelPlot::invalidHighlight, highlight]];
-	validQ
-]
+correctHighlightQ[edges : Except[Automatic], highlight_] := (
+	If[!ListQ[highlight], Message[WolframModelPlot::invalidHighlight, highlight]];
+	ListQ[highlight]
+)
 
 correctHighlightQ[Automatic, _] := True
 
@@ -413,9 +410,6 @@ drawEmbedding[
 			#[[2]] /. (h : (Point | Line | Polygon))[pts_] :> highlighted[h[pts], highlightedQ]] &,
 		embedding,
 		{2}];
-	If[AnyTrue[highlightCounts, # > 0 &],
-		Message[WolframModelPlot::invalidHighlight, highlight];
-		Throw[$Failed]];
 
 	vertexPoints = MapIndexed[
 		With[{style = styles[$vertexPoint][[#2[[1]]]]},

--- a/SetReplace/WolframModelPlot.m
+++ b/SetReplace/WolframModelPlot.m
@@ -162,7 +162,7 @@ correctWolframModelPlotOptionsQ[head_, expr_, edges_, opts_] :=
 	(And @@ (supportedOptionQ[head, ##, opts] & @@@ {
 			{"HyperedgeRendering", $hyperedgeRenderings}})) &&
 	correctCoordinateRulesQ[head, OptionValue[WolframModelPlot, opts, VertexCoordinateRules]] &&
-	correctHighlightQ[edges, OptionValue[WolframModelPlot, opts, GraphHighlight]] &&
+	correctHighlightQ[OptionValue[WolframModelPlot, opts, GraphHighlight]] &&
 	correctHighlightStyleQ[head, OptionValue[WolframModelPlot, opts, GraphHighlightStyle]] &&
 	correctSizeQ[head, "Vertex size", OptionValue[WolframModelPlot, opts, VertexSize]] &&
 	correctSizeQ[head, "Arrowhead length", OptionValue[WolframModelPlot, opts, "ArrowheadLength"]] &&
@@ -181,12 +181,10 @@ correctCoordinateRulesQ[head_, coordinateRules_] :=
 		True
 	]
 
-correctHighlightQ[edges : Except[Automatic], highlight_] := (
+correctHighlightQ[highlight_] := (
 	If[!ListQ[highlight], Message[WolframModelPlot::invalidHighlight, highlight]];
 	ListQ[highlight]
 )
-
-correctHighlightQ[Automatic, _] := True
 
 correctHighlightStyleQ[head_, highlightStyle_] :=
 	If[ColorQ[highlightStyle], True, Message[head::invalidHighlightStyle, highlightStyle]; False]

--- a/SetReplace/WolframModelPlot.wlt
+++ b/SetReplace/WolframModelPlot.wlt
@@ -211,34 +211,24 @@
         {WolframModelPlot::invalidHighlight}
       ],
 
-      testUnevaluated[
-        WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {6}],
-        {WolframModelPlot::invalidHighlight}
-      ],
-
-      testUnevaluated[
-        WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {1, 1}],
-        {WolframModelPlot::invalidHighlight}
-      ],
-
-      testUnevaluated[
-        WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {{1, 2}}],
-        {WolframModelPlot::invalidHighlight}
-      ],
-
       VerificationTest[
         Head[WolframModelPlot[{{1, 2, 3}, {1, 2, 3}}, GraphHighlight -> {{1, 2, 3}}]],
         Graphics
       ],
 
       VerificationTest[
-        Head[WolframModelPlot[{{1, 2, 3}, {1, 2, 3}}, GraphHighlight -> {{1, 2, 3}, {1, 2, 3}}]],
+        Head[WolframModelPlot[{{1, 2, 3}, {1, 2, 3}}, GraphHighlight -> {6}]],
         Graphics
       ],
 
-      testUnevaluated[
-        WolframModelPlot[{{1, 2, 3}, {1, 2, 3}}, GraphHighlight -> {{1, 2, 3}, {1, 2, 3}, {1, 2, 3}}],
-        {WolframModelPlot::invalidHighlight}
+      VerificationTest[
+        Head[WolframModelPlot[{{1, 2, 3}, {1, 2, 3}}, GraphHighlight -> {{1, 2}}]],
+        Graphics
+      ],
+
+      VerificationTest[
+        Head[WolframModelPlot[{{1, 2, 3}, {1, 2, 3}}, GraphHighlight -> {{1, 2, 3}, {1, 2, 3}}]],
+        Graphics
       ],
 
       VerificationTest[
@@ -543,6 +533,8 @@
       }],
 
       testColorPresence[{{1}, {1, 2}, {2, 3, 4}}, {PlotStyle -> <|_List -> color|>}, {color}],
+
+      testColorAbsense[{{1}, {1, 2}, {2, 3, 4}}, {GraphHighlight -> {5}, GraphHighlightStyle -> color}, {color}],
 
       VerificationTest[
         Head[WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, VertexSize -> 0.3]],


### PR DESCRIPTION
## Changes
* Changes `GraphHighlight` to quietly skip highlighting a vertex or an edge instead of throwing an error message if that vertex or edge does not exist in the hypergraph.
* This is particularly useful when highlighting an element in a sequence of hypergraphs, which we can now do without manual filtering.

## Tests
* Attempting to highlight a vertex or an edge that does not exist will no longer produce an error message:
```
In[] := WolframModelPlot[{{1, 2, 3}, {3, 4, 5}, {5, 6, 7}, {7, 8, 1}}, 
 GraphHighlight -> {5, 7, 9, {1, 2, 3}, {2, 3, 4}}]
```
![image](https://user-images.githubusercontent.com/1479325/74247841-b607a500-4cb4-11ea-8ee0-ef04ec66b107.png)
* This allows one to highlight a particular vertex throughout the entire evolution:
```
In[] := WolframModel[{{1, 2}, {1, 3}, {1, 4}} -> {{5, 6}, {6, 5}, {5, 7}, {7, 
     5}, {6, 7}, {7, 6}, {5, 2}, {6, 3}, {7, 4}, {2, 7}, {4, 5}}, {{1,
     1}, {1, 1}, {1, 1}}, 3]["StatesPlotsList", GraphHighlight -> {2}]
```
![image](https://user-images.githubusercontent.com/1479325/74247943-dafc1800-4cb4-11ea-8aeb-578fcb17a517.png)