### PR TITLE
Frame style test fix

### DIFF
--- a/SetReplace/RulePlot.wlt
+++ b/SetReplace/RulePlot.wlt
@@ -211,7 +211,7 @@
       VerificationTest[
         MemberQ[
           Cases[
-            RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], FrameStyle -> RGBColor[0.33, 0.66, 0.77]][[1]],
+            RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], FrameStyle -> RGBColor[0.33, 0.66, 0.77], Frame -> True][[1]],
             _ ? ColorQ,
             All],
           RGBColor[0.33, 0.66, 0.77]]


### PR DESCRIPTION
## Changes
* One of the `RulePlot` tests got broken after the kernel changed the default `Frame -> Automatic` in `RulePlot`.
* It was checking whether the style for the frame was applied, but the frame was never created due to the different option value.
* Added explicit `Frame -> True`, so that it now passes.