### PR TITLE
Secure C++ code

### DIFF
--- a/libSetReplace/IDTypes.hpp
+++ b/libSetReplace/IDTypes.hpp
@@ -5,7 +5,7 @@ namespace SetReplace {
     /** @brief Identifiers for atoms, which are the elements of expressions, i.e., vertices in the graph.
      * @details Positive IDs refer to specific atoms, negative IDs refer to patterns (as, for instance, can be used in the rules).
      */
-    using Atom = int;
+    using Atom = int64_t;
     
     /** @brief Identifiers for rules, which stay the same for the entire evolution of the system.
      */
@@ -13,18 +13,18 @@ namespace SetReplace {
     
     /** @brief Identifiers for expressions, which are the elements of the set, and contain ordered sequences of atoms, i.e., (hyper)edges in the graph.
      */
-    using ExpressionID = int;
+    using ExpressionID = int64_t;
     
     /** @brief Identifiers for substitution events, later events have larger IDs.
      */
-    using EventID = int;
+    using EventID = int64_t;
     constexpr EventID initialConditionEvent = 0;
     constexpr EventID finalStateEvent = -1;
     
     /** @brief Layer this expression belongs to in the causal network.
      * @details Specifically, if the largest generation of expressions in the event inputs is n, the generation of its outputs will be n + 1.
      */
-    using Generation = int;
+    using Generation = int64_t;
     constexpr Generation initialGeneration = 0;
 }
 

--- a/libSetReplace/Match.hpp
+++ b/libSetReplace/Match.hpp
@@ -30,7 +30,7 @@ namespace SetReplace {
     public:
         /** @brief Type of the error occurred during evaluation.
          */
-        enum Error {Aborted, DisconnectedInputs, NoMatches};
+        enum Error {Aborted, DisconnectedInputs, NoMatches, InvalidOrderingFunction, InvalidOrderingDirection};
         
         /** @brief All possible functions available to sort matches. Random is the default that is always applied last.
          */

--- a/libSetReplace/Set.cpp
+++ b/libSetReplace/Set.cpp
@@ -23,11 +23,11 @@ namespace SetReplace {
         Atom nextAtom_ = 1;
         ExpressionID nextExpressionID_ = 0;
         
-        int destroyedExpressionsCount_ = 0;
+        int64_t destroyedExpressionsCount_ = 0;
         
         // In another words, expressions counts by atom.
         // Note, we cannot use atomsIndex_, because it does not keep last generation expressions.
-        std::unordered_map<Atom, int> atomDegrees_;
+        std::unordered_map<Atom, int64_t> atomDegrees_;
         
         // Largest generation produced so far.
         // Note, this is not the same as max of generations of all expressions,
@@ -45,11 +45,11 @@ namespace SetReplace {
                        const std::vector<AtomsVector>& initialExpressions,
                        const Matcher::OrderingSpec orderingSpec,
                        const unsigned int randomSeed) :
-            Implementation(rules, initialExpressions, orderingSpec, randomSeed, [this](const int expressionID) {
+            Implementation(rules, initialExpressions, orderingSpec, randomSeed, [this](const int64_t expressionID) {
                 return expressions_.at(expressionID).atoms;
             }) {}
         
-        int replaceOnce(const std::function<bool()> shouldAbort) {
+        int64_t replaceOnce(const std::function<bool()> shouldAbort) {
             terminationReason_ = TerminationReason::NotTerminated;
 
             if (eventRuleIDs_.size() > stepSpec_.maxEvents) {
@@ -102,13 +102,13 @@ namespace SetReplace {
             matcher_.removeMatchesInvolvingExpressions(match->inputExpressions);
             atomsIndex_.removeExpressions(match->inputExpressions);
             
-            int outputGeneration = 0;
+            Generation outputGeneration = 0;
             for (const auto& inputExpression : match->inputExpressions) {
                 outputGeneration = std::max(outputGeneration, expressions_[inputExpression].generation + 1);
             }
             largestGeneration_ = std::max(largestGeneration_, outputGeneration);
             
-            const EventID eventID = static_cast<int>(eventRuleIDs_.size());
+            const EventID eventID = static_cast<EventID>(eventRuleIDs_.size());
             addExpressions(namedRuleOutputs, eventID, outputGeneration);
             assignDestroyerEvent(match->inputExpressions, eventID);
             eventRuleIDs_.push_back(match->rule);
@@ -116,9 +116,9 @@ namespace SetReplace {
             return 1;
         }
         
-        int replace(const StepSpecification stepSpec, const std::function<bool()> shouldAbort) {
+        int64_t replace(const StepSpecification stepSpec, const std::function<bool()> shouldAbort) {
             updateStepSpec(stepSpec);
-            int count = 0;
+            int64_t count = 0;
             while (true) {
                 if (replaceOnce(shouldAbort)) {
                     ++count;
@@ -170,19 +170,27 @@ namespace SetReplace {
             for (const auto& expression : initialExpressions) {
                 for (const auto& atom : expression) {
                     if (atom <= 0) throw Error::NonPositiveAtoms;
-                    nextAtom_ = std::max(nextAtom_ - 1, atom) + 1;
+                    nextAtom_ = std::max(nextAtom_ - 1, atom);
+                    incrementNextAtom();
                 }
             }
             addExpressions(initialExpressions, initialConditionEvent, initialGeneration);
+        }
+
+        Atom incrementNextAtom() {
+            if (nextAtom_ == std::numeric_limits<Atom>::max()) {
+                throw Error::AtomCountOverflow;
+            }
+            return ++nextAtom_;
         }
         
         void updateStepSpec(const StepSpecification newStepSpec) {
             const auto previousMaxGeneration = stepSpec_.maxGenerationsLocal;
             stepSpec_ = newStepSpec;
             if (newStepSpec.maxGenerationsLocal > previousMaxGeneration) {
-                for (int expressionID = 0; expressionID < expressions_.size(); ++expressionID) {
-                    if (expressions_[expressionID].generation == previousMaxGeneration) {
-                        unindexedExpressions_.push_back(expressionID);
+                for (const auto& idAndExpression : expressions_) {
+                    if (idAndExpression.second.generation == previousMaxGeneration) {
+                        unindexedExpressions_.push_back(idAndExpression.first);
                     }
                 }
             }
@@ -195,19 +203,19 @@ namespace SetReplace {
             unindexedExpressions_.clear();
         }
         
-        TerminationReason willExceedAtomLimits(const std::vector<std::vector<int>> explicitRuleInputs,
-                                  const std::vector<std::vector<int>> explicitRuleOutputs) const {
-            const int currentAtomsCount = static_cast<int>(atomDegrees_.size());
+        TerminationReason willExceedAtomLimits(const std::vector<AtomsVector> explicitRuleInputs,
+                                               const std::vector<AtomsVector> explicitRuleOutputs) const {
+            const int64_t currentAtomsCount = static_cast<int64_t>(atomDegrees_.size());
             
-            std::unordered_map<Atom, int> atomDegreeDeltas;
+            std::unordered_map<Atom, int64_t> atomDegreeDeltas;
             updateAtomDegrees(atomDegreeDeltas, explicitRuleInputs, -1, false);
             updateAtomDegrees(atomDegreeDeltas, explicitRuleOutputs, +1, false);
             
-            int newAtomsCount = currentAtomsCount;
+            int64_t newAtomsCount = currentAtomsCount;
             for (const auto& atomAndDegreeDelta : atomDegreeDeltas) {
                 const Atom atom = atomAndDegreeDelta.first;
-                const int degreeDelta = atomAndDegreeDelta.second;
-                const int currentDegree = atomDegrees_.count(atom) ? static_cast<int>(atomDegrees_.at(atom)) : 0;
+                const int64_t degreeDelta = atomAndDegreeDelta.second;
+                const int64_t currentDegree = static_cast<int64_t>(atomDegrees_.count(atom)) ? atomDegrees_.at(atom) : 0;
                 if (currentDegree == 0 && degreeDelta > 0) {
                     ++newAtomsCount;
                 }
@@ -228,9 +236,9 @@ namespace SetReplace {
             }
         }
         
-        static void updateAtomDegrees(std::unordered_map<Atom, int>& atomDegrees,
+        static void updateAtomDegrees(std::unordered_map<Atom, int64_t>& atomDegrees,
                                       const std::vector<AtomsVector>& deltaExpressions,
-                                      const int deltaCount,
+                                      const int64_t deltaCount,
                                       bool deleteIfZero = true) {
             for (const auto& expression : deltaExpressions) {
                 std::unordered_set<Atom> expressionAtoms;
@@ -246,12 +254,12 @@ namespace SetReplace {
             }
         }
         
-        TerminationReason willExceedExpressionsLimit(const std::vector<std::vector<int>> explicitRuleInputs,
-                                        const std::vector<std::vector<int>> explicitRuleOutputs) const {
-            const int currentExpressionsCount = nextExpressionID_ - destroyedExpressionsCount_;
-            const int newExpressionsCount = currentExpressionsCount
-                                            - static_cast<int>(explicitRuleInputs.size())
-                                            + static_cast<int>(explicitRuleOutputs.size());
+        TerminationReason willExceedExpressionsLimit(const std::vector<AtomsVector> explicitRuleInputs,
+                                                     const std::vector<AtomsVector> explicitRuleOutputs) const {
+            const int64_t currentExpressionsCount = nextExpressionID_ - destroyedExpressionsCount_;
+            const int64_t newExpressionsCount = currentExpressionsCount
+                                                - static_cast<int64_t>(explicitRuleInputs.size())
+                                                + static_cast<int64_t>(explicitRuleOutputs.size());
             if (newExpressionsCount > stepSpec_.maxFinalExpressions) {
                 return TerminationReason::MaxFinalExpressions;
             } else {
@@ -265,7 +273,7 @@ namespace SetReplace {
             for (auto& expression : result) {
                 for (auto& atom : expression) {
                     if (atom < 0 && names.count(atom) == 0) {
-                        names[atom] = nextAtom_++;
+                        names[atom] = incrementNextAtom();
                     }
                     if (atom < 0) {
                         atom = names[atom];
@@ -278,7 +286,7 @@ namespace SetReplace {
         
         std::vector<ExpressionID> addExpressions(const std::vector<AtomsVector>& expressions,
                                                  const EventID creatorEvent,
-                                                 const int generation) {
+                                                 const Generation generation) {
             const auto ids = assignExpressionIDs(expressions, creatorEvent, generation);
             
             // If generation is at least maxGeneration_, we will never use these expressions as inputs, so no need adding them to the index.
@@ -294,7 +302,7 @@ namespace SetReplace {
         
         std::vector<ExpressionID> assignExpressionIDs(const std::vector<AtomsVector>& expressions,
                                                       const EventID creatorEvent,
-                                                      const int generation) {
+                                                      const Generation generation) {
             std::vector<ExpressionID> ids;
             for (const auto& expression : expressions) {
                 ids.push_back(nextExpressionID_);
@@ -314,9 +322,9 @@ namespace SetReplace {
             updateAtomDegrees(atomDegrees_, expressions, -1);
         }
         
-        void updateAtomDegrees(std::unordered_map<Atom, int>& atomDegrees,
+        void updateAtomDegrees(std::unordered_map<Atom, int64_t>& atomDegrees,
                                const std::vector<ExpressionID>& deltaExpressionIDs,
-                               const int deltaCount) const {
+                               const int64_t deltaCount) const {
             std::vector<AtomsVector> expressions;
             for (const auto id : deltaExpressionIDs) {
                 expressions.push_back(expressions_.at(id).atoms);
@@ -344,11 +352,11 @@ namespace SetReplace {
         implementation_ = std::make_shared<Implementation>(rules, initialExpressions, orderingSpec, randomSeed);
     }
     
-    int Set::replaceOnce(const std::function<bool()> shouldAbort) {
+    int64_t Set::replaceOnce(const std::function<bool()> shouldAbort) {
         return implementation_->replaceOnce(shouldAbort);
     }
     
-    int Set::replace(const StepSpecification stepSpec, const std::function<bool()> shouldAbort) {
+    int64_t Set::replace(const StepSpecification stepSpec, const std::function<bool()> shouldAbort) {
         return implementation_->replace(stepSpec, shouldAbort);
     }
     

--- a/libSetReplace/Set.hpp
+++ b/libSetReplace/Set.hpp
@@ -16,7 +16,7 @@ namespace SetReplace {
     public:
         /** @brief Type of the error occurred during evaluation.
          */
-        enum class Error {Aborted, DisconnectedInputs, NonPositiveAtoms};
+        enum class Error {Aborted, DisconnectedInputs, NonPositiveAtoms, AtomCountOverflow};
         
         /** @brief Specification of conditions upon which to stop evaluation.
          * @details Each of these is UpTo, i.e., the evolution is terminated when the first of these, fixed point, or an abort is reached.
@@ -27,11 +27,11 @@ namespace SetReplace {
          * @var maxFinalExpressions Same as for the atoms above, but for expressions.
          */
         struct StepSpecification {
-            int maxEvents = 0;
-            int maxGenerationsLocal = 0;
-            int maxFinalAtoms = 0;
-            int maxFinalAtomDegree = 0;
-            int maxFinalExpressions = 0;
+            int64_t maxEvents = 0;
+            int64_t maxGenerationsLocal = 0;
+            int64_t maxFinalAtoms = 0;
+            int64_t maxFinalAtomDegree = 0;
+            int64_t maxFinalExpressions = 0;
         };
         
         /** @brief Status of evaluation / termination reason if evaluation is finished.
@@ -61,13 +61,13 @@ namespace SetReplace {
          * @param shouldAbort function that should return true if Wolfram Language abort is in progress.
          * @return 1 if substitution was made, 0 if no matches were found.
          */
-        int replaceOnce(const std::function<bool()> shouldAbort);
+        int64_t replaceOnce(const std::function<bool()> shouldAbort);
         
         /** @brief Run replaceOnce() stepSpec.maxEvents times, or until the next expression violates constraints imposed by stepSpec.
          * @param shouldAbort function that should return true if Wolfram Language abort is in progress.
          * @return The number of subtitutions made, could be between 0 and stepSpec.maxEvents.
          */
-        int replace(const StepSpecification stepSpec, const std::function<bool()> shouldAbort);
+        int64_t replace(const StepSpecification stepSpec, const std::function<bool()> shouldAbort);
         
         /** @brief List of all expressions in the set, past and present.
          */

--- a/libSetReplace/SetReplace.cpp
+++ b/libSetReplace/SetReplace.cpp
@@ -1,12 +1,14 @@
 #include <chrono>
+#include <random>
 #include <string>
+#include <unordered_map>
 
 #include "SetReplace.hpp"
 
 #include "Set.hpp"
 
 mint getData(mint* data, mint length, mint index) {
-    if (index >= length) {
+    if (index >= length || index < 0) {
         throw LIBRARY_FUNCTION_ERROR;
     } else {
         return data[index];
@@ -14,28 +16,34 @@ mint getData(mint* data, mint length, mint index) {
 }
 
 namespace SetReplace {
+    // These are global variables that keep all sets returned to Wolfram Language until they are destroyed.
+    // Pointers are not returned directly for security reasons.
+    using SetID = int64_t;
+    std::unordered_map<SetID, Set> sets_;
+
     std::vector<Rule> getRules(WolframLibraryData libData, MTensor& rulesTensor) {
         mint tensorLength = libData->MTensor_getFlattenedLength(rulesTensor);
         mint* tensorData = libData->MTensor_getIntegerData(rulesTensor);
-        int readIndex = 0;
+        mint readIndex = 0;
         const auto getRulesData = [&tensorData, &tensorLength, &readIndex]() -> mint {
             return getData(tensorData, tensorLength, readIndex++);
         };
         
-        const int rulesCount = static_cast<int>(getRulesData());
+        const mint rulesCount = getRulesData();
         std::vector<Rule> rules;
-        for (int ruleIndex = 0; ruleIndex < rulesCount; ++ruleIndex) {
+        for (mint ruleIndex = 0; ruleIndex < rulesCount; ++ruleIndex) {
             if (getRulesData() != 2) {
                 throw LIBRARY_FUNCTION_ERROR;
             } else {
                 std::vector<std::vector<AtomsVector>> ruleInputsAndOutputs(2);
                 
                 for (auto& set : ruleInputsAndOutputs) {
-                    set.resize(getRulesData());
-                    for (int expressionIndex = 0; expressionIndex < set.size(); ++expressionIndex) {
-                        set[expressionIndex].resize(getRulesData());
-                        for (int atomIndex = 0; atomIndex < set[expressionIndex].size(); ++atomIndex) {
-                            set[expressionIndex][atomIndex] = (int)getRulesData();
+                    const mint setLength = getRulesData();
+                    for (mint expressionIndex = 0; expressionIndex < setLength; ++expressionIndex) {
+                        const mint expressionLength = getRulesData();
+                        set.push_back(AtomsVector());
+                        for (mint atomIndex = 0; atomIndex < expressionLength; ++atomIndex) {
+                            set[expressionIndex].push_back(static_cast<Atom>(getRulesData()));
                         }
                     }
                 }
@@ -48,16 +56,18 @@ namespace SetReplace {
     std::vector<AtomsVector> getSet(WolframLibraryData libData, MTensor& setTensor) {
         mint tensorLength = libData->MTensor_getFlattenedLength(setTensor);
         mint* tensorData = libData->MTensor_getIntegerData(setTensor);
-        int readIndex = 0;
+        mint readIndex = 0;
         const auto getSetData = [&tensorData, &tensorLength, &readIndex]() -> mint {
             return getData(tensorData, tensorLength, readIndex++);
         };
         
-        std::vector<AtomsVector> set(getSetData());
-        for (int expressionIndex = 0; expressionIndex < set.size(); ++expressionIndex) {
-            set[expressionIndex].resize(getSetData());
-            for (int atomIndex = 0; atomIndex < set[expressionIndex].size(); ++atomIndex) {
-                set[expressionIndex][atomIndex] = (int)getSetData();
+        const mint setLength = getSetData();
+        std::vector<AtomsVector> set;
+        for (mint expressionIndex = 0; expressionIndex < setLength; ++expressionIndex) {
+            const mint expressionLength = getSetData();
+            set.push_back(AtomsVector());
+            for (mint atomIndex = 0; atomIndex < expressionLength; ++atomIndex) {
+                set[expressionIndex].push_back(static_cast<Atom>(getSetData()));
             }
         }
         return set;
@@ -67,24 +77,25 @@ namespace SetReplace {
         mint tensorLength = libData->MTensor_getFlattenedLength(orderingSpecTensor);
         mint* tensorData = libData->MTensor_getIntegerData(orderingSpecTensor);
         Matcher::OrderingSpec result;
-        for (int i = 0; i < tensorLength; i += 2) {
+        for (mint i = 0; i < tensorLength; i += 2) {
             result.push_back({
-                (Matcher::OrderingFunction)getData(tensorData, tensorLength, i),
-                (Matcher::OrderingDirection)getData(tensorData, tensorLength, i + 1)});
+                static_cast<Matcher::OrderingFunction>(getData(tensorData, tensorLength, i)),
+                static_cast<Matcher::OrderingDirection>(getData(tensorData, tensorLength, i + 1))});
         }
         return result;
     }
     
     Set::StepSpecification getStepSpec(WolframLibraryData libData, MTensor& stepsTensor) {
         mint tensorLength = libData->MTensor_getFlattenedLength(stepsTensor);
-        constexpr int specLength = 5;
+        constexpr mint specLength = 5;
         if (tensorLength != specLength) {
-            throw LIBRARY_DIMENSION_ERROR;
+            throw LIBRARY_FUNCTION_ERROR;
         } else {
             mint* tensorData = libData->MTensor_getIntegerData(stepsTensor);
-            std::vector<int> stepSpecElements(specLength);
-            for (int k = 0; k < specLength; ++k) {
-                stepSpecElements[k] = static_cast<int>(getData(tensorData, specLength, k));
+            std::vector<int64_t> stepSpecElements(specLength);
+            for (mint k = 0; k < specLength; ++k) {
+                stepSpecElements[k] = static_cast<int64_t>(getData(tensorData, specLength, k));
+                if (stepSpecElements[k] < 0) throw LIBRARY_FUNCTION_ERROR;
             }
             Set::StepSpecification result;
             result.maxEvents = stepSpecElements[0];
@@ -100,45 +111,45 @@ namespace SetReplace {
     MTensor putSet(const std::vector<SetExpression>& expressions, WolframLibraryData libData) {
         // creator + destroyer events + generation + atoms count
         // add fake event at the end to specify the length of the last expression
-        int tensorLength = 1 + 4 * (static_cast<int>(expressions.size()) + 1);
+        size_t tensorLength = 1 + 4 * (expressions.size() + 1);
         
         // The rest of the result are the atoms, positions to which are referenced in each expression spec.
         // This is where the first atom will be located.
-        int atomsPointer = tensorLength + 1;
+        size_t atomsPointer = tensorLength + 1;
         
-        for (int i = 0; i < expressions.size(); ++i) {
+        for (size_t i = 0; i < expressions.size(); ++i) {
             tensorLength += expressions[i].atoms.size();
         }
         
-        mint dimensions[1] = {tensorLength};
+        mint dimensions[1] = {static_cast<mint>(tensorLength)};
         MTensor output;
         libData->MTensor_new(MType_Integer, 1, dimensions, &output);
         
-        int writeIndex = 0;
+        mint writeIndex = 0;
         mint position[1];
-        const auto appendToTensor = [libData, &writeIndex, &position, &output](const std::vector<int> numbers) {
+        const auto appendToTensor = [libData, &writeIndex, &position, &output](const std::vector<mint> numbers) {
             for (const auto number : numbers) {
                 position[0] = ++writeIndex;
                 libData->MTensor_setInteger(output, position, number);
             }
         };
         
-        appendToTensor({static_cast<int>(expressions.size())});
-        for (int expressionIndex = 0; expressionIndex < expressions.size(); ++expressionIndex) {
+        appendToTensor({static_cast<mint>(expressions.size())});
+        for (size_t expressionIndex = 0; expressionIndex < expressions.size(); ++expressionIndex) {
             appendToTensor({
                 expressions[expressionIndex].creatorEvent,
                 expressions[expressionIndex].destroyerEvent,
                 expressions[expressionIndex].generation,
-                atomsPointer});
+                static_cast<mint>(atomsPointer)});
             atomsPointer += expressions[expressionIndex].atoms.size();
         }
         
         // Put fake event at the end so that the length of final expression can be determined on WL side.
         constexpr EventID fakeEvent = -3;
         constexpr Generation fakeGeneration = -1;
-        appendToTensor({fakeEvent, fakeEvent, fakeGeneration, atomsPointer});
+        appendToTensor({fakeEvent, fakeEvent, fakeGeneration, static_cast<mint>(atomsPointer)});
         
-        for (int expressionIndex = 0; expressionIndex < expressions.size(); ++expressionIndex) {
+        for (size_t expressionIndex = 0; expressionIndex < expressions.size(); ++expressionIndex) {
             appendToTensor(expressions[expressionIndex].atoms);
         }
         
@@ -158,13 +169,24 @@ namespace SetReplace {
             rules = getRules(libData, MArgument_getMTensor(argv[0]));
             initialExpressions = getSet(libData, MArgument_getMTensor(argv[1]));
             orderingSpec = getOrderingSpec(libData, MArgument_getMTensor(argv[2]));
-            randomSeed = (unsigned int)MArgument_getInteger(argv[3]);
+            randomSeed = static_cast<unsigned int>(MArgument_getInteger(argv[3]));
         } catch (...) {
             return LIBRARY_FUNCTION_ERROR;
         }
         
-        auto setPtr = new Set(rules, initialExpressions, orderingSpec, randomSeed);
-        MArgument_setInteger(result, (int64_t)setPtr);
+        SetID thisSetID;
+        do {
+            std::mt19937_64 randomGenerator(std::chrono::system_clock::now().time_since_epoch().count());
+            std::uniform_int_distribution<SetID> distribution(0, std::numeric_limits<SetID>::max());
+            thisSetID = distribution(randomGenerator);
+        } while (sets_.count(thisSetID) > 0);
+        try {
+            sets_.insert({thisSetID, Set(rules, initialExpressions, orderingSpec, randomSeed)});
+        } catch (...) {
+            return LIBRARY_FUNCTION_ERROR;
+        }
+        
+        MArgument_setInteger(result, thisSetID);
         return LIBRARY_NO_ERROR;
     }
 
@@ -172,7 +194,12 @@ namespace SetReplace {
         if (argc != 1) {
             return LIBRARY_FUNCTION_ERROR;
         }
-        delete (Set*)MArgument_getInteger(argv[0]);
+        const SetID setToDelete = MArgument_getInteger(argv[0]);
+        if (sets_.count(setToDelete)) {
+            sets_.erase(setToDelete);
+        } else {
+            return LIBRARY_FUNCTION_ERROR;
+        }
         return LIBRARY_NO_ERROR;
     }
     
@@ -182,12 +209,20 @@ namespace SetReplace {
         };
     }
 
+    Set& setFromID(const SetID id) {
+        if (sets_.count(id)) {
+            return sets_.at(id);
+        } else {
+            throw LIBRARY_FUNCTION_ERROR;
+        }
+    }
+
     int setReplace(WolframLibraryData libData, mint argc, MArgument *argv, MArgument result) {
         if (argc != 2) {
             return LIBRARY_FUNCTION_ERROR;
         }
         
-        auto setPtr = (Set*)MArgument_getInteger(argv[0]);
+        const SetID setID = MArgument_getInteger(argv[0]);
         Set::StepSpecification stepSpec;
         try {
             stepSpec = getStepSpec(libData, MArgument_getMTensor(argv[1]));
@@ -196,7 +231,7 @@ namespace SetReplace {
         }
         
         try {
-            setPtr->replace(stepSpec, shouldAbort(libData));
+            setFromID(setID).replace(stepSpec, shouldAbort(libData));
         } catch (...) {
             return LIBRARY_FUNCTION_ERROR;
         }
@@ -209,13 +244,16 @@ namespace SetReplace {
             return LIBRARY_FUNCTION_ERROR;
         }
         
-        auto setPtr = (Set*)MArgument_getInteger(argv[0]);
+        const SetID setID = MArgument_getInteger(argv[0]);;
+        
+        std::vector<SetExpression> expressions;
         try {
-            const auto expressions = setPtr->expressions();
-            MArgument_setMTensor(result, putSet(expressions, libData));
+            expressions = setFromID(setID).expressions();
         } catch (...) {
             return LIBRARY_FUNCTION_ERROR;
         }
+        
+        MArgument_setMTensor(result, putSet(expressions, libData));
         
         return LIBRARY_NO_ERROR;
     }
@@ -225,13 +263,16 @@ namespace SetReplace {
             return LIBRARY_FUNCTION_ERROR;
         }
         
-        auto setPtr = (Set*)MArgument_getInteger(argv[0]);
+        const SetID setID = MArgument_getInteger(argv[0]);;
+        
+        Generation maxCompleteGeneration;
         try {
-            const auto maxCompleteGeneration = setPtr->maxCompleteGeneration(shouldAbort(libData));
-            MArgument_setInteger(result, maxCompleteGeneration);
+            maxCompleteGeneration = setFromID(setID).maxCompleteGeneration(shouldAbort(libData));
         } catch (...) {
             return LIBRARY_FUNCTION_ERROR;
         }
+        
+        MArgument_setInteger(result, maxCompleteGeneration);
         
         return LIBRARY_NO_ERROR;
     }
@@ -240,14 +281,17 @@ namespace SetReplace {
         if (argc != 1) {
             return LIBRARY_FUNCTION_ERROR;
         }
-
-        auto setPtr = (Set*)MArgument_getInteger(argv[0]);
+        
+        const SetID setID = MArgument_getInteger(argv[0]);
+        
+        Set::TerminationReason terminationReason;
         try {
-            const Set::TerminationReason terminationReason = setPtr->terminationReason();
-            MArgument_setInteger(result, (int)terminationReason);
+            terminationReason = setFromID(setID).terminationReason();
         } catch (...) {
             return LIBRARY_FUNCTION_ERROR;
         }
+        
+        MArgument_setInteger(result, (int)terminationReason);
 
         return LIBRARY_NO_ERROR;
     }
@@ -257,16 +301,17 @@ namespace SetReplace {
             return LIBRARY_FUNCTION_ERROR;
         }
         
-        auto setPtr = (Set*)MArgument_getInteger(argv[0]);
+        const SetID setID = MArgument_getInteger(argv[0]);
+        
         try {
-            const auto ruleIDs = setPtr->eventRuleIDs();
+            const auto ruleIDs = setFromID(setID).eventRuleIDs();
             mint dimensions[1] = {static_cast<mint>(ruleIDs.size() - 1)};
             MTensor output;
             libData->MTensor_new(MType_Integer, 1, dimensions, &output);
             
-            int writeIndex = 0;
+            mint writeIndex = 0;
             mint position[1];
-            for (int event = 1; event < ruleIDs.size(); ++event) {
+            for (size_t event = 1; event < ruleIDs.size(); ++event) {
                 position[0] = ++writeIndex;
                 libData->MTensor_setInteger(output, position, ruleIDs[event] + 1);
             }


### PR DESCRIPTION
## Changes

* Closes #109.
* Closes #221.
* Makes C++ code check function arguments internally, so that it does not crash if incorrect arguments are passed.
* In line with that, fixes the atom index overflow issue, so that it is now possible to produce evolutions with more than `2^31` vertices/edges.

## Tests

* Does not affect functionality, evolution still works as expected:

```
In[] := WolframModel[{{x, y}, {x, z}} -> {{x, y}, {x, w}, {y, w}, {z, 
    w}}, {{1, 2}, {1, 3}}, 15, "FinalStatePlot"]
```

<img width="399" alt="image" src="https://user-images.githubusercontent.com/1479325/77573394-feff6b80-6ea6-11ea-98de-ddb4f6254f1b.png">