### PR TITLE
Fix ToPatternRules pattern naming

### DIFF
--- a/SetReplace/ToPatternRules.m
+++ b/SetReplace/ToPatternRules.m
@@ -84,7 +84,7 @@ toPatternRules[rule : _Rule, caller_] := Module[
 		 newLeft, leftVertices, rightVertices, rightOnlyVertices},
 	{leftSymbols, rightSymbols} =
 		Union[Cases[#, _ ? AtomQ, {0, 1}], Cases[#, _, {2}]] & /@ List @@ rule;
-	symbols = Union[leftSymbols, rightSymbols];
+	symbols = DeleteDuplicates @ Join[leftSymbols, rightSymbols];
 	newVertexNames =
 		ToHeldExpression /@ StringTemplate["v``"] /@ Range @ Length @ symbols;
 	vertexPatterns = Pattern[#, Blank[]] & /@ newVertexNames;

--- a/SetReplace/ToPatternRules.wlt
+++ b/SetReplace/ToPatternRules.wlt
@@ -123,6 +123,12 @@
           {{v[1], v[2]}, {v[2], v[3]}},
           ToPatternRules[{{v[1], v[2]}, {v[2], v[3]}} -> {{v[1], v[3]}}]],
         {{v[1], v[3]}}
+      ],
+
+      (** Renaming anonymous atoms does not affect names in the output #219 **)
+      VerificationTest[
+        ToPatternRules[{{1, 2}, {1, 3}} -> {{1, 2}, {1, 4}, {2, 4}, {3, 4}}],
+        ToPatternRules[{{x, y}, {x, z}} -> {{x, y}, {x, w}, {y, w}, {z, w}}]
       ]
     }
   |>


### PR DESCRIPTION
## Changes
* Closes #219.
* Output of `ToPatternRules` does no longer depend on the names of anonymous variables.

## Tests
* The following two examples previously produced different results.
```
In[] := ToPatternRules[{{1, 2}, {1, 3}} -> {{1, 2}, {1, 4}, {2, 4}, {3, 4}}]
Out[] = {{v1_, v2_}, {v1_, v3_}} :> 
 Module[{v4}, {{v1, v2}, {v1, v4}, {v2, v4}, {v3, v4}}]
```
```
In[] := ToPatternRules[{{x, y}, {x, z}} -> {{x, y}, {x, w}, {y, w}, {z, w}}]
Out[] = {{v1_, v2_}, {v1_, v3_}} :> 
 Module[{v4}, {{v1, v2}, {v1, v4}, {v2, v4}, {v3, v4}}]
```