### PR TITLE
Strings for evolution object keys/values

### DIFF
--- a/SetReplace/WolframModelEvolutionObject.m
+++ b/SetReplace/WolframModelEvolutionObject.m
@@ -34,6 +34,16 @@ PackageScope["$terminationReason"]
 PackageScope["$eventRuleIDs"]
 
 
+$creatorEvents = "CreatorEvents";
+$destroyerEvents = "DestroyerEvents";
+$generations = "Generations";
+$atomLists = "AtomLists";
+$rules = "Rules";
+$maxCompleteGeneration = "MaxCompleteGeneration";
+$terminationReason = "TerminationReason";
+$eventRuleIDs = "EventRuleIDs";
+
+
 (* ::Section:: *)
 (*Documentation*)
 

--- a/SetReplace/setSubstitutionSystem.m
+++ b/SetReplace/setSubstitutionSystem.m
@@ -38,6 +38,19 @@ PackageScope["$forward"]
 PackageScope["$backward"]
 
 
+(* ::Text:: *)
+(*Termination reason values*)
+
+
+$maxEvents = "MaxEvents";
+$maxGenerationsLocal = "MaxGenerationsLocal";
+$maxFinalVertices = "MaxFinalVertices";
+$maxFinalVertexDegree = "MaxFinalVertexDegree";
+$maxFinalExpressions = "MaxFinalExpressions";
+$fixedPoint = "FixedPoint";
+$timeConstraint = "TimeConstraint";
+
+
 (* ::Section:: *)
 (*Documentation*)
 


### PR DESCRIPTION
## Changes
* Changes `WolframModelEvolutionObject` to use strings instead of internal symbols for the association keys and termination reason values.

## Motivation
* This ***considerably*** simplifies WFR deployment, as one does no longer need to worry about managing contexts of internal symbols.

## Tests
* Does not affect functionality.