### PR TITLE
WolframPhysicsProjectStyleData

### DIFF
--- a/SetReplace/WolframPhysicsProjectStyleData.m
+++ b/SetReplace/WolframPhysicsProjectStyleData.m
@@ -1,0 +1,47 @@
+Package["SetReplace`"]
+
+PackageExport["WolframPhysicsProjectStyleData"]
+
+(* Documentation *)
+
+WolframPhysicsProjectStyleData::usage = usageString[
+  "WolframPhysicsProjectStyleData[] yields an association describing default styles used in Wolfram Physics Project.\n",
+  "WolframPhysicsProjectStyleData[`theme`] gives styles for a particular `theme`.\n",
+  "WolframPhysicsProjectStyleData[`e`] gives a value for a particular style element `e`.\n",
+  "WolframPhysicsProjectStyleData[`theme`, `e`] gives a value for an element `e` of `theme`."];
+
+SyntaxInformation[WolframPhysicsProjectStyleData] = {"ArgumentsPattern" -> {_. _.}};
+
+With[{themesAndElements = Join[$WolframPhysicsProjectPlotThemes, $styleElements], elements = $styleElements},
+  FE`Evaluate[FEPrivate`AddSpecialArgCompletion["WolframPhysicsProjectStyleData" -> {themesAndElements, elements}]]];
+
+(* Implementation *)
+
+(* Evaluate needed to get values for PackageScope symbols loaded after style.m *)
+WolframPhysicsProjectStyleData[theme : Alternatives @@ $WolframPhysicsProjectPlotThemes : $lightTheme] :=
+  Evaluate /@ style[theme]
+
+WolframPhysicsProjectStyleData[
+    theme : Alternatives @@ $WolframPhysicsProjectPlotThemes : $lightTheme, element : Alternatives @@ $styleElements] :=
+  WolframPhysicsProjectStyleData[theme][element]
+
+WolframPhysicsProjectStyleData[args___] /;
+    !Developer`CheckArgumentCount[WolframPhysicsProjectStyleData[args], 0, 2] := (
+  0 /; False
+)
+
+WolframPhysicsProjectStyleData::invalidArg = "The first argument `1` should be either a plot theme or a style element.";
+
+WolframPhysicsProjectStyleData[
+    arg : Except[Alternatives @@ Join[$WolframPhysicsProjectPlotThemes, $styleElements]], ___] := (
+  Message[WolframPhysicsProjectStyleData::invalidArg, arg];
+  0 /; False
+)
+
+WolframPhysicsProjectStyleData::invalidElement = "The second argument `1` should be a style element.";
+
+WolframPhysicsProjectStyleData[
+    theme : Alternatives @@ $WolframPhysicsProjectPlotThemes, el : Except[Alternatives @@ $styleElements]] := (
+  Message[WolframPhysicsProjectStyleData::invalidElement, el];
+  0 /; False
+)

--- a/SetReplace/WolframPhysicsProjectStyleData.m
+++ b/SetReplace/WolframPhysicsProjectStyleData.m
@@ -10,7 +10,7 @@ WolframPhysicsProjectStyleData::usage = usageString[
   "WolframPhysicsProjectStyleData[`g`, `e`] gives a value for a particular style element `e` from group `g`.\n",
   "WolframPhysicsProjectStyleData[`theme`, `g`, `e`] gives a value for an element `e` from group `g` of `theme`."];
 
-SyntaxInformation[WolframPhysicsProjectStyleData] = {"ArgumentsPattern" -> {_. _.}};
+SyntaxInformation[WolframPhysicsProjectStyleData] = {"ArgumentsPattern" -> {_., _., _.}};
 
 $styleGroupNames = Keys[$styleNames];
 $styleElementNames = Catenate[Keys /@ Values @ $styleNames];

--- a/SetReplace/WolframPhysicsProjectStyleData.m
+++ b/SetReplace/WolframPhysicsProjectStyleData.m
@@ -7,41 +7,47 @@ PackageExport["WolframPhysicsProjectStyleData"]
 WolframPhysicsProjectStyleData::usage = usageString[
   "WolframPhysicsProjectStyleData[] yields an association describing default styles used in Wolfram Physics Project.\n",
   "WolframPhysicsProjectStyleData[`theme`] gives styles for a particular `theme`.\n",
-  "WolframPhysicsProjectStyleData[`e`] gives a value for a particular style element `e`.\n",
-  "WolframPhysicsProjectStyleData[`theme`, `e`] gives a value for an element `e` of `theme`."];
+  "WolframPhysicsProjectStyleData[`g`, `e`] gives a value for a particular style element `e` from group `g`.\n",
+  "WolframPhysicsProjectStyleData[`theme`, `g`, `e`] gives a value for an element `e` from group `g` of `theme`."];
 
 SyntaxInformation[WolframPhysicsProjectStyleData] = {"ArgumentsPattern" -> {_. _.}};
 
-With[{themesAndElements = Join[$WolframPhysicsProjectPlotThemes, $styleElements], elements = $styleElements},
-  FE`Evaluate[FEPrivate`AddSpecialArgCompletion["WolframPhysicsProjectStyleData" -> {themesAndElements, elements}]]];
+$styleGroupNames = Keys[$styleNames];
+$styleElementNames = Catenate[Keys /@ Values @ $styleNames];
+
+With[{
+    themesAndGroups = Join[$WolframPhysicsProjectPlotThemes, $styleGroupNames],
+    groupsAndElements = Join[$styleGroupNames, $styleElementNames],
+    elements = $styleElementNames},
+  FE`Evaluate[FEPrivate`AddSpecialArgCompletion[
+    "WolframPhysicsProjectStyleData" -> {themesAndGroups, groupsAndElements, elements}]]];
 
 (* Implementation *)
 
 (* Evaluate needed to get values for PackageScope symbols loaded after style.m *)
 WolframPhysicsProjectStyleData[theme : Alternatives @@ $WolframPhysicsProjectPlotThemes : $lightTheme] :=
-  Evaluate /@ style[theme]
+  Map[Evaluate, $styleNames /. style[theme], {2}]
 
 WolframPhysicsProjectStyleData[
-    theme : Alternatives @@ $WolframPhysicsProjectPlotThemes : $lightTheme, element : Alternatives @@ $styleElements] :=
-  WolframPhysicsProjectStyleData[theme][element]
+    theme : Alternatives @@ $WolframPhysicsProjectPlotThemes : $lightTheme,
+    group : Alternatives @@ $styleGroupNames] :=
+  Evaluate /@ ($styleNames[group] /. style[theme])
+
+WolframPhysicsProjectStyleData[
+    theme : Alternatives @@ $WolframPhysicsProjectPlotThemes : $lightTheme,
+    group : Alternatives @@ $styleGroupNames,
+    element_] /; MemberQ[Keys[$styleNames[group]], element] :=
+  $styleNames[group][element] /. style[theme]
 
 WolframPhysicsProjectStyleData[args___] /;
-    !Developer`CheckArgumentCount[WolframPhysicsProjectStyleData[args], 0, 2] := (
+    !Developer`CheckArgumentCount[WolframPhysicsProjectStyleData[args], 0, 3] := (
   0 /; False
 )
 
-WolframPhysicsProjectStyleData::invalidArg = "The first argument `1` should be either a plot theme or a style element.";
+WolframPhysicsProjectStyleData::invalidArg =
+  "The arguments in `1` should be a style theme (optional), a style group, and a style element (optional).";
 
-WolframPhysicsProjectStyleData[
-    arg : Except[Alternatives @@ Join[$WolframPhysicsProjectPlotThemes, $styleElements]], ___] := (
-  Message[WolframPhysicsProjectStyleData::invalidArg, arg];
-  0 /; False
-)
-
-WolframPhysicsProjectStyleData::invalidElement = "The second argument `1` should be a style element.";
-
-WolframPhysicsProjectStyleData[
-    theme : Alternatives @@ $WolframPhysicsProjectPlotThemes, el : Except[Alternatives @@ $styleElements]] := (
-  Message[WolframPhysicsProjectStyleData::invalidElement, el];
+expr : WolframPhysicsProjectStyleData[RepeatedNull[_, 3]] := (
+  Message[WolframPhysicsProjectStyleData::invalidArg, Defer[expr]];
   0 /; False
 )

--- a/SetReplace/WolframPhysicsProjectStyleData.wlt
+++ b/SetReplace/WolframPhysicsProjectStyleData.wlt
@@ -7,18 +7,17 @@
     ),
     "tests" -> With[{
         themeExample = First @ $WolframPhysicsProjectPlotThemes,
-        elementExample = First @ Keys[WolframPhysicsProjectStyleData[]]}, {
+        groupExample = First @ Keys[WolframPhysicsProjectStyleData[]],
+        elementExample =
+          First @ Keys[WolframPhysicsProjectStyleData[First @ Keys[WolframPhysicsProjectStyleData[]]]],
+        secondGroupElementExample =
+          First @ Keys[WolframPhysicsProjectStyleData[Keys[WolframPhysicsProjectStyleData[]][[2]]]]}, {
       testSymbolLeak[
         WolframPhysicsProjectStyleData[]
       ],
 
       testSymbolLeak[
-        WolframPhysicsProjectStyleData[elementExample]
-      ],
-      
-      testUnevaluated[
-        WolframPhysicsProjectStyleData[themeExample, "VertexSize", 1],
-        {WolframPhysicsProjectStyleData::argb}
+        WolframPhysicsProjectStyleData[groupExample, elementExample]
       ],
 
       testUnevaluated[
@@ -27,8 +26,89 @@
       ],
 
       testUnevaluated[
+        WolframPhysicsProjectStyleData["$$invalid$$", "$$invalid$$"],
+        {WolframPhysicsProjectStyleData::invalidArg}
+      ],
+
+      testUnevaluated[
+        WolframPhysicsProjectStyleData["$$invalid$$", "$$invalid$$", "$$invalid$$"],
+        {WolframPhysicsProjectStyleData::invalidArg}
+      ],
+
+      testUnevaluated[
+        WolframPhysicsProjectStyleData["$$invalid$$", "$$invalid$$", "$$invalid$$", "$$invalid$$"],
+        {WolframPhysicsProjectStyleData::argb}
+      ],
+
+      VerificationTest[
+        AssociationQ @ WolframPhysicsProjectStyleData[themeExample]
+      ],
+
+      testUnevaluated[
         WolframPhysicsProjectStyleData[themeExample, "$$invalid$$"],
-        {WolframPhysicsProjectStyleData::invalidElement}
+        {WolframPhysicsProjectStyleData::invalidArg}
+      ],
+
+      testUnevaluated[
+        WolframPhysicsProjectStyleData[themeExample, "$$invalid$$", "$$invalid$$"],
+        {WolframPhysicsProjectStyleData::invalidArg}
+      ],
+
+      testUnevaluated[
+        WolframPhysicsProjectStyleData[themeExample, "$$invalid$$", "$$invalid$$", "$$invalid$$"],
+        {WolframPhysicsProjectStyleData::argb}
+      ],
+
+      VerificationTest[
+        AssociationQ @ WolframPhysicsProjectStyleData[groupExample]
+      ],
+
+      testUnevaluated[
+        WolframPhysicsProjectStyleData[groupExample, "$$invalid$$"],
+        {WolframPhysicsProjectStyleData::invalidArg}
+      ],
+
+      testUnevaluated[
+        WolframPhysicsProjectStyleData[groupExample, "$$invalid$$", "$$invalid$$"],
+        {WolframPhysicsProjectStyleData::invalidArg}
+      ],
+
+      testUnevaluated[
+        WolframPhysicsProjectStyleData[groupExample, "$$invalid$$", "$$invalid$$", "$$invalid$$"],
+        {WolframPhysicsProjectStyleData::argb}
+      ],
+
+      VerificationTest[
+        AssociationQ @ WolframPhysicsProjectStyleData[themeExample, groupExample]
+      ],
+
+      testUnevaluated[
+        WolframPhysicsProjectStyleData[themeExample, groupExample, "$$invalid$$"],
+        {WolframPhysicsProjectStyleData::invalidArg}
+      ],
+
+      testUnevaluated[
+        WolframPhysicsProjectStyleData[themeExample, groupExample, "$$invalid$$", "$$invalid$$"],
+        {WolframPhysicsProjectStyleData::argb}
+      ],
+
+      testUnevaluated[
+        WolframPhysicsProjectStyleData[
+          themeExample,
+          groupExample,
+          secondGroupElementExample],
+        {WolframPhysicsProjectStyleData::invalidArg}
+      ],
+
+      VerificationTest[
+        WolframPhysicsProjectStyleData[themeExample, groupExample, elementExample],
+        _,
+        SameTest -> MatchQ
+      ],
+
+      testUnevaluated[
+        WolframPhysicsProjectStyleData[themeExample, groupExample, elementExample, "$$invalid$$"],
+        {WolframPhysicsProjectStyleData::argb}
       ],
 
       VerificationTest[
@@ -36,28 +116,30 @@
       ],
 
       VerificationTest[
-        AssociationQ @ WolframPhysicsProjectStyleData[themeExample]
-      ],
-
-      VerificationTest[
-        Equal @@ Length /@ WolframPhysicsProjectStyleData /@ $WolframPhysicsProjectPlotThemes
+        Equal @@ Map[Keys, WolframPhysicsProjectStyleData /@ $WolframPhysicsProjectPlotThemes, {2}]
       ],
 
       VerificationTest[
         Head[WolframPhysicsProjectStyleData[
-            First @ $WolframPhysicsProjectPlotThemes, elementExample]] =!=
+            First @ $WolframPhysicsProjectPlotThemes, groupExample]] =!=
           WolframPhysicsProjectStyleData
       ],
 
       VerificationTest[
-        Head[WolframPhysicsProjectStyleData[elementExample]] =!=
+        Head[WolframPhysicsProjectStyleData[groupExample]] =!=
           WolframPhysicsProjectStyleData
       ],
 
       VerificationTest[
         MemberQ[
           WolframPhysicsProjectStyleData[],
-          WolframPhysicsProjectStyleData[elementExample]]
+          WolframPhysicsProjectStyleData[groupExample]]
+      ],
+
+      VerificationTest[
+        MemberQ[
+          WolframPhysicsProjectStyleData /@ $WolframPhysicsProjectPlotThemes,
+          WolframPhysicsProjectStyleData[]]
       ]
     }]
   |>,

--- a/SetReplace/WolframPhysicsProjectStyleData.wlt
+++ b/SetReplace/WolframPhysicsProjectStyleData.wlt
@@ -1,0 +1,76 @@
+<|
+  "WolframPhysicsProjectStyleData" -> <|
+    "init" -> (
+      Attributes[Global`testUnevaluated] = Attributes[Global`testSymbolLeak] = {HoldAll};
+      Global`testUnevaluated[args___] := SetReplace`PackageScope`testUnevaluated[VerificationTest, args];
+      Global`testSymbolLeak[args___] := SetReplace`PackageScope`testSymbolLeak[VerificationTest, args];
+    ),
+    "tests" -> With[{
+        themeExample = First @ $WolframPhysicsProjectPlotThemes,
+        elementExample = First @ Keys[WolframPhysicsProjectStyleData[]]}, {
+      testSymbolLeak[
+        WolframPhysicsProjectStyleData[]
+      ],
+
+      testSymbolLeak[
+        WolframPhysicsProjectStyleData[elementExample]
+      ],
+      
+      testUnevaluated[
+        WolframPhysicsProjectStyleData[themeExample, "VertexSize", 1],
+        {WolframPhysicsProjectStyleData::argb}
+      ],
+
+      testUnevaluated[
+        WolframPhysicsProjectStyleData["$$invalid$$"],
+        {WolframPhysicsProjectStyleData::invalidArg}
+      ],
+
+      testUnevaluated[
+        WolframPhysicsProjectStyleData[themeExample, "$$invalid$$"],
+        {WolframPhysicsProjectStyleData::invalidElement}
+      ],
+
+      VerificationTest[
+        AssociationQ @ WolframPhysicsProjectStyleData[]
+      ],
+
+      VerificationTest[
+        AssociationQ @ WolframPhysicsProjectStyleData[themeExample]
+      ],
+
+      VerificationTest[
+        Equal @@ Length /@ WolframPhysicsProjectStyleData /@ $WolframPhysicsProjectPlotThemes
+      ],
+
+      VerificationTest[
+        Head[WolframPhysicsProjectStyleData[
+            First @ $WolframPhysicsProjectPlotThemes, elementExample]] =!=
+          WolframPhysicsProjectStyleData
+      ],
+
+      VerificationTest[
+        Head[WolframPhysicsProjectStyleData[elementExample]] =!=
+          WolframPhysicsProjectStyleData
+      ],
+
+      VerificationTest[
+        MemberQ[
+          WolframPhysicsProjectStyleData[],
+          WolframPhysicsProjectStyleData[elementExample]]
+      ]
+    }]
+  |>,
+
+  "$WolframPhysicsProjectPlotThemes" -> <|
+    "tests" -> {
+      VerificationTest[
+        ListQ @ $WolframPhysicsProjectPlotThemes
+      ],
+
+      VerificationTest[
+        Length[$WolframPhysicsProjectPlotThemes] > 0
+      ]
+    }
+  |>
+|>

--- a/SetReplace/style.m
+++ b/SetReplace/style.m
@@ -49,7 +49,7 @@ PackageScope["$ruleArrowStyle"]
 PackageScope["$ruleGridColor"]
 PackageScope["$ruleImageSizePerPlotRange"]
 
-$styleNames = <|
+$styleNames = KeySort /@ KeySort @ <|
   "EvolutionObject" -> <|"Icon" -> $evolutionObjectIcon|>,
   "SpatialGraph" -> <|
     "DestroyedEdgeStyle" -> $destroyedEdgeStyle,

--- a/SetReplace/style.m
+++ b/SetReplace/style.m
@@ -102,16 +102,22 @@ $WolframPhysicsProjectPlotThemes::usage = usageString[
 $WolframPhysicsProjectPlotThemes = {$lightTheme};
 
 style[$lightTheme] = <|
+  (* Evolution object *)
   $evolutionObjectIcon -> $graphIcon,
+
+  (* Hypergraph diffs *)
   $destroyedEdgeStyle -> Directive[Hue[0.08, 0, 0.42], AbsoluteDashing[{1, 2}]],
   $createdEdgeStyle -> Directive[Hue[0.02, 0.94, 0.83], Thick],
   $destroyedAndCreatedEdgeStyle -> Directive[Hue[0.02, 0.94, 0.83], Thick, AbsoluteDashing[{1, 3}]],
+
+  (* Causal graph *)
   $causalGraphVertexStyle -> Directive[Hue[0.11, 1, 0.97], EdgeForm[{Hue[0.11, 1, 0.97], Opacity[1]}]],
   $causalGraphInitialVertexStyle ->
     Directive[RGBColor[{0.259, 0.576, 1}], EdgeForm[{RGBColor[{0.259, 0.576, 1}], Opacity[1]}]],
   $causalGraphFinalVertexStyle -> Directive[White, EdgeForm[{Hue[0.11, 1, 0.97], Opacity[1]}]],
   $causalGraphEdgeStyle -> Hue[0, 1, 0.56],
 
+  (* WolframModelPlot *)
   $vertexSize -> 0.06,
   $arrowheadLength -> 0.1,
   $edgeArrowheadShape -> Polygon[{
@@ -133,6 +139,7 @@ style[$lightTheme] = <|
   $hyperedgeRendering -> "Polygons",
   $wolframModelPlotImageSize -> {{360}, {420}},
 
+  (* RulePlot *)
   $sharedRuleElementsHighlight -> RGBColor[0.5, 0.5, 0.95],
   $ruleHyperedgeRendering -> "Polygons",
   $ruleVertexSize -> 0.1,

--- a/SetReplace/style.m
+++ b/SetReplace/style.m
@@ -3,7 +3,7 @@ Package["SetReplace`"]
 PackageExport["$WolframPhysicsProjectPlotThemes"]
 
 PackageScope["style"]
-PackageScope["$styleElements"]
+PackageScope["$styleNames"]
 
 PackageScope["$lightTheme"]
 
@@ -49,49 +49,55 @@ PackageScope["$ruleArrowStyle"]
 PackageScope["$ruleGridColor"]
 PackageScope["$ruleImageSizePerPlotRange"]
 
-$evolutionObjectIcon = "EvolutionObjectIcon";
-$destroyedEdgeStyle = "DestroyedEdgeStyle";
-$createdEdgeStyle = "CreatedEdgeStyle";
-$destroyedAndCreatedEdgeStyle = "DestroyedAndCreatedEdgeStyle";
-$causalGraphVertexStyle = "CausalGraphVertexStyle";
-$causalGraphInitialVertexStyle = "CausalGraphInitialVertexStyle";
-$causalGraphFinalVertexStyle = "CausalGraphFinalVertexStyle";
-$causalGraphEdgeStyle = "CausalGraphEdgeStyle";
-
-$vertexSize = "VertexSize";
-$arrowheadLength = "ArrowheadLength";
-$edgeArrowheadShape = "EdgeArrowheadShape";
-$vertexStyle = "VertexStyle";
-$edgeLineStyle = "EdgeLineStyle";
-$edgePolygonStyle = "EdgePolygonStyle";
-$unaryEdgeStyle = "UnaryEdgeStyle";
-$vertexStyleFromPlotStyleDirective = "VertexStyleFromPlotStyleDirective";
-$edgeLineStyleFromPlotStyleDirective = "EdgeLineStyleFromPlotStyleDirective";
-$edgePolygonStyleFromEdgeStyleDirective = "EdgePolygonStyleFromEdgeStyleDirective";
-$highlightedVertexStyleDirective = "HighlightedVertexStyleDirective";
-$highlightedEdgeLineStyleDirective = "HighlightedEdgeLineStyleDirective";
-$highlightedUnaryEdgeStyleDirective = "HighlightedUnaryEdgeStyleDirective";
-$highlightedEdgePolygonStyleDirective = "HighlightedEdgePolygonStyleDirective";
-$highlightStyle = "HighlightStyle";
-$hyperedgeRendering = "HyperedgeRendering";
-$wolframModelPlotImageSize = "WolframModelPlotImageSize";
-
-$sharedRuleElementsHighlight = "SharedRuleElementHighlight";
-$ruleHyperedgeRendering = "RuleHyperedgeRendering";
-$ruleVertexSize = "RuleVertexSize";
-$ruleArrowheadLength = "RuleArrowheadLength";
-$rulePartsAspectRatio = "RulePartsAspectRatio";
-$rulePartsAspectRatioMin = "RulePartsAspectRatioMin";
-$rulePartsAspectRatioMax = "RulePartsAspectRatioMax";
-$ruleGraphPadding = "RuleGraphPadding";
-$ruleSidesSpacing = "RuleSidesSpacing";
-$rulePartsFrameStyle = "RulePartsFrameStyle";
-$ruleArrowShape = "RuleArrowShape";
-$ruleArrowLength = "RuleArrowLength";
-$ruleArrowPadding = "RuleArrowPadding";
-$ruleArrowStyle = "RuleArrowStyle";
-$ruleGridColor = "RuleGridColor";
-$ruleImageSizePerPlotRange = "RuleImageSizePerPlotRange";
+$styleNames = <|
+  "EvolutionObject" -> <|"Icon" -> $evolutionObjectIcon|>,
+  "SpatialGraph" -> <|
+    "DestroyedEdgeStyle" -> $destroyedEdgeStyle,
+    "CreatedEdgeStyle" -> $destroyedEdgeStyle,
+    "DestroyedAndCreatedEdgeStyle" -> $destroyedAndCreatedEdgeStyle,
+    "VertexSize" -> $vertexSize,
+    "ArrowheadLength" -> $arrowheadLength,
+    "EdgeArrowheadShape" -> $edgeArrowheadShape,
+    "VertexStyle" -> $vertexStyle,
+    "EdgeLineStyle" -> $edgeLineStyle,
+    "EdgePolygonStyle" -> $edgePolygonStyle,
+    "UnaryEdgeStyle" -> $unaryEdgeStyle,
+    "VertexStyleFromPlotStyleDirective" -> $vertexStyleFromPlotStyleDirective,
+    "EdgeLineStyleFromPlotStyleDirective" -> $edgeLineStyleFromPlotStyleDirective,
+    "EdgePolygonStyleFromEdgeStyleDirective" -> $edgePolygonStyleFromEdgeStyleDirective,
+    "HighlightedVertexStyleDirective" -> $highlightedVertexStyleDirective,
+    "HighlightedEdgeLineStyleDirective" -> $highlightedEdgeLineStyleDirective,
+    "HighlightedUnaryEdgeStyleDirective" -> $highlightedUnaryEdgeStyleDirective,
+    "HighlightedEdgePolygonStyleDirective" -> $highlightedEdgePolygonStyleDirective,
+    "HighlightStyle" -> $highlightStyle,
+    "HyperedgeRendering" -> $hyperedgeRendering,
+    "DefaultImageSize" -> $wolframModelPlotImageSize
+  |>,
+  "CausalGraph" -> <|
+    "VertexStyle" -> $causalGraphVertexStyle,
+    "InitialVertexStyle" -> $causalGraphInitialVertexStyle,
+    "FinalVertexStyle" -> $causalGraphFinalVertexStyle,
+    "EdgeStyle" -> $causalGraphEdgeStyle
+  |>,
+  "Rule" -> <|
+    "SharedElementHighlight" -> $sharedRuleElementsHighlight,
+    "HyperedgeRendering" -> $ruleHyperedgeRendering,
+    "VertexSize" -> $ruleVertexSize,
+    "ArrowheadLength" -> $ruleArrowheadLength,
+    "PartsAspectRatio" -> $rulePartsAspectRatio,
+    "PartsAspectRatioMin" -> $rulePartsAspectRatioMin,
+    "PartsAspectRatioMax" -> $rulePartsAspectRatioMax,
+    "GraphPadding" -> $ruleGraphPadding,
+    "SidesSpacing" -> $ruleSidesSpacing,
+    "PartsFrameStyle" -> $rulePartsFrameStyle,
+    "ArrowShape" -> $ruleArrowShape,
+    "ArrowLength" -> $ruleArrowLength,
+    "ArrowPadding" -> $ruleArrowPadding,
+    "ArrowStyle" -> $ruleArrowStyle,
+    "GridColor" -> $ruleGridColor,
+    "ImageSizePerPlotRange" -> $ruleImageSizePerPlotRange
+  |>
+|>;
 
 $lightTheme = "Light";
 
@@ -160,5 +166,3 @@ style[$lightTheme] = <|
   $ruleGridColor -> GrayLevel[0.85],
   $ruleImageSizePerPlotRange -> 128
 |>;
-
-$styleElements = Keys[style[$lightTheme]];

--- a/SetReplace/style.m
+++ b/SetReplace/style.m
@@ -1,6 +1,9 @@
 Package["SetReplace`"]
 
+PackageExport["$WolframPhysicsProjectPlotThemes"]
+
 PackageScope["style"]
+PackageScope["$styleElements"]
 
 PackageScope["$lightTheme"]
 
@@ -46,9 +49,55 @@ PackageScope["$ruleArrowStyle"]
 PackageScope["$ruleGridColor"]
 PackageScope["$ruleImageSizePerPlotRange"]
 
+$evolutionObjectIcon = "EvolutionObjectIcon";
+$destroyedEdgeStyle = "DestroyedEdgeStyle";
+$createdEdgeStyle = "CreatedEdgeStyle";
+$destroyedAndCreatedEdgeStyle = "DestroyedAndCreatedEdgeStyle";
+$causalGraphVertexStyle = "CausalGraphVertexStyle";
+$causalGraphInitialVertexStyle = "CausalGraphInitialVertexStyle";
+$causalGraphFinalVertexStyle = "CausalGraphFinalVertexStyle";
+$causalGraphEdgeStyle = "CausalGraphEdgeStyle";
+
+$vertexSize = "VertexSize";
+$arrowheadLength = "ArrowheadLength";
+$edgeArrowheadShape = "EdgeArrowheadShape";
+$vertexStyle = "VertexStyle";
+$edgeLineStyle = "EdgeLineStyle";
+$edgePolygonStyle = "EdgePolygonStyle";
+$unaryEdgeStyle = "UnaryEdgeStyle";
+$vertexStyleFromPlotStyleDirective = "VertexStyleFromPlotStyleDirective";
+$edgeLineStyleFromPlotStyleDirective = "EdgeLineStyleFromPlotStyleDirective";
+$edgePolygonStyleFromEdgeStyleDirective = "EdgePolygonStyleFromEdgeStyleDirective";
+$highlightedVertexStyleDirective = "HighlightedVertexStyleDirective";
+$highlightedEdgeLineStyleDirective = "HighlightedEdgeLineStyleDirective";
+$highlightedUnaryEdgeStyleDirective = "HighlightedUnaryEdgeStyleDirective";
+$highlightedEdgePolygonStyleDirective = "HighlightedEdgePolygonStyleDirective";
+$highlightStyle = "HighlightStyle";
+$hyperedgeRendering = "HyperedgeRendering";
+$wolframModelPlotImageSize = "WolframModelPlotImageSize";
+
+$sharedRuleElementsHighlight = "SharedRuleElementHighlight";
+$ruleHyperedgeRendering = "RuleHyperedgeRendering";
+$ruleVertexSize = "RuleVertexSize";
+$ruleArrowheadLength = "RuleArrowheadLength";
+$rulePartsAspectRatio = "RulePartsAspectRatio";
+$rulePartsAspectRatioMin = "RulePartsAspectRatioMin";
+$rulePartsAspectRatioMax = "RulePartsAspectRatioMax";
+$ruleGraphPadding = "RuleGraphPadding";
+$ruleSidesSpacing = "RuleSidesSpacing";
+$rulePartsFrameStyle = "RulePartsFrameStyle";
+$ruleArrowShape = "RuleArrowShape";
+$ruleArrowLength = "RuleArrowLength";
+$ruleArrowPadding = "RuleArrowPadding";
+$ruleArrowStyle = "RuleArrowStyle";
+$ruleGridColor = "RuleGridColor";
+$ruleImageSizePerPlotRange = "RuleImageSizePerPlotRange";
+
 $lightTheme = "Light";
 
-$lightStyles = <|
+$WolframPhysicsProjectPlotThemes = {$lightTheme};
+
+style[$lightTheme] = <|
   $evolutionObjectIcon -> $graphIcon,
   $destroyedEdgeStyle -> Directive[Hue[0.08, 0, 0.42], AbsoluteDashing[{1, 2}]],
   $createdEdgeStyle -> Directive[Hue[0.02, 0.94, 0.83], Thick],
@@ -101,4 +150,4 @@ $lightStyles = <|
   $ruleImageSizePerPlotRange -> 128
 |>;
 
-style[$lightTheme] = $lightStyles;
+$styleElements = Keys[style[$lightTheme]];

--- a/SetReplace/style.m
+++ b/SetReplace/style.m
@@ -95,6 +95,10 @@ $ruleImageSizePerPlotRange = "RuleImageSizePerPlotRange";
 
 $lightTheme = "Light";
 
+$WolframPhysicsProjectPlotThemes::usage = usageString[
+  "$WolframPhysicsProjectPlotThemes gives the list of plot themes available for the Wolfram Physics Project."
+];
+
 $WolframPhysicsProjectPlotThemes = {$lightTheme};
 
 style[$lightTheme] = <|


### PR DESCRIPTION
## Changes
* Implements `WolframPhysicsProjectStyleData`.
* If called with 0 arguments, it returns the entire style association for the `"Light"` plot theme, which is the only theme available at the moment.
* If called with 1 argument, which is a plot theme, returns the association for that plot theme.
* Can also take a style group and an (optional) style element arguments after the theme specification (if any).

## Tests
* Get all styles for the physics project:
```
In[] := WolframPhysicsProjectStyleData[]
```
![image](https://user-images.githubusercontent.com/1479325/75617001-f2e1f180-5b26-11ea-9416-35b30f38a860.png)
* Get values for all causal graph styles:
```
In[] := WolframPhysicsProjectStyleData["CausalGraph"]
```
![image](https://user-images.githubusercontent.com/1479325/75617004-02613a80-5b27-11ea-83f5-a32c5ff8178f.png)
* Get the value of the default vertex size:
```
In[] := WolframPhysicsProjectStyleData["SpatialGraph", "VertexSize"]
Out[] = 0.06
```
* This is equivalent to extracting the same value from the association:
```
In[] := WolframPhysicsProjectStyleData[]["SpatialGraph"]["VertexSize"]
Out[] = 0.06
```
* Specify `"Light"` plot theme explicitly (which is the only one supported at the moment):
```
In[] := WolframPhysicsProjectStyleData["Light", "SpatialGraph", "EdgePolygonStyle"]
```
![image](https://user-images.githubusercontent.com/1479325/75615970-9d9ee380-5b18-11ea-870c-382214167734.png)