### PR TITLE
Allow context change in internal builds

### DIFF
--- a/build.wls
+++ b/build.wls
@@ -18,12 +18,7 @@ Check[
 Check[
   copyWLSourceToBuildDirectory[];
   $version = updateVersion[];
-  $context = Replace[
-    tryEnvironment["CONTEXT", "SetReplace"], "Version" -> "SetReplace$" <> StringReplace[$version, "." -> "$"]] <> "`";
-  If[$context =!= "SetReplace`",
-    Print["Building with context ", $context];
-    renameContext[$context];
-  ];
+  renameContext[Automatic, $version];
   packPaclet[];
   deleteBuildDirectory[];,
 

--- a/build.wls
+++ b/build.wls
@@ -18,8 +18,8 @@ Check[
 Check[
   copyWLSourceToBuildDirectory[];
   $version = updateVersion[];
-  renameContext[Automatic, $version];
-  packPaclet[];
+  $context = renameContext[Automatic, $version];
+  packPaclet[$context];
   deleteBuildDirectory[];,
 
   Exit[1];

--- a/scripts/buildInit.wl
+++ b/scripts/buildInit.wl
@@ -56,6 +56,15 @@ copyWLSourceToBuildDirectory[] /; !$internalBuildQ := With[{
 
 fileStringReplace[file_, rules_] := Export[file, StringReplace[Import[file, "Text"], rules], "Text"]
 
+renameContext[Automatic, version_] := Module[{context},
+  context = Replace[
+    tryEnvironment["CONTEXT", "SetReplace"], "Version" -> "SetReplace$" <> StringReplace[$version, "." -> "$"]] <> "`";
+  If[context =!= "SetReplace`",
+    Print["Building with context ", context];
+    renameContext[context];
+  ];
+]
+
 renameContext[newContext_] := fileStringReplace[#, "SetReplace`" -> newContext] & /@
   (FileNameJoin[{$buildDirectory, #}] &) /@
   Select[MatchQ[FileExtension[#], "m" | "wl"] &] @ Import[$buildDirectory]

--- a/scripts/buildInit.wl
+++ b/scripts/buildInit.wl
@@ -56,13 +56,9 @@ copyWLSourceToBuildDirectory[] /; !$internalBuildQ := With[{
 
 fileStringReplace[file_, rules_] := Export[file, StringReplace[Import[file, "Text"], rules], "Text"]
 
-$contextAntVariable = "${env.CONTEXT}";
-
 renameContext[Automatic, version_] := Module[{context},
   context = Replace[
-    If[$internalBuildQ,
-      Replace[AntProperty[$contextAntVariable], $contextAntVariable -> "SetReplace"],
-      tryEnvironment["CONTEXT", "SetReplace"]],
+    If[$internalBuildQ, AntProperty["context"], tryEnvironment["CONTEXT", "SetReplace"]],
     "Version" -> "SetReplace$" <> StringReplace[version, "." -> "$"]] <> "`";
   If[context =!= "SetReplace`",
     Print["Building with context ", context];

--- a/scripts/buildInit.wl
+++ b/scripts/buildInit.wl
@@ -56,10 +56,14 @@ copyWLSourceToBuildDirectory[] /; !$internalBuildQ := With[{
 
 fileStringReplace[file_, rules_] := Export[file, StringReplace[Import[file, "Text"], rules], "Text"]
 
+$contextAntVariable = "${env.CONTEXT}";
+
 renameContext[Automatic, version_] := Module[{context},
   context = Replace[
-    If[$internalBuildQ, Replace[AntProperty["context"], Null -> "SetReplace"], tryEnvironment["CONTEXT", "SetReplace"]],
-    "Version" -> "SetReplace$" <> StringReplace[$version, "." -> "$"]] <> "`";
+    If[$internalBuildQ,
+      Replace[AntProperty[$contextAntVariable], $contextAntVariable -> "SetReplace"],
+      tryEnvironment["CONTEXT", "SetReplace"]],
+    "Version" -> "SetReplace$" <> StringReplace[version, "." -> "$"]] <> "`";
   If[context =!= "SetReplace`",
     Print["Building with context ", context];
     renameContext[context];

--- a/scripts/buildInit.wl
+++ b/scripts/buildInit.wl
@@ -104,8 +104,7 @@ packPaclet[context_] := Module[{pacletFileName},
     Print["$InstallationDirectory: ", $InstallationDirectory];
     Unset[$MessagePrePrint];
   ];
-  pacletFileName =
-    CreatePacletArchive[$buildDirectory, If[$internalBuildQ, AntProperty["output_directory"], $repoRoot]];
+  pacletFileName = PackPaclet[$buildDirectory, If[$internalBuildQ, AntProperty["output_directory"], $repoRoot]];
   If[context =!= "SetReplace`", RenameFile[pacletFileName, addModifiedContextFlag[pacletFileName]]];
   If[$internalBuildQ,
     SetDirectory[AntProperty["output_directory"]];

--- a/scripts/buildInit.wl
+++ b/scripts/buildInit.wl
@@ -58,7 +58,8 @@ fileStringReplace[file_, rules_] := Export[file, StringReplace[Import[file, "Tex
 
 renameContext[Automatic, version_] := Module[{context},
   context = Replace[
-    tryEnvironment["CONTEXT", "SetReplace"], "Version" -> "SetReplace$" <> StringReplace[$version, "." -> "$"]] <> "`";
+    If[$internalBuildQ, Replace[AntProperty["context"], Null -> "SetReplace"], tryEnvironment["CONTEXT", "SetReplace"]],
+    "Version" -> "SetReplace$" <> StringReplace[$version, "." -> "$"]] <> "`";
   If[context =!= "SetReplace`",
     Print["Building with context ", context];
     renameContext[context];

--- a/scripts/packPaclet.wls
+++ b/scripts/packPaclet.wls
@@ -5,8 +5,8 @@ Check[
 
   copyWLSourceToBuildDirectory[];
   $version = updateVersion[];
-  renameContext[Automatic, $version];
-  packPaclet[];,
+  $context = renameContext[Automatic, $version];
+  packPaclet[$context];,
 
   If[$internalBuild, AntFail, Print]["Paclet packing failed."];
   Exit[1];

--- a/scripts/packPaclet.wls
+++ b/scripts/packPaclet.wls
@@ -4,7 +4,8 @@ Check[
   Get[FileNameJoin[{DirectoryName[$InputFileName], "buildInit.wl"}]];
 
   copyWLSourceToBuildDirectory[];
-  updateVersion[];
+  $version = updateVersion[];
+  renameContext[Automatic, $version];
   packPaclet[];,
 
   If[$internalBuild, AntFail, Print]["Paclet packing failed."];

--- a/scripts/re_build_SetReplace.xml
+++ b/scripts/re_build_SetReplace.xml
@@ -2,9 +2,9 @@
   <property name='build_target' value='internal' />
   <property name='component' value='${ant.project.name}' />
   <property name='system_id' value='### Must be set by Jenkins ###' />
-  <property name='context' value='${env.CONTEXT}' />
 
   <property environment='env' />
+  <property name='context' value='${env.CONTEXT}' />
   <import file='${env.RE_ANTLIBRARY_HOME}/ant-lib.xml' />
 
   <!--

--- a/scripts/re_build_SetReplace.xml
+++ b/scripts/re_build_SetReplace.xml
@@ -2,6 +2,7 @@
   <property name='build_target' value='internal' />
   <property name='component' value='${ant.project.name}' />
   <property name='system_id' value='### Must be set by Jenkins ###' />
+  <property name='context' value='${env.CONTEXT}' />
 
   <property environment='env' />
   <import file='${env.RE_ANTLIBRARY_HOME}/ant-lib.xml' />

--- a/scripts/re_build_SetReplace.xml
+++ b/scripts/re_build_SetReplace.xml
@@ -4,6 +4,9 @@
   <property name='system_id' value='### Must be set by Jenkins ###' />
 
   <property environment='env' />
+  <condition property="context" value="${env.CONTEXT}" else="SetReplace">
+    <isset property="env.CONTEXT" />
+  </condition>
   <import file='${env.RE_ANTLIBRARY_HOME}/ant-lib.xml' />
 
   <!--

--- a/scripts/re_build_SetReplace.xml
+++ b/scripts/re_build_SetReplace.xml
@@ -69,6 +69,7 @@
     <property name='keep.files_directory' value='true' />
   </target>
   
+  <property name='PacletNew.execute.has-custom' value='true' />
   <target name='PacletNew.SetReplace.execute' extensionOf='PacletNew.execute.custom'>
     <mathematica
       exe='${mathExe}'

--- a/scripts/re_build_SetReplace.xml
+++ b/scripts/re_build_SetReplace.xml
@@ -4,7 +4,6 @@
   <property name='system_id' value='### Must be set by Jenkins ###' />
 
   <property environment='env' />
-  <property name='context' value='${env.CONTEXT}' />
   <import file='${env.RE_ANTLIBRARY_HOME}/ant-lib.xml' />
 
   <!--


### PR DESCRIPTION
## Changes

* Allows changing the paclet context in internal builds by setting `env.CONTEXT` variable.
* This significantly simplifies the workflow of making WFR paclet files for all architectures.
* If the paclet is created with a custom context (i.e., the WFR version), `-C` is appended to the paclet name, so that it's not accidentally confused with a normal paclet.

## Tests

* Build the paclet with the version context and check the filename contains `-C` suffix:

```
>> CONTEXT="Version" ./build.wls && ls *.paclet
Building with context SetReplace$0$2$95`
Build done.
SetReplace-0.2.95-C.paclet
```

* Also checked that internal builds work (with and without a custom context).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/273)
<!-- Reviewable:end -->
