### PR TITLE
multisetFilterRules

### DIFF
--- a/SetReplace/utilities.m
+++ b/SetReplace/utilities.m
@@ -4,6 +4,7 @@ PackageScope["vertexList"]
 PackageScope["fromCounts"]
 PackageScope["multisetIntersection"]
 PackageScope["multisetComplement"]
+PackageScope["multisetFilterRules"]
 PackageScope["indexHypergraph"]
 
 vertexList[edges_] := Sort[Union[Catenate[edges]]]
@@ -13,5 +14,10 @@ fromCounts[association_] := Catenate @ KeyValueMap[ConstantArray] @ association
 multisetIntersection[sets___] := fromCounts[Merge[KeyIntersection[Counts /@ {sets}], Min]]
 
 multisetComplement[set1_, set2_] := fromCounts[Select[# > 0 &][Merge[{Counts[set1], -Counts[set2]}, Total]]]
+
+multisetFilterRules[rules_, filter_] := Catenate @ MapThread[
+  Function[{keyValues, count}, keyValues[[1]] -> # & /@ Take[keyValues[[2]], UpTo[count]]],
+  {Normal @ KeySort @ KeyTake[Merge[Association /@ Join[rules, # -> Nothing & /@ filter], # &], filter],
+    Values @ KeySort @ Counts[filter]}]
 
 indexHypergraph[e_] := With[{vertices = vertexList[e]}, Replace[e, Thread[vertices -> Range[Length[vertices]]], {2}]]

--- a/SetReplace/utilities.wlt
+++ b/SetReplace/utilities.wlt
@@ -119,6 +119,10 @@
 
       VerificationTest[
         multisetUnion[],
+        {}
+      ],
+
+      VerificationTest[
         multisetUnion[{1, 2, 3}],
         {1, 2, 3}
       ],

--- a/SetReplace/utilities.wlt
+++ b/SetReplace/utilities.wlt
@@ -2,6 +2,7 @@
   "ToPatternRules" -> <|
     "init" -> (
       Global`multisetComplement = SetReplace`PackageScope`multisetComplement;
+      Global`multisetFilterRules = SetReplace`PackageScope`multisetFilterRules;
     ),
     "tests" -> {
       VerificationTest[
@@ -42,6 +43,73 @@
       VerificationTest[
         multisetComplement[{1, 1, 1, 1, 2, 3, 4, 5}, {1, 1, 2, 4, 6}],
         {1, 1, 3, 5}
+      ],
+
+      (* multisetFilterRules *)
+
+      VerificationTest[
+        multisetFilterRules[{}, {}],
+        {}
+      ],
+
+      VerificationTest[
+        multisetFilterRules[{1 -> a}, {}],
+        {}
+      ],
+
+      VerificationTest[
+        multisetFilterRules[{}, {1}],
+        {}
+      ],
+
+      VerificationTest[
+        multisetFilterRules[{1 -> a}, {1}],
+        {1 -> a}
+      ],
+
+      VerificationTest[
+        multisetFilterRules[{1 -> a}, {1, 1}],
+        {1 -> a}
+      ],
+
+      VerificationTest[
+        multisetFilterRules[{1 -> a, 1 -> b}, {1}],
+        {1 -> a}
+      ],
+
+      VerificationTest[
+        multisetFilterRules[{1 -> a, 1 -> b}, {1, 1}],
+        {1 -> a, 1 -> b}
+      ],
+
+      VerificationTest[
+        multisetFilterRules[{1 -> a, 2 -> b, 2 -> c}, {1, 1, 2}],
+        {1 -> a, 2 -> b}
+      ],
+
+      VerificationTest[
+        multisetFilterRules[{1 -> a, 2 -> b, 2 -> c, 2 -> d, 3 -> e, 3 -> f}, {2, 2, 3, 3, 3}],
+        {2 -> b, 2 -> c, 3 -> e, 3 -> f}
+      ],
+
+      VerificationTest[
+        multisetFilterRules[{2 -> {b, c}, 2 -> {c, d}, 2 -> {d, e}, 3 -> e, 3 -> f}, {2, 2, 3, 3, 3}],
+        {2 -> {b, c}, 2 -> {c, d}, 3 -> e, 3 -> f}
+      ],
+
+      VerificationTest[
+        multisetFilterRules[{1 -> a, {2, x} -> b, {2, x} -> c, {2, x} -> d, 3 -> e, 3 -> f}, {{2, x}, {2, x}, 3, 3, 3}],
+        {3 -> e, 3 -> f, {2, x} -> b, {2, x} -> c}
+      ],
+
+      VerificationTest[
+        multisetFilterRules[{1 -> a, 2 -> b, 2 -> c, 2 -> d, {3, x} -> e, {3, x} -> f}, {2, 2, {3, x}, {3, x}, 3}],
+        {2 -> b, 2 -> c, {3, x} -> e, {3, x} -> f}
+      ],
+
+      VerificationTest[
+        multisetFilterRules[{1 -> a, 2 -> b, 2 -> c, 2 -> d, {3, x} -> e, {3, x} -> f}, {2, 2, {3, x}, {3, x}}],
+        {2 -> b, 2 -> c, {3, x} -> e, {3, x} -> f}
       ]
     }
   |>


### PR DESCRIPTION
## Changes
* Implements a multiset version of `FilterRules`.
* Filter exactly as many rules as are specified in the second argument.

## Review notes
* Useful for splitting unified hypergraph embedding back into component hypergraphs.

## Tests
* The following picks up exactly the number of rules from the list as specified by the second argument, but not more than that:
```
In[] := SetReplace`PackageScope`multisetFilterRules[{1 -> a, 2 -> b, 2 -> c, 
  2 -> d, 3 -> e, 3 -> f}, {2, 2, 3, 3, 3}]
Out[] = {2 -> b, 2 -> c, 3 -> e, 3 -> f}
```