### PR TITLE
Adaptive arrowheads

### DIFF
--- a/Kernel/WolframModelPlot.m
+++ b/Kernel/WolframModelPlot.m
@@ -250,7 +250,8 @@ wolframModelPlot[
 		graphicsOptions_] := Catch[Module[{embedding, graphics, imageSizeScaleFactor},
 	embedding = hypergraphEmbedding[edgeType, hyperedgeRendering, vertexCoordinates] @ edges;
 	numericArrowheadLength = Replace[
-		arrowheadLength, Automatic -> style[$lightTheme][$arrowheadLengthFunction][vertexEmbeddingRange[embedding[[1]]]]];
+		arrowheadLength,
+		Automatic -> style[$lightTheme][$arrowheadLengthFunction][<|"PlotRange" -> vertexEmbeddingRange[embedding[[1]]]|>]];
 	graphics =
 		drawEmbedding[styles, vertexLabels, highlight, highlightColor, vertexSize, numericArrowheadLength] @ embedding;
 	imageSizeScaleFactor = Min[1, 0.7 (#[[2]] - #[[1]])] & /@ PlotRange[graphics];

--- a/Kernel/style.m
+++ b/Kernel/style.m
@@ -147,7 +147,7 @@ style[$lightTheme] = <|
 
   (* WolframModelPlot *)
   $vertexSize -> 0.06,
-  $arrowheadLengthFunction -> Function[plotRange, Max[0.1, Min[0.185, 0.066 + 0.017 plotRange]]],
+  $arrowheadLengthFunction -> (Max[0.1, Min[0.185, 0.066 + 0.017 #PlotRange]] &),
   $edgeArrowheadShape -> Polygon[{
     {-1.10196, -0.289756}, {-1.08585, -0.257073}, {-1.05025, -0.178048}, {-1.03171, -0.130243}, {-1.01512, -0.0824391},
     {-1.0039, -0.037561}, {-1., 0.}, {-1.0039, 0.0341466}, {-1.01512, 0.0780486}, {-1.03171, 0.127805},

--- a/Kernel/style.m
+++ b/Kernel/style.m
@@ -16,7 +16,7 @@ PackageScope["$causalGraphInitialVertexStyle"]
 PackageScope["$causalGraphFinalVertexStyle"]
 PackageScope["$causalGraphEdgeStyle"]
 PackageScope["$vertexSize"]
-PackageScope["$arrowheadLength"]
+PackageScope["$arrowheadLengthFunction"]
 PackageScope["$edgeArrowheadShape"]
 PackageScope["$vertexStyle"]
 PackageScope["$edgeLineStyle"]
@@ -61,7 +61,7 @@ $styleNames = KeySort /@ KeySort @ <|
     "CreatedEdgeStyle" -> $destroyedEdgeStyle,
     "DestroyedAndCreatedEdgeStyle" -> $destroyedAndCreatedEdgeStyle,
     "VertexSize" -> $vertexSize,
-    "ArrowheadLength" -> $arrowheadLength,
+    "ArrowheadLengthFunction" -> $arrowheadLengthFunction,
     "EdgeArrowheadShape" -> $edgeArrowheadShape,
     "VertexStyle" -> $vertexStyle,
     "EdgeLineStyle" -> $edgeLineStyle,
@@ -147,7 +147,7 @@ style[$lightTheme] = <|
 
   (* WolframModelPlot *)
   $vertexSize -> 0.06,
-  $arrowheadLength -> 0.1,
+  $arrowheadLengthFunction -> Function[plotRange, Max[0.1, Min[0.185, 0.066 + 0.017 plotRange]]],
   $edgeArrowheadShape -> Polygon[{
     {-1.10196, -0.289756}, {-1.08585, -0.257073}, {-1.05025, -0.178048}, {-1.03171, -0.130243}, {-1.01512, -0.0824391},
     {-1.0039, -0.037561}, {-1., 0.}, {-1.0039, 0.0341466}, {-1.01512, 0.0780486}, {-1.03171, 0.127805},

--- a/Tests/WolframModelPlot.wlt
+++ b/Tests/WolframModelPlot.wlt
@@ -293,6 +293,11 @@
         ]
       } & /@ {VertexSize, "ArrowheadLength"},
 
+      VerificationTest[
+        Head[WolframModelPlot[#, "ArrowheadLength" -> Automatic]],
+        Graphics
+      ] & /@ {{{1, 2, 3}, {3, 4, 5}}, {{1, 1}}, {{1}}, {}},
+
       (* HypergraphPlot can still be used *)
 
       VerificationTest[

--- a/Tests/WolframModelPlot.wlt
+++ b/Tests/WolframModelPlot.wlt
@@ -23,6 +23,10 @@
         {{1, 2, 3}, {3, 4, 5}, {1, 2, 3, 4}}
       };
 
+      {$minArrowheadSize, $maxArrowheadSize} =
+        WolframPhysicsProjectStyleData["SpatialGraph", "ArrowheadLengthFunction"][
+          <|"PlotRange" -> #|>] & /@ {0, 1.*^100}
+
       $selfLoopLength = FirstCase[
         WolframModelPlot[{{1, 1}}, "HyperedgeRendering" -> "Subgraphs"],
         Line[pts_] :> RegionMeasure[Line[pts]],
@@ -603,32 +607,36 @@
             {{{1, 2}}, {{1, 2, 3}}, {{1, 2, 3}, {3, 4, 5}}, RandomInteger[10, {5, 5}]})
       ],
 
-      VerificationTest[
-        Equal @@ (
-          Mean[Cases[
-              WolframModelPlot[#, "HyperedgeRendering" -> "Subgraphs"],
-              Line[pts_] :> EuclideanDistance @@ pts,
-              All]] & /@
-            {{{1, 2}}, {{1, 2, 3}}, {{1, 2, 3}, {3, 4, 5}}, {{1, 2, 3}, {3, 4, 5}, {5, 6, 1}}, {{1, 2, 3, 4, 5, 1}}})
-      ],
+      With[{$minArrowheadSize = $minArrowheadSize, $maxArrowheadSize = $maxArrowheadSize},
+        VerificationTest[
+          Length[DeleteDuplicates[
+            Mean[Cases[
+                WolframModelPlot[#, "HyperedgeRendering" -> "Subgraphs"],
+                Line[pts_] :> EuclideanDistance @@ pts,
+                All]] & /@
+              {{{1, 2}}, {{1, 2, 3}}, {{1, 2, 3}, {3, 4, 5}}, {{1, 2, 3}, {3, 4, 5}, {5, 6, 1}}, {{1, 2, 3, 4, 5, 1}}},
+            #2 - #1 <= $maxArrowheadSize - $minArrowheadSize &]] == 1
+        ]],
 
-      VerificationTest[
-        Abs[
-              First[
-                Nearest[
-                  Cases[
-                    WolframModelPlot[#, "HyperedgeRendering" -> "Subgraphs"],
-                    Line[pts_] :> RegionMeasure[Line[pts]],
-                    All],
-                  $selfLoopLength]] -
-            $selfLoopLength] <
-          1.*^-10
-      ] & /@ {
-        {{1, 1}},
-        {{1, 2, 3}, {1, 1}},
-        {{1, 2, 3}, {3, 4, 5}, {5, 5}},
-        {{1, 2, 3}, {3, 4, 5}, {5, 6, 1, 1}},
-        {{1, 2, 3, 4, 5, 5, 1}}},
+      With[{
+          $minArrowheadSize = $minArrowheadSize, $maxArrowheadSize = $maxArrowheadSize, $selfLoopLength = $selfLoopLength},
+        VerificationTest[
+          Abs[
+                First[
+                  Nearest[
+                    Cases[
+                      WolframModelPlot[#, "HyperedgeRendering" -> "Subgraphs"],
+                      Line[pts_] :> RegionMeasure[Line[pts]],
+                      All],
+                    $selfLoopLength]] -
+              $selfLoopLength] <
+            $maxArrowheadSize - $minArrowheadSize
+        ] & /@ {
+          {{1, 1}},
+          {{1, 2, 3}, {1, 1}},
+          {{1, 2, 3}, {3, 4, 5}, {5, 5}},
+          {{1, 2, 3}, {3, 4, 5}, {5, 6, 1, 1}},
+          {{1, 2, 3, 4, 5, 5, 1}}}],
 
       (* Automatic image size *)
       VerificationTest[

--- a/Tests/WolframModelPlot.wlt
+++ b/Tests/WolframModelPlot.wlt
@@ -25,7 +25,7 @@
 
       {$minArrowheadSize, $maxArrowheadSize} =
         WolframPhysicsProjectStyleData["SpatialGraph", "ArrowheadLengthFunction"][
-          <|"PlotRange" -> #|>] & /@ {0, 1.*^100}
+          <|"PlotRange" -> #|>] & /@ {0, 1.*^100};
 
       $selfLoopLength = FirstCase[
         WolframModelPlot[{{1, 1}}, "HyperedgeRendering" -> "Subgraphs"],


### PR DESCRIPTION
## Changes

* Closes #217.
* Make the arrowheads adaptively change from `0.1` to `0.185` depending on the size of the graph.
* The style spec is contributed by *Jeremy Davis*.

## Comments

* The arrowhead function is now in `style.m`. This is the first precedent where a function is used for a style.

## Tests
* Comparison of old arrowheads (on the left), and the new adaptive ones (on the right):

```
In[] := Grid@Transpose[
  WolframModel[{{1, 2, 3}, {4, 5, 6}, {1, 4}} -> {{2, 7, 8}, {3, 9, 
         10}, {5, 11, 12}, {6, 13, 14}, {8, 12}, {11, 10}, {13, 
         7}, {14, 9}}, {{1, 1, 1}, {1, 1, 1}, {1, 1}, {1, 1}, {1, 1}},
       3]["EventsStatesPlotsList", "ArrowheadLength" -> #] & /@ {0.1, 
    Automatic}]
```

<img width="408" alt="image" src="https://user-images.githubusercontent.com/1479325/76712423-3e7fc800-66ef-11ea-8d50-0b37a544c783.png">

* The new spec makes it possible to see arrows on graphs 1.85 larger than before:

```
In[] := WolframModel[{{1, 2}, {2, 3}} -> {{4, 2}, {4, 1}, {2, 1}, {3, 
    4}}, {{1, 2}, {2, 3}, {3, 4}, {4, 1}}, 5, "FinalStatePlot"]
```

<img width="399" alt="image" src="https://user-images.githubusercontent.com/1479325/76712427-55beb580-66ef-11ea-967e-14895148a7cf.png">

* The new spec function can be looked up with `WolframPhysicsProjectStyleData`:

```
In[] := WolframPhysicsProjectStyleData["SpatialGraph", 
  "ArrowheadLengthFunction"]
Out[] = Max[0.1, Min[0.185, 0.066 + 0.017 #PlotRange]] &
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/268)
<!-- Reviewable:end -->
