### PR TITLE
EventsStatesPlotsList

### DIFF
--- a/SetReplace/WolframModelEvolutionObject.wlt
+++ b/SetReplace/WolframModelEvolutionObject.wlt
@@ -1306,7 +1306,46 @@
           {{1, {3} -> {6, 7}}, {4, 5, 6, 7}},
           {{DirectedInfinity[1], {4, 5, 6, 7} -> {}}, {}}
         }
-      ]
+      ],
+
+      (* EventsStatesPlotsList *)
+
+      VerificationTest[
+        Head /@ WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 3]["EventsStatesPlotsList"],
+        ConstantArray[Graphics, WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 3, "EventsCount"] + 1]
+      ],
+
+      VerificationTest[
+        Head /@ WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 3][
+          "EventsStatesPlotsList", "IncludeBoundaryEvents" -> All],
+        ConstantArray[Graphics, WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 3, "EventsCount"] + 1]
+      ],
+
+      With[{evo = WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 3]}, testUnevaluated[
+        evo["EventsStatesPlotsList", "$$$invalid$$$"],
+        {WolframModelEvolutionObject::nonopt}
+      ]],
+
+      With[{evo = WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 3]}, testUnevaluated[
+        evo["EventsStatesPlotsList", "$$$invalid$$$" -> 3],
+        {WolframModelEvolutionObject::optx}
+      ]],
+
+      VerificationTest[
+        AbsoluteOptions[#, ImageSize] & /@
+          WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 1]["EventsStatesPlotsList", ImageSize -> 123.],
+        ConstantArray[{ImageSize -> 123.}, 2]
+      ],
+
+      testUnevaluated[
+        WolframModel[1 -> 2, {1}, 2, "EventsStatesPlotsList"],
+        {WolframModel::nonHypergraphPlot}
+      ],
+
+      With[{evo = WolframModel[{{1, 2}} -> {{1, 3}, {3, 2}}, {{1, 1}}, <|"MaxEvents" -> 30|>]}, testUnevaluated[
+        evo["EventsStatesPlotsList", VertexSize -> x],
+        {WolframModelPlot::invalidSize}
+      ]]
     }]
   |>
 |>

--- a/SetReplace/WolframModelEvolutionObject.wlt
+++ b/SetReplace/WolframModelEvolutionObject.wlt
@@ -1321,6 +1321,12 @@
         ConstantArray[Graphics, WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 3, "EventsCount"] + 1]
       ],
 
+      VerificationTest[
+        Head /@ WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 0][
+          "EventsStatesPlotsList", "IncludeBoundaryEvents" -> #],
+        {Graphics}
+      ] & /@ {None, "Initial", "Final", All},
+
       With[{evo = WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 3]}, testUnevaluated[
         evo["EventsStatesPlotsList", "$$$invalid$$$"],
         {WolframModelEvolutionObject::nonopt}


### PR DESCRIPTION
## Changes
* Implements `"EventsStatesPlotsList"` property of `WolframModel` and `WolframModelEvolutionObject`.
* That produces plots similar to `WolframModelPlot /@ WolframModel[..., "AllEventsStatesList"]`, however, it also highlights edges that were just created and edges that are about to be destroyed.
* Setting `"IncludeBoundaryEvents" -> "Initial"` or `"IncludeBoundaryEvents" -> "Final"` highlights all initial edges as just created, and all final edges as about to be destroyed respectively.

## Review notes
* @sskini2, could you ask Jeremy if the style for the edge that is both just created and about to be destroyed is good?
* The tests only check the code does not fail with error messages. They don't test if the pictures produced are correct, as we don't have the technology for that yet.

## Tests
* Show evolution of a `WolframModel`:
```
In[] := WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 
   1}}, 3, "EventsStatesPlotsList"]
```
![image](https://user-images.githubusercontent.com/1479325/74359287-fdfbfa00-4d90-11ea-81ea-4cf12dab46ed.png)
* Same for a more complicated rule:
```
In[] := WolframModel[{{1, 2, 3}, {4, 5, 6}, {1, 4}} -> {{2, 8, 7}, {9, 3, 
     10}, {5, 11, 12}, {6, 13, 14}, {10, 13}, {7, 9}, {11, 8}, {12, 
     14}}, {{1, 1, 1}, {1, 1, 1}, {1, 1}, {1, 1}, {1, 1}}, 
  6]["EventsStatesPlotsList"]
```
![image](https://user-images.githubusercontent.com/1479325/74359323-0c4a1600-4d91-11ea-88a0-1bb816044854.png)
* Including boundary events also highlights initial and final edges respectively:
```
In[] := WolframModel[{{1, 2, 3}, {4, 5, 6}, {1, 4}} -> {{2, 8, 7}, {9, 3, 
     10}, {5, 11, 12}, {6, 13, 14}, {10, 13}, {7, 9}, {11, 8}, {12, 
     14}}, {{1, 1, 1}, {1, 1, 1}, {1, 1}, {1, 1}, {1, 1}}, 
  3]["EventsStatesPlotsList", "IncludeBoundaryEvents" -> All]
```
![image](https://user-images.githubusercontent.com/1479325/74359353-1ff57c80-4d91-11ea-9848-a465776a7fdf.png)
* Note, the highlighting is not equivalent to diffing, as an edge can be destroyed only to be replaced with the same edge:
```
In[] := WolframModel[{{1}} -> {{2}}, {{1}}, 3, "EventsStatesPlotsList"]
```
![image](https://user-images.githubusercontent.com/1479325/74359417-3ac7f100-4d91-11ea-88c2-4be418e96d28.png)