### PR TITLE
Listable WolframModelPlot

### DIFF
--- a/SetReplace/WolframModelPlot.m
+++ b/SetReplace/WolframModelPlot.m
@@ -51,7 +51,8 @@ HypergraphPlot = WolframModelPlot;
 (* Messages *)
 
 General::invalidEdges =
-	"First argument of WolframModelPlot must be list of lists, where elements represent vertices.";
+	"First argument of WolframModelPlot must be a hypergraph, i.e., a list of lists, " <>
+	"where elements represent vertices, or a list of such hypergraphs.";
 
 General::invalidEdgeType =
 	"Edge type `1` should be one of `2`.";
@@ -74,6 +75,9 @@ General::invalidPlotStyle =
 General::invalidStyleLength =
 	"The list of styles `1` should have the same length as the number of `2` `3`.";
 
+General::multigraphElementwiseStyle =
+	"The elementwise style specification `1` is not supported for lists of hypergraphs.";
+
 (* Evaluation *)
 
 func : WolframModelPlot[args___] := Module[{result = wolframModelPlot$parse[args]},
@@ -85,20 +89,26 @@ func : WolframModelPlot[args___] := Module[{result = wolframModelPlot$parse[args
 wolframModelPlot$parse[args___] /; !Developer`CheckArgumentCount[WolframModelPlot[args], 1, 2] := $Failed
 
 (* allow composite vertices, but not list-vertices *)
-$hypergraphPattern = h_List /; AllTrue[h, ListQ[#] && Length[#] > 0 &] && AllTrue[h, Not @* ListQ, 2];
+$hypergraphPattern = _List ? (Function[h, AllTrue[h, ListQ[#] && Length[#] > 0 &] && AllTrue[h, Not @* ListQ, 2]]);
+$multiHypergraphPattern = $hypergraphPattern | {$hypergraphPattern...};
 
-wolframModelPlot$parse[edges : Except[$hypergraphPattern], edgeType_ : $defaultEdgeType, o : OptionsPattern[]] := (
+wolframModelPlot$parse[edges : Except[$multiHypergraphPattern], edgeType_ : $defaultEdgeType, o : OptionsPattern[]] := (
 	Message[WolframModelPlot::invalidEdges];
 	$Failed
 )
 
 wolframModelPlot$parse[
-		edges : $hypergraphPattern,
+		edges : $multiHypergraphPattern,
 		edgeType : Except[Alternatives[Alternatives @@ $edgeTypes, OptionsPattern[]]],
 		o : OptionsPattern[]] := (
 	Message[WolframModelPlot::invalidEdgeType, edgeType, $edgeTypes];
 	$Failed
 )
+
+wolframModelPlot$parse[
+	edges : {$hypergraphPattern...}, edgeType : Alternatives @@ $edgeTypes : $defaultEdgeType, o : OptionsPattern[]] /;
+		correctWolframModelPlotOptionsQ[WolframModelPlot, Defer[WolframModelPlot[edges, o]], edges, {o}] :=
+	wolframModelPlot$parse[#, edgeType, o] & /@ edges
 
 wolframModelPlot$parse[
 			edges : $hypergraphPattern, edgeType : Alternatives @@ $edgeTypes : $defaultEdgeType, o : OptionsPattern[]] /;
@@ -168,9 +178,9 @@ correctWolframModelPlotOptionsQ[head_, expr_, edges_, opts_] :=
 	correctSizeQ[head, "Arrowhead length", OptionValue[WolframModelPlot, opts, "ArrowheadLength"]] &&
 	correctPlotStyleQ[head, OptionValue[WolframModelPlot, opts, PlotStyle]] &&
 	correctStyleLengthQ[
-		head, "vertices", Length[vertexList[edges]], OptionValue[WolframModelPlot, opts, VertexStyle]] &&
+		head, "vertices", MatchQ[edges, {$hypergraphPattern...}], Length[vertexList[edges]], OptionValue[WolframModelPlot, opts, VertexStyle]] &&
 	And @@ (correctStyleLengthQ[
-		head, "edges", Length[edges], OptionValue[WolframModelPlot, opts, #]] & /@ {EdgeStyle, "EdgePolygonStyle"})
+		head, "edges", MatchQ[edges, {$hypergraphPattern...}], Length[edges], OptionValue[WolframModelPlot, opts, #]] & /@ {EdgeStyle, "EdgePolygonStyle"})
 
 correctCoordinateRulesQ[head_, coordinateRules_] :=
 	If[!MatchQ[coordinateRules,
@@ -203,8 +213,15 @@ correctPlotStyleQ[head_, style_List] := (
 
 correctPlotStyleQ[__] := True
 
-correctStyleLengthQ[head_, name_, correctLength_, styles_List] /; Length[styles] =!= correctLength := (
+(* Single hypergraph *)
+correctStyleLengthQ[head_, name_, False, correctLength_, styles_List] /; Length[styles] =!= correctLength := (
 	Message[head::invalidStyleLength, styles, name, correctLength];
+	False
+)
+
+(* Multiple hypergraphs *)
+correctStyleLengthQ[head_, name_, True, correctLength_, styles_List] := (
+	Message[head::multigraphElementwiseStyle, styles];
 	False
 )
 

--- a/SetReplace/WolframModelPlot.m
+++ b/SetReplace/WolframModelPlot.m
@@ -106,7 +106,7 @@ wolframModelPlot$parse[
 )
 
 wolframModelPlot$parse[
-	edges : {$hypergraphPattern...}, edgeType : Alternatives @@ $edgeTypes : $defaultEdgeType, o : OptionsPattern[]] /;
+	edges : {$hypergraphPattern..}, edgeType : Alternatives @@ $edgeTypes : $defaultEdgeType, o : OptionsPattern[]] /;
 		correctWolframModelPlotOptionsQ[WolframModelPlot, Defer[WolframModelPlot[edges, o]], edges, {o}] :=
 	wolframModelPlot$parse[#, edgeType, o] & /@ edges
 

--- a/SetReplace/WolframModelPlot.wlt
+++ b/SetReplace/WolframModelPlot.wlt
@@ -101,8 +101,14 @@
         {WolframModelPlot::invalidEdges}
       ],
 
-      testUnevaluated[
+      VerificationTest[
         WolframModelPlot[{{}}],
+        {_Graphics},
+        SameTest -> MatchQ
+      ],
+
+      testUnevaluated[
+        WolframModelPlot[{{{}}}],
         {WolframModelPlot::invalidEdges}
       ],
 
@@ -653,7 +659,19 @@
           !AllTrue[sizes[[1, All, 2]], # > 29.9999 &] &&
           And @@ ((AllTrue[sizes[[2, All, #]] / sizes[[1, All, #]], 1.9999 < # < 2.0001 &] &) /@ {1, 2})
         ]
-      ]
+      ],
+
+      (* Multiple hypergraphs *)
+      VerificationTest[
+        Head /@ WolframModelPlot[{{{1, 2, 3}, {3, 4, 5}}, {{3, 4, 5}, {5, 6, 7}}, {{5, 6, 7}, {7, 8, 5}}}, ##],
+        {Graphics, Graphics, Graphics}
+      ] & @@@ {
+        {},
+        {GraphHighlight -> {3, {3, 4, 5}}},
+        {VertexSize -> 0.1, "ArrowheadLength" -> 0.2},
+        {EdgeStyle -> Red},
+        {VertexCoordinateRules -> {3 -> {0, 0}, 4 -> {1, 0}}}
+      }
     }
   |>
 |>


### PR DESCRIPTION
## Changes
* Allows supplying a list of hypergraphs to `WolframModelPlot`, in which case it returns the list of plots.
* All options are passed to each of the plots.

## Caveats
* For now, it's identical to mapping `WolframModelPlot` over the list of hypergraphs.
* Highlighting of new / deleted edges etc. will come in a separate PR.

## Tests
* Plot a list of hypergraphs:
```
In[] := WolframModelPlot[{{{1, 2, 3}, {3, 4, 5}}, {{3, 4, 5}, {5, 6, 7}}, {{5,
     6, 7}, {7, 8, 9}, {9, 10, 1}}}]
```
![image](https://user-images.githubusercontent.com/1479325/74279234-883c5380-4ce8-11ea-8cb6-22ade1bc78e2.png)
* Highlight the same vertex on all of them:
```
In[] := WolframModelPlot[{{{1, 2, 3}, {3, 4, 5}}, {{3, 4, 5}, {5, 6, 7}}, {{5,
     6, 7}, {7, 8, 9}, {9, 10, 1}}}, GraphHighlight -> {3}]
```
![image](https://user-images.githubusercontent.com/1479325/74279277-a1450480-4ce8-11ea-9789-48a7739eb67f.png)