### PR TITLE
multisetUnion

### DIFF
--- a/SetReplace/utilities.m
+++ b/SetReplace/utilities.m
@@ -3,6 +3,7 @@ Package["SetReplace`"]
 PackageScope["vertexList"]
 PackageScope["fromCounts"]
 PackageScope["multisetIntersection"]
+PackageScope["multisetUnion"]
 PackageScope["multisetComplement"]
 PackageScope["indexHypergraph"]
 
@@ -11,6 +12,8 @@ vertexList[edges_] := Sort[Union[Catenate[edges]]]
 fromCounts[association_] := Catenate @ KeyValueMap[ConstantArray] @ association
 
 multisetIntersection[sets___] := fromCounts[Merge[KeyIntersection[Counts /@ {sets}], Min]]
+
+multisetUnion[sets___] := fromCounts[Merge[Counts /@ {sets}, Max]]
 
 multisetComplement[set1_, set2_] := fromCounts[Select[# > 0 &][Merge[{Counts[set1], -Counts[set2]}, Total]]]
 

--- a/SetReplace/utilities.wlt
+++ b/SetReplace/utilities.wlt
@@ -1,9 +1,12 @@
 <|
-  "ToPatternRules" -> <|
+  "utilities" -> <|
     "init" -> (
       Global`multisetComplement = SetReplace`PackageScope`multisetComplement;
+      Global`multisetUnion = SetReplace`PackageScope`multisetUnion;
     ),
     "tests" -> {
+      (* multisetComplement *)
+
       VerificationTest[
         multisetComplement[{}, {}],
         {}
@@ -42,6 +45,48 @@
       VerificationTest[
         multisetComplement[{1, 1, 1, 1, 2, 3, 4, 5}, {1, 1, 2, 4, 6}],
         {1, 1, 3, 5}
+      ],
+
+      (* multisetUnion *)
+
+      VerificationTest[
+        multisetUnion[],
+        {}
+      ],
+
+      VerificationTest[
+        multisetUnion[{1, 2, 3}],
+        {1, 2, 3}
+      ],
+
+      VerificationTest[
+        multisetUnion[{1, 2, 3, 3}],
+        {1, 2, 3, 3}
+      ],
+
+      VerificationTest[
+        multisetUnion[{1, 2, 3, 3}, {1, 3, 5}],
+        {1, 2, 3, 3, 5}
+      ],
+
+      VerificationTest[
+        multisetUnion[{1, 1, 2}, {1, 2, 2}],
+        {1, 1, 2, 2}
+      ],
+
+      VerificationTest[
+        multisetUnion[{1, 1, 2}, {1, 2, 2}, {1, 2, 3, 3}],
+        {1, 1, 2, 2, 3, 3}
+      ],
+
+      VerificationTest[
+        multisetUnion[{1, 1}, {}],
+        {1, 1}
+      ],
+
+      VerificationTest[
+        multisetUnion[{{1, 5}, {1, 4}, {1, 5}, 3, 5}, {{1, 5}, 2, 2, 3, 4}],
+        {{1, 5}, {1, 5}, {1, 4}, 3, 5, 2, 2, 4}
       ]
     }
   |>


### PR DESCRIPTION
## Changes
* Implements `multisetUnion` utility function.
* Does the same as `Union`, but preserves counts of multiple elements.

## Review notes
* Will be used for computing unified embeddings of multiple hypergraphs.

## Tests
* The following keeps correct counts of 1's and 2's in the list:
```
In[] := SetReplace`PackageScope`multisetUnion[{1, 2, 2, 3}, {1, 1, 2, 4}]
Out[] = {1, 1, 2, 2, 3, 4}
```
* Compare to `Union` that "loses" elements:
```
In[] := Union[{1, 2, 2, 3}, {1, 1, 2, 4}]
Out[] = {1, 2, 3, 4}
```