### PR TITLE
Automatic Steps

### DIFF
--- a/Kernel/WolframModel.m
+++ b/Kernel/WolframModel.m
@@ -326,6 +326,12 @@ wolframModelStepsSpecQ[stepsSpec_Association] /;
 	AllTrue[fromStepsSpec[stepsSpec], stepCountQ] := True
 
 
+wolframModelStepsSpecQ[Automatic] := True
+
+
+wolframModelStepsSpecQ[{Automatic, _ ? (# >= 0 &)}] := True
+
+
 wolframModelStepsSpecQ[_] := False
 
 
@@ -391,7 +397,7 @@ expr : WolframModel[
 
 
 WolframModel::invalidSteps =
-	"The steps specification `1` should be an Integer, Infinity, " <>
+	"The steps specification `1` should be an Integer, Infinity, Automatic, " <>
 	"or an association with one or more keys from `2`.";
 
 

--- a/Kernel/WolframModel.m
+++ b/Kernel/WolframModel.m
@@ -197,13 +197,13 @@ WolframModel[
 			property : _ ? wolframModelPropertyQ : "EvolutionObject",
 			o : OptionsPattern[] /; unrecognizedOptions[WolframModel, {o}] === {}] :=
 	Module[{
-			patternRules, initialSet, steps, terminationReasonOverride, overridenOptionValue, evolution, modifiedEvolution,
-			result},
+			patternRules, initialSet, steps, terminationReasonOverride, optionsOverride, overridenOptionValue, evolution,
+			modifiedEvolution, propertyEvaluateWithOptions, result},
 		patternRules = fromRulesSpec[rulesSpec];
 		initialSet = Catch[fromInitSpec[rulesSpec, initSpec]];
 		{steps, terminationReasonOverride, optionsOverride} =
 			fromStepsSpec[initialSet, stepsSpec, OptionValue[TimeConstraint]];
-		overridenOptionValue[option_] := OptionValue[WolframModel, Join[optionsOverride, {o}], option];
+		overridenOptionValue = OptionValue[WolframModel, Join[optionsOverride, {o}], #] &;
 		evolution = If[initialSet =!= $Failed,
 			Check[
 				setSubstitutionSystem[
@@ -352,7 +352,7 @@ wolframModelStepsSpecQ[stepsSpec_ ? stepCountQ] := True
 
 wolframModelStepsSpecQ[stepsSpec_Association] /;
 	SubsetQ[Values[$stepSpecKeys], Keys[stepsSpec]] &&
-	AllTrue[fromStepsSpec[stepsSpec], stepCountQ] := True
+	AllTrue[First[fromStepsSpec[{}, stepsSpec, Infinity]], stepCountQ] := True
 
 
 wolframModelStepsSpecQ[Automatic] := True

--- a/Kernel/WolframModelEvolutionObject.m
+++ b/Kernel/WolframModelEvolutionObject.m
@@ -821,7 +821,7 @@ propertyEvaluate[True, includeBoundaryEventsPattern][
 	$fixedPoint -> "FixedPoint",
 	$timeConstraint -> "TimeConstraint",
 	$Aborted -> "Aborted",
-	x_ ? MissingQ :> x,
+	x : (_ ? MissingQ | Automatic) :> x,
 	_ -> Missing["NotAvailable"]
 }]]
 

--- a/Tests/WolframModel.wlt
+++ b/Tests/WolframModel.wlt
@@ -807,6 +807,64 @@
         ]
       }]] /@ DeleteCases[$SetReplaceMethods, Automatic],
 
+      (*** Automatic steps ***)
+
+      VerificationTest[
+        2 WolframModel[{{1, 2}} -> {{2, 3}}, {{1, 1}}, Automatic, "AllEventsCount"],
+        WolframModel[{{1, 2}} -> {{2, 3}}, {{1, 1}}, {Automatic, 2}, "AllEventsCount"]
+      ],
+
+      VerificationTest[
+        WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, Automatic, "AllEventsCount"] > 0
+      ],
+
+      (* fractional factors should work *)
+      VerificationTest[
+        WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, {Automatic, 1 / Pi}, "AllEventsCount"] <
+          WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, Automatic, "AllEventsCount"]
+      ],
+
+      VerificationTest[
+        WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, {Automatic, 1. - 1.*^-20}, "AllEventsCount"],
+        WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, Automatic, "AllEventsCount"]
+      ],
+
+      (* there should be no message if input has more edges than the step constraint *)
+      VerificationTest[
+        WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, {Automatic, 0}, "AllEventsCount"],
+        0
+      ],
+
+      (* TerminationReason should not leak internal information *)
+      VerificationTest[
+        WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, Automatic, "TerminationReason"],
+        Automatic
+      ],
+
+      (* Evaluation should never take too long *)
+      VerificationTest[
+        Head[TimeConstrained[WolframModel[
+          {{0, 0}, {0, 0}, {0, 0}} -> {{0, 0}, {0, 0}, {0, 0}, {0, 0}}, {{1, 1}, {1, 1}, {1, 1}}, Automatic], 60]],
+        WolframModelEvolutionObject
+      ],
+
+      (* We don't want partial generations *)
+      VerificationTest[
+        WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, Automatic, "PartialGenerationsCount"],
+        0
+      ],
+
+      (* even if specifically asked for *)
+      VerificationTest[
+        WolframModel[
+          {{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}},
+          {{1, 1}},
+          Automatic,
+          "PartialGenerationsCount",
+          "IncludePartialGenerations" -> True],
+        0
+      ],
+
       (** Properties **)
 
       VerificationTest[


### PR DESCRIPTION
## Changes

* Allows `Automatic` for step count.
* The default automation corresponds to `<|"MaxEvents" -> 5000, "MaxEdges" -> 200|>`.
* In addition, `TimeConstraint` is set to `5`, and partial generations are dropped.
* Additionally these constraints can be multiplied by a factor (and are rounded if the result is non-integer). This is specified as `{Automatic, factor}`.
* `"TerminationReason"` in that case is set to `Automatic`.
* Note that because of `TimeConstraint`, the behavior is non-deterministic.

## Tests

* Automate everything!

```
In[] := WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 
    2}}, Automatic, Automatic, "FinalStatePlot"]
```

<img width="399" alt="image" src="https://user-images.githubusercontent.com/1479325/77106701-ea7a2980-69f5-11ea-8602-87282023e904.png">

* Make a 10 times larger version:

```
In[] := WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 
    2}}, Automatic, {Automatic, 10}, "FinalStatePlot"]
```

<img width="399" alt="image" src="https://user-images.githubusercontent.com/1479325/77106752-fbc33600-69f5-11ea-840e-6ef07a4ce7c2.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/272)
<!-- Reviewable:end -->
