### PR TITLE
Fix ambiguity in the interpretation of _...

### DIFF
--- a/Kernel/WolframModel.m
+++ b/Kernel/WolframModel.m
@@ -43,7 +43,7 @@ $WolframModelProperties::usage = usageString[
 
 
 SyntaxInformation[WolframModel] =
-	{"ArgumentsPattern" -> {_, _..., OptionsPattern[]}};
+	{"ArgumentsPattern" -> {_, _ ..., OptionsPattern[]}};
 
 
 (* ::Section:: *)


### PR DESCRIPTION
***Internal Wolfram commit, already merged on stash, but needs review here to be merged.***

Old parse of `_...` is `RepeatedNull[Blank[]]`
New parse of `_...` will be `Repeated[Optional[Blank[]]]`

So fix the ambiguity by introducing a space.