### PR TITLE
multisetComplement

### DIFF
--- a/SetReplace/utilities.m
+++ b/SetReplace/utilities.m
@@ -3,6 +3,7 @@ Package["SetReplace`"]
 PackageScope["vertexList"]
 PackageScope["fromCounts"]
 PackageScope["multisetIntersection"]
+PackageScope["multisetComplement"]
 PackageScope["indexHypergraph"]
 
 vertexList[edges_] := Sort[Union[Catenate[edges]]]
@@ -10,5 +11,7 @@ vertexList[edges_] := Sort[Union[Catenate[edges]]]
 fromCounts[association_] := Catenate @ KeyValueMap[ConstantArray] @ association
 
 multisetIntersection[sets___] := fromCounts[Merge[KeyIntersection[Counts /@ {sets}], Min]]
+
+multisetComplement[set1_, set2_] := fromCounts[Select[# > 0 &][Merge[{Counts[set1], -Counts[set2]}, Total]]]
 
 indexHypergraph[e_] := With[{vertices = vertexList[e]}, Replace[e, Thread[vertices -> Range[Length[vertices]]], {2}]]

--- a/SetReplace/utilities.wlt
+++ b/SetReplace/utilities.wlt
@@ -1,0 +1,48 @@
+<|
+  "ToPatternRules" -> <|
+    "init" -> (
+      Global`multisetComplement = SetReplace`PackageScope`multisetComplement;
+    ),
+    "tests" -> {
+      VerificationTest[
+        multisetComplement[{}, {}],
+        {}
+      ],
+
+      VerificationTest[
+        multisetComplement[{1}, {}],
+        {1}
+      ],
+
+      VerificationTest[
+        multisetComplement[{}, {1}],
+        {}
+      ],
+
+      VerificationTest[
+        multisetComplement[{1}, {1}],
+        {}
+      ],
+
+      VerificationTest[
+        multisetComplement[{1, 1}, {1}],
+        {1}
+      ],
+
+      VerificationTest[
+        multisetComplement[{1, 2, 2, 3, 4}, {1, 1, 2, 3, 5}],
+        {2, 4}
+      ],
+
+      VerificationTest[
+        multisetComplement[{{1, 5}, {1, 4}, {1, 5}, 3, 5}, {{1, 5}, 2, 2, 3, 4}],
+        {{1, 5}, {1, 4}, 5}
+      ],
+
+      VerificationTest[
+        multisetComplement[{1, 1, 1, 1, 2, 3, 4, 5}, {1, 1, 2, 4, 6}],
+        {1, 1, 3, 5}
+      ]
+    }
+  |>
+|>


### PR DESCRIPTION
## Changes
* Implements `multisetComplement` utility function.
* Does the same as `Complement`, but preserves counts of multiple elements.

## Review comments
* That's useful, in particular, for hypergraph diffing.

## Tests
* The following keeps the correct count of 1's in the list:
```
In[] := SetReplace`PackageScope`multisetComplement[{1, 1, 1, 2, 3}, {1, 2, 4}]
Out[] = {1, 1, 3}
```
* Compare:
```
In[] := Complement[{1, 1, 1, 2, 3}, {1, 2, 4}]
Out[] = {3}
```