### PR TITLE
Fix empty hypergraph unifications

### DIFF
--- a/Kernel/HypergraphUnifications.m
+++ b/Kernel/HypergraphUnifications.m
@@ -25,7 +25,9 @@ hypergraphUnifications[args___] /; !Developer`CheckArgumentCount[HypergraphUnifi
 hypergraphUnifications[e1_List, e2_List] := With[{
     uniqueE1 = Map[$$1, e1, {2}], uniqueE2 = Map[$$2, e2, {2}]},
   findUnion[uniqueE1, uniqueE2, ##] & @@@
-    Reap[findRemainingOverlaps[uniqueE1, uniqueE2, emptyEdgeMatch[], emptyVertexMatch[]]][[2, 1]]
+    Replace[
+      Reap[findRemainingOverlaps[uniqueE1, uniqueE2, emptyEdgeMatch[], emptyVertexMatch[]]][[2]],
+      {overlaps_} -> overlaps]
 ]
 
 hypergraphUnifications[e : Except[_List], _] := hypergraphNotListFail[e]

--- a/Tests/HypergraphUnifications.wlt
+++ b/Tests/HypergraphUnifications.wlt
@@ -108,7 +108,29 @@
         {{{1, 2}, {2, 1}}, {{a, b}, {b, c}, {c, d, e}}},
         {{{1, 2}}, {{a, b}, {b, c}, {c, d, e}}},
         ConstantArray[{{1, 1}, {1, 1}, {1, 1}}, 2]
-      }
+      },
+
+      (* #220 *)
+
+      VerificationTest[
+        HypergraphUnifications[{}, {}],
+        {}
+      ],
+
+      VerificationTest[
+        HypergraphUnifications[{{1}}, {}],
+        {}
+      ],
+
+      VerificationTest[
+        HypergraphUnifications[{}, {{1}}],
+        {}
+      ],
+
+      VerificationTest[
+        HypergraphUnifications[{{1, 2}}, {{1, 2, 3}}],
+        {}
+      ]
     }
   |>
 |>


### PR DESCRIPTION
## Changes
* Resolves #220.
* Fixes `HypergraphUnifications` for non-overlapping hypergraphs.

## Comments
* Non-overlapping hypergraphs can only occur if there are no edges with the same arity, so this case is not very common.
* The reason was inconsistent levels in the output of `Reap`.

## Tests
* Failing cases from #220 now work and return empty lists:
```
In[] := HypergraphUnifications[{}, {}]
Out[] = {}
```
```
In[] := HypergraphUnifications[{{1}}, {}]
Out[] = {}
```
```
In[] := HypergraphUnifications[{{1, 2}}, {{1, 2, 3}}]
Out[] = {}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/264)
<!-- Reviewable:end -->
