### PR TITLE
Non-square RulePlot

### DIFF
--- a/SetReplace/RulePlot.m
+++ b/SetReplace/RulePlot.m
@@ -48,6 +48,9 @@ RulePlot::notHypergraphRule =
 RulePlot::invalidSpacings =
   "Spacings `1` should be either a single number, or a two-by-two list.";
 
+RulePlot::invalidAspectRatio =
+  "RulePartsAspectRatio `1` should be a positive number.";
+
 (* Evaluation *)
 
 WolframModel /: func : RulePlot[wm : WolframModel[args___] /; Quiet[Developer`CheckArgumentCount[wm, 1, 1]], opts___] :=
@@ -98,6 +101,7 @@ correctOptionsQ[args_, {opts___}] :=
   supportedOptionQ[RulePlot, Frame, {True, False, Automatic}, {opts}] &&
   correctEdgeTypeQ[OptionValue[RulePlot, {opts}, "EdgeType"]] &&
   correctSpacingsQ[{opts}] &&
+  correctRulePartsAspectRatioQ[OptionValue[RulePlot, {opts}, "RulePartsAspectRatio"]] &&
   correctWolframModelPlotOptionsQ[
     RulePlot, Defer[RulePlot[WolframModel[args], opts]], Automatic, FilterRules[{opts}, Options[WolframModelPlot]]]
 
@@ -113,6 +117,14 @@ correctSpacingsQ[opts_] := Module[{spacings, correctQ},
   If[!correctQ, Message[RulePlot::invalidSpacings, spacings]];
   correctQ
 ]
+
+correctRulePartsAspectRatioQ[Automatic] := True
+
+correctRulePartsAspectRatioQ[aspectRatio_] :=
+  If[NumericQ[aspectRatio] && aspectRatio > 0,
+    True,
+    Message[RulePlot::invalidAspectRatio, aspectRatio];
+    False]
 
 (* Implementation *)
 


### PR DESCRIPTION
## Changes
* Adds `"RulePartsAspectRatio"` option to `RulePlot`, which controls the aspect ratio of rule-side boxes.
* The default value is `Automatic`, which chooses the aspect ratio based on the rule shape.
* If multiple rules are present, chooses the aspect ratio closest to 1, or exactly 1 if the aspect ratios go opposite ways for different rules.

## Tests
* Default `RulePlot` now uses an automatic aspect ratio:
```
In[] := RulePlot[WolframModel[{{1, 3}, {2, 3}} -> {{1, 2}, {2, 3}, {3, 4}, {3,
      5}}], Frame -> Automatic]
```
![image](https://user-images.githubusercontent.com/1479325/74483074-b30edf00-4e83-11ea-92fc-49416577f8b5.png)
* But custom aspect ratio can be specified as well:
```
In[] := RulePlot[WolframModel[{{1, 3}, {2, 3}} -> {{1, 2}, {2, 3}, {3, 4}, {3,
      5}}], Frame -> Automatic, "RulePartsAspectRatio" -> 1.2]
```
![image](https://user-images.githubusercontent.com/1479325/74483142-d2a60780-4e83-11ea-85a9-0f21e1314713.png)
* Aspect ratio is limited from 0.2 to 5 to avoid extremely skinny rules in cases like this:
```
In[] := RulePlot[WolframModel[{{1, 2}} -> {{1, 3}, {3, 2}}], 
 Frame -> Automatic]
```
![image](https://user-images.githubusercontent.com/1479325/74483181-eb162200-4e83-11ea-85da-d8aa42d18cd2.png)
* In case of multiple rules, the aspect ratio closest to 1 is chosen:
```
In[] := RulePlot[WolframModel[{{{1, 2}, {2, 3}, {3, 4}, {3, 5}} -> {{1, 
      3}, {2, 3}}, {{2, 3}, {3, 4}, {3, 5}, {3, 6}} -> {{3, 2}}}], 
 Frame -> Automatic]
```
![image](https://user-images.githubusercontent.com/1479325/74483230-0bde7780-4e84-11ea-8127-2d74ee46d370.png)
* For horizontal rules, the length is maintained, but for vertical ones, the height is maintained:
![image](https://user-images.githubusercontent.com/1479325/74483290-34667180-4e84-11ea-8cd8-60d388a7be7f.png)