### PR TITLE
WolframModel properties autocompletion

### DIFF
--- a/SetReplace/WolframModel.m
+++ b/SetReplace/WolframModel.m
@@ -424,5 +424,5 @@ WolframModel[
 (* ::Section:: *)
 (*Autocompletion*)
 
-With[{properties = $WolframModelProperties},
+With[{properties = $newParameterlessProperties},
 	FE`Evaluate[FEPrivate`AddSpecialArgCompletion["WolframModel" -> {0, 0, 0, properties}]]];

--- a/SetReplace/WolframModel.m
+++ b/SetReplace/WolframModel.m
@@ -419,3 +419,10 @@ WolframModel[
 		property : Except[OptionsPattern[]] ? (Not[wolframModelPropertyQ[#]] &),
 		o : OptionsPattern[] /; unrecognizedOptions[WolframModel, {o}] === {}] := 0 /;
 	Message[WolframModel::invalidProperty, property]
+
+
+(* ::Section:: *)
+(*Autocompletion*)
+
+With[{properties = $WolframModelProperties},
+	FE`Evaluate[FEPrivate`AddSpecialArgCompletion["WolframModel" -> {0, 0, 0, properties}]]];

--- a/SetReplace/WolframModelEvolutionObject.m
+++ b/SetReplace/WolframModelEvolutionObject.m
@@ -18,6 +18,7 @@ PackageScope["propertyEvaluate"]
 
 
 PackageScope["$propertiesParameterless"]
+PackageScope["$newParameterlessProperties"]
 
 
 (* ::Text:: *)
@@ -178,6 +179,9 @@ $propertiesParameterless = Join[
   Keys @ Select[#[[1]] == 0 &] @ $propertyArgumentCounts,
   Select[First[$propertyArgumentCounts[$oldToNewPropertyNames[#]]] == 0 &] @ Keys[$oldToNewPropertyNames]
 ];
+
+
+$newParameterlessProperties = Intersection[$propertiesParameterless, Keys[$propertyArgumentCounts]];
 
 
 (* ::Subsection:: *)


### PR DESCRIPTION
## Changes
* Adds autocompletion for `WolframModel` properties.
* Legacy option names are not listed, only the new ones.
* Does not work for `WolframModelEvolutionObject` at this time.

## Notes
* If someone knows how to add autocompletion for the evolution object (i.e., for `SubValues`), please let me know.
* Fuzzy matching algorithm does not seem to work here, but it also does not work for entities, so that looks like a frontend bug.

## Tests
* Start typing the option name and enjoy:
<img width="724" alt="Screen Shot 2020-02-24 at 11 53 22" src="https://user-images.githubusercontent.com/1479325/75173042-43f37f00-56fc-11ea-9546-5faf523d680a.png">

* Old option names are not autocompleted though, i.e., `"AllExpressions"` is hidden:
<img width="591" alt="Screen Shot 2020-02-24 at 12 01 54" src="https://user-images.githubusercontent.com/1479325/75173811-75b91580-56fd-11ea-84f5-3414073378c2.png">