### PR TITLE
Fix default plot style in WolframModelPlot

### DIFF
--- a/SetReplace/WolframModelPlot.m
+++ b/SetReplace/WolframModelPlot.m
@@ -28,7 +28,7 @@ Options[WolframModelPlot] = Join[{
 	GraphHighlight -> {},
 	GraphHighlightStyle -> Red,
 	"HyperedgeRendering" -> "Polygons",
-	PlotStyle -> $plotStyleAutomatic,
+	PlotStyle -> Automatic,
 	VertexCoordinateRules -> {},
 	VertexLabels -> None,
 	VertexSize -> 0.06,


### PR DESCRIPTION
## Changes
* Default `PlotStyle` in `WolframModelPlot` is now `Automatic` instead of exposing internal variables.

## Tests
* Functionality is not changed, the `Automatic` `PlotStyle` still picks up the same variable which was previously explicitly assigned to `PlotStyle` option:
```
In[] := WolframModelPlot[{{1, 2, 3}, {3, 4, 5}, {5, 6, 7}, {7, 8, 9}, {9, 10, 
   1}}]
```
![image](https://user-images.githubusercontent.com/1479325/74250040-0fbd9e80-4cb8-11ea-9897-ef78e00d8422.png)
* However, the explicit option value is now `Automatic`:
```
In[] := Options[WolframModelPlot, EdgeStyle]
```
```
Out[] = {EdgeStyle -> Automatic}
```