### PR TITLE
Custom context

### DIFF
--- a/build.wls
+++ b/build.wls
@@ -17,7 +17,13 @@ Check[
 
 Check[
   copyWLSourceToBuildDirectory[];
-  updateVersion[];
+  $version = updateVersion[];
+  $context = Replace[
+    tryEnvironment["CONTEXT", "SetReplace"], "Version" -> "SetReplace$" <> StringReplace[$version, "." -> "$"]] <> "`";
+  If[$context =!= "SetReplace`",
+    Print["Building with context ", $context];
+    renameContext[$context];
+  ];
   packPaclet[];
   deleteBuildDirectory[];,
 

--- a/scripts/buildInit.wl
+++ b/scripts/buildInit.wl
@@ -58,6 +58,12 @@ copyWLSourceToBuildDirectory[] /; !$internalBuildQ := With[{
   CopyFile[FileNameJoin[{$repoRoot, "SetReplace", #}], FileNameJoin[{$buildDirectory, #}]] & /@ files;
 ];
 
+fileStringReplace[file_, rules_] := Export[file, StringReplace[Import[file, "Text"], rules], "Text"]
+
+renameContext[newContext_] := fileStringReplace[#, "SetReplace`" -> newContext] & /@
+  (FileNameJoin[{$buildDirectory, #}] &) /@
+  Select[MatchQ[FileExtension[#], "m" | "wl"] &] @ Import[$buildDirectory]
+
 $baseVersionPacletMessage = "Will create paclet with the base version number.";
 updateVersion::noGitLink = "Could not find GitLink. " <> $baseVersionPacletMessage;
 
@@ -76,6 +82,7 @@ updateVersion[] /; Names["GitLink`*"] =!= {} := Module[{
     Return[]];
 
   Export[pacletInfoFilename, Paclet @@ Normal[Join[pacletInfo, <|Version -> versionString|>]]];
+  versionString
 ];
 
 updateVersion[] /; Names["GitLink`*"] === {} := Message[updateVersion::noGitLink];


### PR DESCRIPTION
## Changes
* Allows the user to choose the context for the paclet at build time.
* `CONTEXT` environment variable can be explicitly set to the desired context.
* Alternatively, `CONTEXT="Version"` makes the version-specific context chosen automatically.

## Motivation
* This is needed to insulate Wolfram Function Repository functions from each other and from separately-installed SetReplace.

## Tests
* Build normally to get a default ``SetReplace` `` context:
```
>> ./build.wls&&./install.wls
Build done.
Installed. Restart running kernels to complete installation.

In[] := Quit
In[] := << SetReplace`
In[] := SetReplace`WolframModel[1 -> 2, {1}, "FinalState"]
Out[] = {2}
```
* Specify the context explicitly:
```
>> CONTEXT="SR" ./build.wls&&./install.wls
Building with context SR`
Build done.
Installed. Restart running kernels to complete installation.

In[] := Quit
In[] := << SR`
In[] := SR`WolframModel[1 -> 2, {1}, "FinalState"]
Out[] = {2}
```
* Use the version-specific context:
```
>> CONTEXT="Version" ./build.wls&&./install.wls
Building with context SetReplace$0$2$79`
Build done.
Installed. Restart running kernels to complete installation.

In[] := Quit
In[] := << SetReplace$0$2$79`
In[] := Context[WolframModel]
Out[] = "SetReplace$0$2$79`"
```