### PR TITLE
Fix GitLink install in WL build 6697939

### DIFF
--- a/scripts/buildInit.wl
+++ b/scripts/buildInit.wl
@@ -3,7 +3,7 @@ Needs["PacletManager`"];
 
 $internalBuildQ = AntProperty["build_target"] === "internal";
 
-If[PacletInformation["GitLink"] === {},
+If[PacletFind["GitLink", "Internal" -> All] === {},
   If[$internalBuildQ,
     PacletInstall["GitLink", "Site" -> "http://paclet-int.wolfram.com:8080/PacletServerInternal"],
     PacletInstall["https://www.wolframcloud.com/obj/maxp1/GitLink-2019.11.26.01.paclet"]];


### PR DESCRIPTION
## Changes
* Fixes the build script to work in WL build 6697939.
* This build removes `PacletInformation` from `` System` `` context, so it is now replaced with `PacletFind`.

## Tests
* Run `./build.wls` twice, it would previously fail saying `GitLink` is already installed, but will now succeed:
```
>> ./build.wls && ./build.wls      
Build done.
Build done.
```