### PR TITLE
Git SHA and Build Time

### DIFF
--- a/Kernel/buildData.m
+++ b/Kernel/buildData.m
@@ -1,0 +1,16 @@
+(* The backtick magic is necessary to prevent it being interpreted as a beginning of a template argument. *)
+Package["SetReplace<*"`"*>"]
+
+PackageExport["$SetReplaceGitSHA"]
+PackageExport["$SetReplaceBuildTime"]
+
+$SetReplaceGitSHA::usage = usageString[
+  "$SetReplaceGitSHA gives the Git SHA of the repository from which SetReplace was built."];
+
+$SetReplaceBuildTime::usage = usageString[
+  "$SetReplaceBuildTime gives the date object at which SetReplace was built."];
+
+(* This is a template file. Data is inserted at build time. *)
+
+$SetReplaceGitSHA = <*ToString[gitSHA[], InputForm]*>; (* gitSHA[] is defined in buildInit.wl *)
+$SetReplaceBuildTime = <*ToString[DateObject[TimeZone -> "UTC"], InputForm]*>;

--- a/Tests/buildData.wlt
+++ b/Tests/buildData.wlt
@@ -1,0 +1,37 @@
+<|
+  "$SetReplaceGitSHA" -> <|
+    "tests" -> {
+      VerificationTest[
+        StringLength @ $SetReplaceGitSHA,
+        40
+      ],
+
+      VerificationTest[
+        StringMatchQ[$SetReplaceGitSHA, HexadecimalCharacter...]
+      ]
+    }
+  |>,
+
+  "$SetReplaceBuildTime" -> <|
+    "tests" -> {
+      VerificationTest[
+        DateObjectQ @ $SetReplaceBuildTime
+      ],
+
+      VerificationTest[
+        $SetReplaceBuildTime["TimeZone"],
+        "UTC"
+      ],
+
+      (* could not be built in the future *)
+      VerificationTest[
+        $SetReplaceBuildTime < Now
+      ],
+
+      (* could not be built before $SetReplaceBuildTime was implemented *)
+      VerificationTest[
+        DateObject[{2020, 3, 17, 0, 0, 0}, TimeZone -> "UTC"] < $SetReplaceBuildTime
+      ]
+    }
+  |>
+|>

--- a/build.wls
+++ b/build.wls
@@ -24,6 +24,7 @@ Check[
     Print["Building with context ", $context];
     renameContext[$context];
   ];
+  updateBuildData[];
   packPaclet[];
   deleteBuildDirectory[];,
 

--- a/scripts/buildInit.wl
+++ b/scripts/buildInit.wl
@@ -83,6 +83,25 @@ updateVersion[] /; Names["GitLink`*"] =!= {} := Module[{
 
 updateVersion[] /; Names["GitLink`*"] === {} := Message[updateVersion::noGitLink];
 
+gitSHA[] /; Names["GitLink`*"] =!= {} := Module[{gitRepo, sha, cleanQ},
+  gitRepo = GitOpen[$repoRoot];
+  sha = GitSHA[gitRepo, gitRepo["HEAD"]];
+  cleanQ = AllTrue[# === {} &]@GitStatus[gitRepo];
+  If[cleanQ, sha, sha <> "*"]
+]
+
+gitSHA::noGitLink = "Could not find GitLink. $SetReplaceGitSHA will not be available.";
+
+gitSHA[] /; Names["GitLink`*"] === {} := (
+  Message[gitSHA::noGitLink];
+  Missing["NotAvailable"]
+)
+
+updateBuildData[] := With[{
+    buildDataFile = File[FileNameJoin[{$buildDirectory, "Kernel", "buildData.m"}]]},
+  FileTemplateApply[buildDataFile, buildDataFile];
+]
+
 packPaclet[] := (
   If[$internalBuildQ,
     Print["$Version: ", $Version];

--- a/scripts/packPaclet.wls
+++ b/scripts/packPaclet.wls
@@ -5,6 +5,7 @@ Check[
 
   copyWLSourceToBuildDirectory[];
   updateVersion[];
+  updateBuildData[];
   packPaclet[];,
 
   If[$internalBuild, AntFail, Print]["Paclet packing failed."];


### PR DESCRIPTION
## Changes

* Closes #231.
* Adds two constants that are defined at build time:
  * `$SetReplaceGitSHA` contains the SHA of the repo from which the paclet was built. `*` added at the end, if the repo is dirty.
  * `$SetReplaceBuildTime` contains the `DateObject` of the build time.
* The `$SetReplaceBuildTime` is in UTC because I don't think the timezone is particularly important.
* This is useful to put into research notebooks so that we can be certain we can reproduce them.

## Tests

* Compare `$SetReplaceGitSHA` with the last commit on GitHub:

```
In[] := $SetReplaceGitSHA
Out[] = "95a60da2c3fe95fba3774337f97f4855282a1553"
```

* Check that build time makes sense:

```
In[] := $SetReplaceBuildTime
```

<img width="231" alt="image" src="https://user-images.githubusercontent.com/1479325/76887305-735b5e80-6858-11ea-969a-32a514dbf8d4.png">

* Checked that this works for internal builds as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/270)
<!-- Reviewable:end -->
