### PR TITLE
WolframModelPlot drawing optimizations

### DIFF
--- a/Kernel/WolframModelPlot.m
+++ b/Kernel/WolframModelPlot.m
@@ -454,9 +454,11 @@ addConvexPolygons[edgeType_][edge_, subgraphsShapes_] := Module[{points, region,
 
 (** Drawing **)
 
-applyStyle[style : Except[_List], shapes_] := {style, shapes}
+applyStyle[style : Except[_List], shapes_] := With[{trimmedShapes = DeleteCases[shapes, {}]},
+	If[trimmedShapes === {}, Nothing, {style, trimmedShapes}]
+]
 
-applyStyle[style_List, shapes_] := Transpose[{style, shapes}]
+applyStyle[style_List, shapes_] := Replace[DeleteCases[Transpose[{style, shapes}], {_, {}}], {} -> Nothing]
 
 drawEmbedding[
 			styles_,

--- a/Kernel/WolframModelPlot.m
+++ b/Kernel/WolframModelPlot.m
@@ -463,8 +463,8 @@ drawEmbedding[
 		embeddingShapes[[2]]], {$edgeLine, $edgePolygon, $edgePoint}][[2, All]];
 
 	(* would only work if coordinates consist of a single point *)
-	labels = If[VertexLabels === None,
-		Nothing,
+	labels = If[vertexLabels === None,
+		Graphics[{}],
 		GraphPlot[
 			Graph[embedding[[1, All, 1]], {}],
 			VertexCoordinates -> embedding[[1, All, 2, 1, 1]],

--- a/Kernel/WolframModelPlot.m
+++ b/Kernel/WolframModelPlot.m
@@ -110,43 +110,77 @@ wolframModelPlot$parse[
 		correctWolframModelPlotOptionsQ[WolframModelPlot, Defer[WolframModelPlot[edges, o]], edges, {o}] :=
 	wolframModelPlot$parse[#, edgeType, o] & /@ edges
 
+parseHighlight[_, _, {}, _] := ConstantArray[Automatic, 3]
+
+parseHighlight[vertices_, edges_, highlightList_, highlightStyle_] := Module[{
+		highlightCounts, vertexHighlightFlags, edgeHighlightFlags},
+	highlightCounts = Counts[highlightList];
+	{vertexHighlightFlags, edgeHighlightFlags} = Map[
+		With[{highlightedQ = If[MissingQ[highlightCounts[#]], False, highlightCounts[#]-- > 0]},
+			Replace[highlightedQ, False -> Automatic]] &,
+		{vertices, edges},
+		{2}];
+	{Replace[
+			vertexHighlightFlags,
+			True -> Directive[highlightStyle, style[$lightTheme][$highlightedVertexStyleDirective]], {1}],
+		Replace[
+			edgeHighlightFlags,
+			True -> Directive[highlightStyle, style[$lightTheme][$highlightedEdgeLineStyleDirective]], {1}],
+		Replace[
+			edgeHighlightFlags,
+			True -> Directive[highlightStyle, style[$lightTheme][$highlightedEdgePolygonStyleDirective]], {1}]}
+]
+
 wolframModelPlot$parse[
 			edges : $hypergraphPattern, edgeType : Alternatives @@ $edgeTypes : $defaultEdgeType, o : OptionsPattern[]] /;
 				correctWolframModelPlotOptionsQ[WolframModelPlot, Defer[WolframModelPlot[edges, o]], edges, {o}] := Module[{
-		optionValue, plotStyles, edgeStyle, styles},
+		optionValue, vertices, highlightedVertexStyles, highlightedEdgeLineStyles, highlightedEdgePointStyles,
+		highlightedEdgePolygonStyles, styles},
 	optionValue[opt_] := OptionValue[WolframModelPlot, {o}, opt];
 	vertices = vertexList[edges];
-	(* these are lists, one style for each vertex element *)
+	(* these are either single styles or lists, one style for each element *)
+	{highlightedVertexStyles, highlightedEdgeLineStyles, highlightedEdgePolygonStyles} =
+		parseHighlight[vertices, edges, optionValue[GraphHighlight], optionValue[GraphHighlightStyle]];
 	styles = <|
 		$vertexPoint -> Replace[
 			parseStyles[
-				optionValue[VertexStyle],
+				highlightedVertexStyles,
 				vertices,
-				parseStyles[optionValue[PlotStyle], vertices, <||>, Identity],
-				Directive[#, style[$lightTheme][$vertexStyleFromPlotStyleDirective]] &],
+				parseStyles[
+					optionValue[VertexStyle],
+					vertices,
+					parseStyles[optionValue[PlotStyle], vertices, Automatic, Identity],
+					Directive[#, style[$lightTheme][$vertexStyleFromPlotStyleDirective]] &],
+				Identity],
 			Automatic -> $plotStyleAutomatic[$vertexPoint],
-			{1}],
-		$edgeLine -> (Replace[
+			{0, 1}],
+		$edgeLine -> Replace[
 			edgeStyles = parseStyles[
-				optionValue[EdgeStyle],
+				highlightedEdgeLineStyles,
 				edges,
-				parseStyles[optionValue[PlotStyle], edges, <||>, Identity],
-				Directive[#, style[$lightTheme][$edgeLineStyleFromPlotStyleDirective]] &],
+				parseStyles[
+					optionValue[EdgeStyle],
+					edges,
+					parseStyles[optionValue[PlotStyle], edges, Automatic, Identity],
+					Directive[#, style[$lightTheme][$edgeLineStyleFromPlotStyleDirective]] &],
+				Identity],
 			Automatic -> $plotStyleAutomatic[$edgeLine],
-			{1}]),
-		$edgePoint -> Replace[edgeStyles, Automatic -> $plotStyleAutomatic[$edgePoint], {1}],
+			{0, 1}],
+		$edgePoint -> Replace[edgeStyles, Automatic -> $plotStyleAutomatic[$edgePoint], {0, 1}],
 		$edgePolygon -> Replace[
 			parseStyles[
-				optionValue["EdgePolygonStyle"],
+				highlightedEdgePolygonStyles,
 				edges,
-				edgeStyles,
-				Directive[#, style[$lightTheme][$edgePolygonStyleFromEdgeStyleDirective]] &],
+				parseStyles[
+					optionValue["EdgePolygonStyle"],
+					edges,
+					edgeStyles,
+					Directive[#, style[$lightTheme][$edgePolygonStyleFromEdgeStyleDirective]] &],
+				Identity],
 			Automatic -> $plotStyleAutomatic[$edgePolygon],
-			{1}]|>;
+			{0, 1}]|>;
 	wolframModelPlot[edges, edgeType, styles, ##, FilterRules[{o}, Options[Graphics]]] & @@
 			(optionValue /@ {
-				GraphHighlight,
-				GraphHighlightStyle,
 				"HyperedgeRendering",
 				VertexCoordinateRules,
 				VertexLabels,
@@ -163,10 +197,17 @@ toListStyleSpec[spec_Association, elements_] := Replace[elements, Reverse[Join[{
 
 toListStyleSpec[spec_List, _] := spec
 
-parseStyles[newSpec_, elements_, oldSpec_, oldToNewTransform_] :=
+parseStyles[newSpec : Except[_List | _Association], elements_, Automatic, oldToNewTransform_] := newSpec
+
+parseStyles[newSpec_, elements_, oldSpec_, oldToNewTransform_] /;
+		AllTrue[{oldSpec, newSpec}, MatchQ[#, _List | _Association | Automatic] &] :=
 	MapThread[
 		If[#2 === Automatic, #1, Replace[#1, Automatic -> oldToNewTransform[#2]]] &,
 		toListStyleSpec[#, elements] & /@ {newSpec, oldSpec}]
+
+parseStyles[newSpec_, elements_, oldSpec_, oldToNewTransform_] /;
+		AllTrue[{oldSpec, newSpec}, MatchQ[#, Except[_List | _Association]] &] :=
+	First[parseStyles[{newSpec}, {}, {oldSpec}, oldToNewTransform]]
 
 wolframModelPlot$parse[___] := $Failed
 
@@ -239,8 +280,6 @@ wolframModelPlot[
 		edges_,
 		edgeType_,
 		styles_,
-		highlight_,
-		highlightColor_,
 		hyperedgeRendering_,
 		vertexCoordinates_,
 		vertexLabels_,
@@ -253,7 +292,7 @@ wolframModelPlot[
 		arrowheadLength,
 		Automatic -> style[$lightTheme][$arrowheadLengthFunction][<|"PlotRange" -> vertexEmbeddingRange[embedding[[1]]]|>]];
 	graphics =
-		drawEmbedding[styles, vertexLabels, highlight, highlightColor, vertexSize, numericArrowheadLength] @ embedding;
+		drawEmbedding[styles, vertexLabels, vertexSize, numericArrowheadLength] @ embedding;
 	imageSizeScaleFactor = Min[1, 0.7 (#[[2]] - #[[1]])] & /@ PlotRange[graphics];
 	Show[
 		graphics,
@@ -415,61 +454,37 @@ addConvexPolygons[edgeType_][edge_, subgraphsShapes_] := Module[{points, region,
 
 (** Drawing **)
 
+applyStyle[style : Except[_List], shapes_] := {style, shapes}
+
+applyStyle[style_List, shapes_] := Transpose[{style, shapes}]
+
 drawEmbedding[
 			styles_,
 			vertexLabels_,
-			highlight_,
-			highlightColor_,
 			vertexSize_,
 			arrowheadLength_][
-			embedding_] := Module[{
-		highlightCounts, embeddingShapes, vertexPoints, lines, polygons, edgePoints, labels,
-		singleVertexEdgeCounts, getSingleVertexEdgeRadius},
-	highlightCounts = Counts[highlight];
-	embeddingShapes = Map[
-		With[{highlightedQ = If[MissingQ[highlightCounts[#[[1]]]], False, highlightCounts[#[[1]]]-- > 0]},
-			#[[2]] /. (h : (Point | Line | Polygon))[pts_] :> highlighted[h[pts], highlightedQ]] &,
-		embedding,
-		{2}];
-
-	vertexPoints = MapIndexed[
-		With[{vertexStyle = styles[$vertexPoint][[#2[[1]]]]},
-			# /. {
-				highlighted[Point[p_], h_] :> {
-					If[h, Directive[highlightColor, style[$lightTheme][$highlightedVertexStyleDirective]], vertexStyle],
-					Disk[p, vertexSize]}}] &,
-		embeddingShapes[[1]]];
-
+			embedding_] := Module[{singleVertexEdgeCounts, getSingleVertexEdgeRadius},
 	singleVertexEdgeCounts = <||>;
 	getSingleVertexEdgeRadius[coords_] := (
 		singleVertexEdgeCounts[coords] = Lookup[singleVertexEdgeCounts, Key[coords], vertexSize] + vertexSize
 	);
-
-	{lines, polygons, edgePoints} = Reap[MapIndexed[
-		With[{
-				lineStyle = styles[$edgeLine][[#2[[1]]]],
-				polygonStyle = styles[$edgePolygon][[#2[[1]]]],
-				pointStyle = styles[$edgePoint][[#2[[1]]]]},
-			# /. {
-				highlighted[Line[pts_], h_] :> Sow[{
-					If[h, Directive[style[$lightTheme][$highlightedEdgeLineStyleDirective], highlightColor], lineStyle],
-					arrow[style[$lightTheme][$edgeArrowheadShape], arrowheadLength, vertexSize][pts]}, $edgeLine],
-				highlighted[Polygon[pts_], h_] :> Sow[{
-					If[h, Directive[style[$lightTheme][$highlightedEdgePolygonStyleDirective], highlightColor], polygonStyle],
-					Polygon[pts]}, $edgePolygon],
-				highlighted[Point[p_], h_] :> Sow[{
-					If[h, Directive[style[$lightTheme][$highlightedUnaryEdgeStyleDirective], highlightColor], pointStyle],
-					Circle[p, getSingleVertexEdgeRadius[p]]}, $edgePoint]}] &,
-		embeddingShapes[[2]]], {$edgeLine, $edgePolygon, $edgePoint}][[2, All]];
-
-	(* would only work if coordinates consist of a single point *)
-	labels = If[vertexLabels === None,
-		Graphics[{}],
-		GraphPlot[
-			Graph[embedding[[1, All, 1]], {}],
-			VertexCoordinates -> embedding[[1, All, 2, 1, 1]],
-			VertexLabels -> vertexLabels,
-			VertexShapeFunction -> None,
-			EdgeShapeFunction -> None]];
-	Show[Graphics[{polygons, lines, vertexPoints, edgePoints}], labels]
+	Show[
+		Graphics[{
+			applyStyle[styles[$edgePolygon], Cases[#, _Polygon, All] & /@ embedding[[2, All, 2]]],
+			applyStyle[styles[$edgeLine],
+				Cases[
+						#, Line[pts_] :> arrow[style[$lightTheme][$edgeArrowheadShape], arrowheadLength, vertexSize][pts], All] & /@
+					embedding[[2, All, 2]]],
+			applyStyle[styles[$vertexPoint], Cases[#, Point[pts_] :> Disk[pts, vertexSize], All] & /@ embedding[[1, All, 2]]],
+			applyStyle[styles[$edgePoint],
+					Cases[#, Point[pts_] :> Circle[pts, getSingleVertexEdgeRadius[pts]], All] & /@ embedding[[2, All, 2]]]}],
+		If[vertexLabels === None,
+			Graphics[{}],
+			GraphPlot[
+				Graph[embedding[[1, All, 1]], {}],
+				VertexCoordinates -> embedding[[1, All, 2, 1, 1]],
+				VertexLabels -> vertexLabels,
+				VertexShapeFunction -> None,
+				EdgeShapeFunction -> None]]
+	]
 ]

--- a/Kernel/arrow.m
+++ b/Kernel/arrow.m
@@ -7,14 +7,21 @@ arrow[shape_, arrowheadLength_, vertexSize_][pts_] := Module[{ptsStartToArrowEnd
   ptsStartToLineEnd = lineTake[ptsStartToArrowEnd, 0 ;; - arrowheadLength];
   {
     Line[ptsStartToLineEnd],
-    If[Length[ptsStartToArrowEnd] > 1,
-      arrowhead[
+    If[Length[ptsStartToArrowEnd] > 1 && arrowheadLength > 0,
+      If[MatchQ[shape, Polygon[{{_ ? NumericQ, _ ? NumericQ}...}]], polygonArrowhead, arrowhead][
         shape,
         Last[ptsStartToArrowEnd],
         Normalize[ptsStartToArrowEnd[[-1]] - ptsStartToLineEnd[[-1]]],
         arrowheadLength],
       Nothing]
   }
+]
+
+polygonArrowhead[shape_, endPt_, {0 | 0., 0 | 0.}, length_] := {}
+
+polygonArrowhead[shape_, endPt_, direction_, length_] := With[{
+    rotationMatrix = RotationMatrix[{{1, 0}, direction}]},
+  Polygon[Transpose[rotationMatrix.Transpose[length shape[[1]]] + endPt]]
 ]
 
 arrowhead[shape_, endPt_, {0 | 0., 0 | 0.}, length_] := {}

--- a/Kernel/style.m
+++ b/Kernel/style.m
@@ -27,7 +27,6 @@ PackageScope["$edgeLineStyleFromPlotStyleDirective"]
 PackageScope["$edgePolygonStyleFromEdgeStyleDirective"]
 PackageScope["$highlightedVertexStyleDirective"]
 PackageScope["$highlightedEdgeLineStyleDirective"]
-PackageScope["$highlightedUnaryEdgeStyleDirective"]
 PackageScope["$highlightedEdgePolygonStyleDirective"]
 PackageScope["$highlightStyle"]
 PackageScope["$hyperedgeRendering"]
@@ -83,7 +82,6 @@ $styleNames = KeySort /@ KeySort @ <|
     "EdgePolygonStyleFromEdgeStyleDirective" -> $edgePolygonStyleFromEdgeStyleDirective,
     "HighlightedVertexStyleDirective" -> $highlightedVertexStyleDirective,
     "HighlightedEdgeLineStyleDirective" -> $highlightedEdgeLineStyleDirective,
-    "HighlightedUnaryEdgeStyleDirective" -> $highlightedUnaryEdgeStyleDirective,
     "HighlightedEdgePolygonStyleDirective" -> $highlightedEdgePolygonStyleDirective,
     "HighlightStyle" -> $highlightStyle,
     "HyperedgeRendering" -> $hyperedgeRendering,
@@ -200,7 +198,6 @@ style[$lightTheme] = <|
   $edgePolygonStyleFromEdgeStyleDirective -> Directive[Opacity[0.1], EdgeForm[None]],
   $highlightedVertexStyleDirective -> EdgeForm[Directive[GrayLevel[0], Opacity[0.7]]],
   $highlightedEdgeLineStyleDirective -> Opacity[1],
-  $highlightedUnaryEdgeStyleDirective -> Opacity[1],
   $highlightedEdgePolygonStyleDirective -> Opacity[0.3],
   $highlightStyle -> Red,
   $hyperedgeRendering -> "Polygons",

--- a/Tests/WolframModelPlot.wlt
+++ b/Tests/WolframModelPlot.wlt
@@ -601,14 +601,6 @@
             {{{1}}, {{1, 2, 3}}, {{1, 2, 3}, {3, 4, 5}}, RandomInteger[10, {5, 5}]})
       ],
 
-      VerificationTest[
-        Length[Union[
-          Catenate[Cases[
-              WolframModelPlot[#1, "HyperedgeRendering" -> "Subgraphs"], p : Polygon[___] :> Area[p], All] & /@
-            {{{1, 2}}, {{1, 2, 3}}, {{1, 2, 3}, {3, 4, 5}}, RandomInteger[10, {5, 5}]}],
-          SameTest -> (Abs[#2 - #1]/#1 < 1.*^-5 &)]] == 1
-      ],
-
       With[{$minArrowheadSize = $minArrowheadSize, $maxArrowheadSize = $maxArrowheadSize},
         VerificationTest[
           Length[DeleteDuplicates[

--- a/Tests/WolframModelPlot.wlt
+++ b/Tests/WolframModelPlot.wlt
@@ -344,18 +344,18 @@
 
       VerificationTest[
         Length[Union[Cases[
-          WolframModelPlot[#, "HyperedgeRendering" -> "Subgraphs"],
+          WolframModelPlot[#, "HyperedgeRendering" -> "Subgraphs", "ArrowheadLength" -> 0],
           Polygon[___],
           All]]],
-        1
+        0
       ] & /@ $layoutTestHypergraphs,
 
       VerificationTest[
         Length[Union[Cases[
-          WolframModelPlot[#, "HyperedgeRendering" -> "Polygons"],
+          WolframModelPlot[#, "HyperedgeRendering" -> "Polygons", "ArrowheadLength" -> 0],
           Polygon[___],
           All]]],
-        1 + Length[#]
+        0 + Length[#]
       ] & /@ $layoutTestHypergraphs,
 
       (* VertexLabels *)
@@ -602,9 +602,11 @@
       ],
 
       VerificationTest[
-        SameQ @@ (
-          Union[Cases[WolframModelPlot[#, "HyperedgeRendering" -> "Subgraphs"], p : Polygon[___] :> Area[p], All]] & /@
-            {{{1, 2}}, {{1, 2, 3}}, {{1, 2, 3}, {3, 4, 5}}, RandomInteger[10, {5, 5}]})
+        Length[Union[
+          Catenate[Cases[
+              WolframModelPlot[#1, "HyperedgeRendering" -> "Subgraphs"], p : Polygon[___] :> Area[p], All] & /@
+            {{{1, 2}}, {{1, 2, 3}}, {{1, 2, 3}, {3, 4, 5}}, RandomInteger[10, {5, 5}]}],
+          SameTest -> (Abs[#2 - #1]/#1 < 1.*^-5 &)]] == 1
       ],
 
       With[{$minArrowheadSize = $minArrowheadSize, $maxArrowheadSize = $maxArrowheadSize},


### PR DESCRIPTION
## Changes

* Closes #240.
* Does three optimizations:
  * Speeds up drawing of arrowheads by (1) skipping them altogether is `"ArrowheadLength" -> 0`, and optimizing the computation of shape embeddings otherwise.
  * Fixes a weed by which `drawEmbedding` would still make a call to `GraphPlot` to obtain `VertexLabels` even if `None` were requested.
  * The largest optimization: streamlines `drawEmbedding` function by only including a style once in the result if no elementwise styles were specified.

## Commens

* Note that the largest optimization is not on the kernel side, but on the frontend side (the filesize of the images should decrease as well, although I did not check that).
* This is because the graphics objects produced are now much smaller, only contain element styles once, and don't have nested `Rotate`, `Translate`, and `Scale` to draw arrowheads. This makes drawing by the frontend significantly faster, however, `AbsoluteTiming` cannot detect that, so the timing needs to be measured manually.
* To get a timing in the status bar like I have in the examples below, set `EvaluationCompletionAction` to `"ShowTiming"` in front-end settings:

<img width="1024" alt="Screen Shot 2020-03-23 at 21 50 54" src="https://user-images.githubusercontent.com/1479325/77379956-6060f680-6d50-11ea-86e4-1ad329d94133.png">

## Tests

* This example used to take 18 seconds, but now only takes 8.5 seconds:

```
In[] := state = WolframModel[{{1, 2, 3}, {4, 5, 6}, {1, 4}} -> {{2, 7, 8}, {3,
       9, 10}, {5, 11, 12}, {6, 13, 14}, {8, 12}, {11, 10}, {13, 
      7}, {14, 9}}, {{1, 1, 1}, {1, 1, 1}, {1, 1}, {1, 1}, {1, 1}}, 
   10, "FinalState"];
In[] := AbsoluteTiming[WolframModelPlot[state]]
```

Before:

<img width="540" alt="Screen Shot 2020-03-23 at 19 15 34" src="https://user-images.githubusercontent.com/1479325/77371873-ad39d280-6d3a-11ea-9cb6-ed79b26b5e19.png">

After:

<img width="540" alt="Screen Shot 2020-03-23 at 19 12 31" src="https://user-images.githubusercontent.com/1479325/77371669-40263d00-6d3a-11ea-8f34-dba6eecdbcba.png">

Even better performance can be achieved by setting `"ArrowheadLength" -> 0` (reasonable to do for large graphs, but not a default since we don't know what resolution or plot range the output image will be used for):

<img width="540" alt="Screen Shot 2020-03-23 at 19 19 01" src="https://user-images.githubusercontent.com/1479325/77372050-2802ed80-6d3b-11ea-9deb-fff0e36016f6.png">

which is quite close to `GraphPlot`:

<img width="540" alt="Screen Shot 2020-03-23 at 19 21 05" src="https://user-images.githubusercontent.com/1479325/77372164-731d0080-6d3b-11ea-9dec-6d0ab7accf21.png">

We can also use `"HyperedgeRendering" -> "Subgraphs"`,  but note this will produce a different embedding, as it would not close edges into polygons:

<img width="535" alt="Screen Shot 2020-03-23 at 21 45 57" src="https://user-images.githubusercontent.com/1479325/77379683-af5a5c00-6d4f-11ea-9101-4e515b44ceb3.png">