### PR TITLE
Offline Build

### DIFF
--- a/scripts/buildInit.wl
+++ b/scripts/buildInit.wl
@@ -68,7 +68,6 @@ updateVersion[] /; Names["GitLink`*"] =!= {} := Module[{
   Check[
     versionInformation = Import[FileNameJoin[{$repoRoot, "scripts", "version.wl"}]];
     gitRepo = GitOpen[$repoRoot];
-    GitFetch[gitRepo, "origin"];
     minorVersionNumber = Length[GitRange[
       gitRepo, Except[versionInformation["Checkpoint"]], GitMergeBase[gitRepo, "HEAD", "origin/master"]]];
     pacletInfoFilename = FileNameJoin[{$buildDirectory, "PacletInfo.m"}];

--- a/scripts/buildInit.wl
+++ b/scripts/buildInit.wl
@@ -69,7 +69,7 @@ updateVersion[] /; Names["GitLink`*"] =!= {} := Module[{
     versionInformation = Import[FileNameJoin[{$repoRoot, "scripts", "version.wl"}]];
     gitRepo = GitOpen[$repoRoot];
     minorVersionNumber = Length[GitRange[
-      gitRepo, Except[versionInformation["Checkpoint"]], GitMergeBase[gitRepo, "HEAD", "origin/master"]]];
+      gitRepo, Except[versionInformation["Checkpoint"]], GitMergeBase[gitRepo, "HEAD", "master"]]];
     pacletInfoFilename = FileNameJoin[{$buildDirectory, "PacletInfo.m"}];
     pacletInfo = Association @@ Import[pacletInfoFilename];
     versionString = pacletInfo[Version] <> "." <> ToString[minorVersionNumber];,


### PR DESCRIPTION
## Changes

* Fixes #222.
* Build script no longer requires an Internet connection.
* This is achieved by removing unnecessary `GitFetch`, and using `master` instead of `origin/master` to determine the version number.

## Tests

* Disconnect from the Internet.
* Run `./build.wls`, and check the paclet file created has the correct version:

```
>> SetReplace git:(internalBuild) ./build.wls && ls *.paclet           
Build done.
SetReplace-0.2.95.paclet
```

* Also checked internal builds still work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/271)
<!-- Reviewable:end -->
