### PR TITLE
Hypergraph embedding optimization

### DIFF
--- a/Kernel/WolframModelPlot.m
+++ b/Kernel/WolframModelPlot.m
@@ -359,11 +359,16 @@ graphEmbedding[vertices_, vertexEmbeddingEdges_, edgeEmbeddingEdges_, layout_, c
 	relevantCoordinateRules = Normal[Merge[Select[MemberQ[vertices, #[[1]]] &][coordinateRules], Last]];
 	vertexCoordinateRules = If[vertexEmbeddingEdges === edgeEmbeddingEdges,
 		relevantCoordinateRules,
-		graphEmbedding[vertices, vertexEmbeddingEdges, layout, relevantCoordinateRules][[1]]
+		vertexEmbedding[vertices, vertexEmbeddingEdges, layout, relevantCoordinateRules]
 	];
 	unscaledEmbedding = graphEmbedding[vertices, edgeEmbeddingEdges, layout, vertexCoordinateRules];
 	rescaleEmbedding[unscaledEmbedding, relevantCoordinateRules]
 ]
+
+vertexEmbedding[vertices_, edges_, layout_, {}] := Thread[vertices -> GraphEmbedding[Graph[vertices, edges], layout]]
+
+vertexEmbedding[vertices_, edges_, layout_, coordinateRules_] :=
+	graphEmbedding[vertices, edges, layout, coordinateRules][[1]]
 
 graphEmbedding[vertices_, edges_, layout_, coordinateRules_] := Replace[
 	Reap[

--- a/Kernel/WolframModelPlot.m
+++ b/Kernel/WolframModelPlot.m
@@ -334,7 +334,7 @@ hypergraphEmbedding[
 		vertices, vertexEmbeddingNormalEdges, edgeEmbeddingNormalEdges},
 	vertices = vertexList[edges];
 	{vertexEmbeddingNormalEdges, edgeEmbeddingNormalEdges} =
-		(toNormalEdges[#] /@ edges) & /@ {vertexLayoutEdgeType, edgeLayoutEdgeType};
+		toNormalEdges[edges, #] & /@ {vertexLayoutEdgeType, edgeLayoutEdgeType};
 	normalToHypergraphEmbedding[
 		edges,
 		edgeEmbeddingNormalEdges,
@@ -346,13 +346,11 @@ hypergraphEmbedding[
 			coordinateRules]]
 ]
 
-toNormalEdges["Ordered"][hyperedge_] :=
-	DirectedEdge @@@ Partition[hyperedge, 2, 1]
+toNormalEdges[edges_, partitionArgs___] := DirectedEdge @@@ Partition[#, partitionArgs] & /@ edges
 
-toNormalEdges["Cyclic"][hyperedge : Except[{}]] :=
-	DirectedEdge @@@ Append[Partition[hyperedge, 2, 1], hyperedge[[{-1, 1}]]]
+toNormalEdges[edges_, "Ordered"] := toNormalEdges[edges, 2, 1]
 
-toNormalEdges["Cyclic"][{}] := {}
+toNormalEdges[edges_, "Cyclic"] := toNormalEdges[edges, 2, 1, 1]
 
 graphEmbedding[vertices_, vertexEmbeddingEdges_, edgeEmbeddingEdges_, layout_, coordinateRules_] := Module[{
 		relevantCoordinateRules, vertexCoordinateRules, unscaledEmbedding},


### PR DESCRIPTION
## Changes

* Improves performance of hypergraph embedding, and, therefore, `WolframModelPlot`.
* This is a situational improvement, which is only useful for simple graphs with no coordinates manually specified.

## Tests

* Before:

```
In[] := $SetReplaceGitSHA
Out[] = "6cf0cf9e103be67b99697e7a9b8356897411dd28"
```
```
In[] := state = WolframModel[{{x, y}, {x, z}} -> {{x, y}, {x, w}, {y, w}, {z, 
      w}}, {{1, 2}, {1, 3}}, 15, "FinalState"];
In[] := WolframModelPlot[state]
```

<img width="444" alt="Screen Shot 2020-03-26 at 02 42 47" src="https://user-images.githubusercontent.com/1479325/77617851-7b2b9a80-6f0b-11ea-8091-d7e3e6a291b8.png">

* With this PR (30% faster):

```
In[] := $SetReplaceGitSHA
Out[] = "dcb25ebc1f1bf3f1aecc979c97bbe0ec313f0a7b"
```
```
In[] := state = WolframModel[{{x, y}, {x, z}} -> {{x, y}, {x, w}, {y, w}, {z, 
      w}}, {{1, 2}, {1, 3}}, 15, "FinalState"];
In[] := WolframModelPlot[state]
```

<img width="444" alt="Screen Shot 2020-03-26 at 02 44 28" src="https://user-images.githubusercontent.com/1479325/77617928-b7f79180-6f0b-11ea-8739-54b3bdb27fba.png">

* `GraphPlot` is still much faster (2.6 times faster for this case):

```
In[] := GraphPlot[Rule @@@ state]
```

<img width="444" alt="Screen Shot 2020-03-26 at 02 47 00" src="https://user-images.githubusercontent.com/1479325/77618109-1290ed80-6f0c-11ea-8a28-79a6095404af.png">