### PR TITLE
graphicsQ and checkGraphics

### DIFF
--- a/Kernel/testUtilities.m
+++ b/Kernel/testUtilities.m
@@ -2,6 +2,8 @@ Package["SetReplace`"]
 
 PackageScope["testUnevaluated"]
 PackageScope["testSymbolLeak"]
+PackageScope["checkGraphics"]
+PackageScope["graphicsQ"]
 
 (* VerificationTest should not directly appear here, as it is replaced by test.wls into other heads during evaluation.
     Use testHead argument instead. *)
@@ -29,3 +31,22 @@ testSymbolLeak[testHead_, expr_, opts___] :=
     0,
     opts
   ];
+
+(* UsingFrontEnd is necessary while running from wolframscript *)
+(* Flashes a new frontend window momentarily, but that is ok, because this function is mostly for use in the CI *)
+frontEndErrors[expr_] := UsingFrontEnd @ Module[{notebook, result},
+  notebook = CreateDocument[ExpressionCell[expr]];
+  result = MathLink`CallFrontEnd[FrontEnd`GetErrorsInSelectionPacket[notebook]];
+  NotebookClose[notebook];
+  result
+]
+
+checkGraphics::frontEndErrors := "Front End errors `2` generated for graphics `1`.";
+
+checkGraphics[graphics_] := With[{
+    errors = frontEndErrors[graphics]},
+  If[errors =!= {}, Message[checkGraphics::frontEndErrors, graphics, errors]];
+  graphics
+]
+
+graphicsQ[graphics_] := Head[graphics] === Graphics && frontEndErrors[graphics] === {}

--- a/Kernel/testUtilities.m
+++ b/Kernel/testUtilities.m
@@ -36,6 +36,7 @@ testSymbolLeak[testHead_, expr_, opts___] :=
 (* Flashes a new frontend window momentarily, but that is ok, because this function is mostly for use in the CI *)
 frontEndErrors[expr_] := UsingFrontEnd @ Module[{notebook, result},
   notebook = CreateDocument[ExpressionCell[expr]];
+  SelectionMove[notebook, All, Notebook];
   result = MathLink`CallFrontEnd[FrontEnd`GetErrorsInSelectionPacket[notebook]];
   NotebookClose[notebook];
   result

--- a/Kernel/testUtilities.m
+++ b/Kernel/testUtilities.m
@@ -41,12 +41,11 @@ frontEndErrors[expr_] := UsingFrontEnd @ Module[{notebook, result},
   result
 ]
 
-checkGraphics::frontEndErrors := "Front End errors `2` generated for graphics `1`.";
+checkGraphics::frontEndErrors := "``";
 
-checkGraphics[graphics_] := With[{
-    errors = frontEndErrors[graphics]},
-  If[errors =!= {}, Message[checkGraphics::frontEndErrors, graphics, errors]];
+checkGraphics[graphics_] := (
+  Message[checkGraphics::frontEndErrors, #] & /@ Flatten[frontEndErrors[graphics]];
   graphics
-]
+)
 
 graphicsQ[graphics_] := Head[graphics] === Graphics && frontEndErrors[graphics] === {}

--- a/Tests/RulePlot.wlt
+++ b/Tests/RulePlot.wlt
@@ -4,6 +4,8 @@
       Attributes[Global`testUnevaluated] = Attributes[Global`testSymbolLeak] = {HoldAll};
       Global`testUnevaluated[args___] := SetReplace`PackageScope`testUnevaluated[VerificationTest, args];
       Global`testSymbolLeak[args___] := SetReplace`PackageScope`testSymbolLeak[VerificationTest, args];
+      Global`checkGraphics[args___] := SetReplace`PackageScope`checkGraphics[args];
+      Global`graphicsQ[args___] := SetReplace`PackageScope`graphicsQ[args];
 
       $rulesForVertexSizeConsistency = {
         {{1}} -> {{1}},
@@ -58,8 +60,7 @@
       ],
 
       VerificationTest[
-        Head[RulePlot[WolframModel[{{1}} -> {{2}}]]],
-        Graphics
+        graphicsQ[RulePlot[WolframModel[{{1}} -> {{2}}]]]
       ],
 
       testUnevaluated[
@@ -68,8 +69,7 @@
       ],
 
       VerificationTest[
-        Head[RulePlot[WolframModel[{{1}} -> {{2}}, Method -> "$$$AnyMethod$$$"]]],
-        Graphics
+        graphicsQ[RulePlot[WolframModel[{{1}} -> {{2}}, Method -> "$$$AnyMethod$$$"]]]
       ],
 
       testUnevaluated[
@@ -83,8 +83,7 @@
       ],
 
       VerificationTest[
-        Head[RulePlot[WolframModel[{{{1}} -> {{2}}, {{1}} -> {{2}}}]]],
-        Graphics
+        graphicsQ[RulePlot[WolframModel[{{{1}} -> {{2}}, {{1}} -> {{2}}}]]]
       ],
 
       (* Options *)
@@ -92,8 +91,7 @@
       (** EdgeType **)
 
       VerificationTest[
-        Head[RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], "EdgeType" -> #]],
-        Graphics
+        graphicsQ[RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], "EdgeType" -> #]]
       ] & /@ {"Ordered", "Cyclic"},
 
       testUnevaluated[
@@ -116,7 +114,7 @@
       VerificationTest[
         With[{
             color = RGBColor[0.4, 0.6, 0.2]},
-          FreeQ[RulePlot[WolframModel[#], GraphHighlightStyle -> color], color] & /@
+          FreeQ[checkGraphics @ RulePlot[WolframModel[#], GraphHighlightStyle -> color], color] & /@
             {{{1}} -> {{2}}, {{1}} -> {{1}}, {{1, 2}} -> {{1, 2}}, {{1, 2}} -> {{2, 3}}, {{1, 2}} -> {{3, 4}}}],
         {True, False, False, False, True}
       ],
@@ -124,8 +122,7 @@
       (** HyperedgeRendering **)
 
       VerificationTest[
-        Head[RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], "HyperedgeRendering" -> #]],
-        Graphics
+        graphicsQ[RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], "HyperedgeRendering" -> #]]
       ] & /@ {"Subgraphs", "Polygons"},
 
       testUnevaluated[
@@ -143,7 +140,7 @@
       VerificationTest[
         SameQ @@
           Cases[
-            RulePlot[
+            checkGraphics @ RulePlot[
               WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}],
               VertexCoordinateRules -> {1 -> {0, 0}, 2 -> {1, 0}, 3 -> {2, 0}, 4 -> {3, 0}, 5 -> {4, 0}}],
             Disk[p_, _] :> p,
@@ -156,7 +153,7 @@
         Length[
             Union[
               Cases[
-                RulePlot[
+                checkGraphics @ RulePlot[
                   WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}],
                   VertexCoordinateRules -> {1 -> {0, 0}, 2 -> {0, 0}, 3 -> {0, 0}, 4 -> {0, 0}, 5 -> {0, 0}}],
                 Disk[p_, _] :> p,
@@ -165,8 +162,7 @@
       ],
 
       VerificationTest[
-        Head[RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], VertexCoordinateRules -> {}]],
-        Graphics
+        graphicsQ[RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], VertexCoordinateRules -> {}]]
       ],
 
       testUnevaluated[
@@ -177,19 +173,24 @@
       (** VertexLabels **)
 
       VerificationTest[
-        Sort[Cases[RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], VertexLabels -> Automatic], Text[i_, ___] :> i, All]],
+        Sort[Cases[
+          checkGraphics @ RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], VertexLabels -> Automatic],
+          Text[i_, ___] :> i,
+          All]],
         {1, 2, 3, 3, 4, 5}
       ],
 
       VerificationTest[
-        Length[Cases[RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], VertexLabels -> x], Text[x, ___], All]],
+        Length[Cases[
+          checkGraphics @ RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], VertexLabels -> x], Text[x, ___], All]],
         6
       ],
 
       (** Graphics **)
 
       VerificationTest[
-        Background /. AbsoluteOptions[RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], Background -> Black], Background],
+        Background /. AbsoluteOptions[
+          checkGraphics @ RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], Background -> Black], Background],
         Black,
         SameTest -> Equal
       ],
@@ -197,8 +198,7 @@
       (** Frame **)
 
       VerificationTest[
-        Head[RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], Frame -> #]],
-        Graphics
+        graphicsQ[RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], Frame -> #]]
       ] & /@ {False, True, Automatic},
 
       testUnevaluated[
@@ -211,7 +211,8 @@
       VerificationTest[
         MemberQ[
           Cases[
-            RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], FrameStyle -> RGBColor[0.33, 0.66, 0.77], Frame -> True][[1]],
+            checkGraphics @ RulePlot[
+              WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], FrameStyle -> RGBColor[0.33, 0.66, 0.77], Frame -> True][[1]],
             _ ? ColorQ,
             All],
           RGBColor[0.33, 0.66, 0.77]]
@@ -220,7 +221,8 @@
       VerificationTest[
         Not @ MemberQ[
           Cases[
-            RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], FrameStyle -> RGBColor[0.33, 0.66, 0.77], Frame -> False][[1]],
+            checkGraphics @ RulePlot[
+              WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], FrameStyle -> RGBColor[0.33, 0.66, 0.77], Frame -> False][[1]],
             _ ? ColorQ,
             All],
           RGBColor[0.33, 0.66, 0.77]]
@@ -230,28 +232,28 @@
 
       VerificationTest[
         MatchQ[
-          RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], PlotLegends -> "Text"],
+          checkGraphics @ RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], PlotLegends -> "Text"],
           Legended[_, Placed[StandardForm[{{1, 2, 3}} -> {{3, 4, 5}}], Below]]]
       ],
 
       VerificationTest[
-        MatchQ[RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], PlotLegends -> "test"], Legended[_, "test"]]
+        MatchQ[
+          checkGraphics @ RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], PlotLegends -> "test"],
+          Legended[_, "test"]]
       ],
 
       VerificationTest[
-        Not @ MatchQ[RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}]], Legended[___]]
+        Not @ MatchQ[checkGraphics @ RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}]], Legended[___]]
       ],
 
       (** Spacings **)
 
       VerificationTest[
-        Head[RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], Spacings -> #]],
-        Graphics
+        graphicsQ[RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], Spacings -> #]]
       ] & /@ {0, 1, {{1, 0}, {0, 0}}, {{0, 1}, {0, 0}}, {{0, 0}, {1, 0}}, {{0, 0}, {0, 1}}},
 
       VerificationTest[
-        Head[RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], Spacings -> #]],
-        Graphics
+        graphicsQ[RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], Spacings -> #]]
       ] & /@ {1, {{1, 1}, {1, 1}}},
 
       testUnevaluated[
@@ -271,21 +273,21 @@
       (** Vertex amplification **)
 
       VerificationTest[
-        First[Cases[RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}]], Disk[_, r_] :> r, All]] > 
-          First[Cases[WolframModelPlot[{{1, 2, 3}}], Disk[_, r_] :> r, All]]
+        First[Cases[checkGraphics @ RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}]], Disk[_, r_] :> r, All]] > 
+          First[Cases[checkGraphics @ WolframModelPlot[{{1, 2, 3}}], Disk[_, r_] :> r, All]]
       ],
 
       (** Consistent vertex sizes **)
 
       VerificationTest[
-        SameQ @@ Cases[RulePlot[WolframModel[#]], Disk[_, r_] :> r, All]
+        SameQ @@ Cases[checkGraphics @ RulePlot[WolframModel[#]], Disk[_, r_] :> r, All]
       ] & /@ $rulesForVertexSizeConsistency,
 
       (** Shared vertices are colored **)
 
       VerificationTest[
-        Cases[RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}]], _ ? ColorQ, All] =!=
-          Cases[RulePlot[WolframModel[{{1, 2, 3}} -> {{4, 5, 6}}]], _ ? ColorQ, All]
+        Cases[checkGraphics @ RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}]], _ ? ColorQ, All] =!=
+          Cases[checkGraphics @ RulePlot[WolframModel[{{1, 2, 3}} -> {{4, 5, 6}}]], _ ? ColorQ, All]
       ],
 
       (** RulePartsAspectRatio **)
@@ -305,19 +307,21 @@
         VerificationTest[
           SameQ @@ (ImageSizeRaw /.
               Options[
-                  RulePlot[WolframModel[rule], VertexCoordinateRules -> coordinatesNormal, "RulePartsAspectRatio" -> #],
+                  checkGraphics @ RulePlot[
+                    WolframModel[rule], VertexCoordinateRules -> coordinatesNormal, "RulePartsAspectRatio" -> #],
                   ImageSizeRaw] & /@
                 {0.01, 0.1})
         ],
 
         Function[coordinates, checkAspectRatio[
-            RulePlot[WolframModel[rule], VertexCoordinateRules -> coordinates, "RulePartsAspectRatio" -> #],
+            checkGraphics @ RulePlot[
+              WolframModel[rule], VertexCoordinateRules -> coordinates, "RulePartsAspectRatio" -> #],
             #,
             0.001,
             2] & /@
           {0.01, 0.1, 0.5, 0.8, 1, 1.2, 2, 10, 100}] /@ {coordinatesNormal, coordaintesSquare, coordinatesFlipped},
 
-        checkAspectRatio[RulePlot[WolframModel[rule], VertexCoordinateRules -> #1], #2, #3, 2] & @@@ {
+        checkAspectRatio[checkGraphics @ RulePlot[WolframModel[rule], VertexCoordinateRules -> #1], #2, #3, 2] & @@@ {
           {coordinatesNormal, 2 / 3, 0.1},
           {coordaintesSquare, 1, 0.1},
           {coordinatesFlipped, 2, 0.1},
@@ -326,13 +330,19 @@
 
         (* outer frame *)
         checkAspectRatio[
-            RulePlot[WolframModel[Table[rule, #]], Frame -> True, VertexCoordinateRules -> #2], #3, 0.1, 1] & @@@ {
+            checkGraphics @ RulePlot[WolframModel[Table[rule, #]], Frame -> True, VertexCoordinateRules -> #2],
+            #3,
+            0.1,
+            1] & @@@ {
           {1, coordinatesNormal, 1 / 3},
           {2, coordinatesNormal, 1 / 6},
           {1, coordaintesSquare, 1 / 2},
           {2, coordaintesSquare, 1 / 4},
           {3, coordaintesSquare, 1 / 6}}
       }]
+    },
+    "options" -> {
+      "Parallel" -> False
     }
   |>
 |>

--- a/Tests/WolframModelEvolutionObject.wlt
+++ b/Tests/WolframModelEvolutionObject.wlt
@@ -4,6 +4,8 @@
       Attributes[Global`testUnevaluated] = Attributes[Global`testSymbolLeak] = {HoldAll};
       Global`testUnevaluated[args___] := SetReplace`PackageScope`testUnevaluated[VerificationTest, args];
       Global`testSymbolLeak[args___] := SetReplace`PackageScope`testSymbolLeak[VerificationTest, args];
+      Global`checkGraphics[args___] := SetReplace`PackageScope`checkGraphics[args];
+      Global`graphicsQ[args___] := SetReplace`PackageScope`graphicsQ[args];
 
       $largeEvolution = Hold[WolframModel[
         {{0, 1}, {0, 2}, {0, 3}} ->
@@ -601,8 +603,7 @@
       (* FinalStatePlot *)
 
       VerificationTest[
-        Head[WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 3]["FinalStatePlot"]],
-        Graphics
+        graphicsQ[WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 3]["FinalStatePlot"]]
       ],
 
       With[{evo = WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 3]}, testUnevaluated[
@@ -617,7 +618,8 @@
 
       VerificationTest[
         AbsoluteOptions[
-          WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 3]["FinalStatePlot", ImageSize -> 123.],
+          checkGraphics @ WolframModel[
+            {{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 3]["FinalStatePlot", ImageSize -> 123.],
           ImageSize],
         {ImageSize -> 123.}
       ],
@@ -794,8 +796,8 @@
       (* StatesPlotsList *)
 
       VerificationTest[
-        Head /@ WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 3]["StatesPlotsList"],
-        ConstantArray[Graphics, 4]
+        graphicsQ /@ WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 3]["StatesPlotsList"],
+        ConstantArray[True, 4]
       ],
 
       With[{evo = WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 3]}, testUnevaluated[
@@ -810,7 +812,8 @@
 
       VerificationTest[
         AbsoluteOptions[#, ImageSize] & /@
-          WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 3]["StatesPlotsList", ImageSize -> 123.],
+          checkGraphics[WolframModel[
+            {{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 3]["StatesPlotsList", ImageSize -> 123.]],
         ConstantArray[{ImageSize -> 123.}, 4]
       ],
 
@@ -1322,20 +1325,20 @@
       (* EventsStatesPlotsList *)
 
       VerificationTest[
-        Head /@ WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 3]["EventsStatesPlotsList"],
-        ConstantArray[Graphics, WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 3, "EventsCount"] + 1]
+        graphicsQ /@ WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 3]["EventsStatesPlotsList"],
+        ConstantArray[True, WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 3, "EventsCount"] + 1]
       ],
 
       VerificationTest[
-        Head /@ WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 3][
+        graphicsQ /@ WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 3][
           "EventsStatesPlotsList", "IncludeBoundaryEvents" -> All],
-        ConstantArray[Graphics, WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 3, "EventsCount"] + 1]
+        ConstantArray[True, WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 3, "EventsCount"] + 1]
       ],
 
       VerificationTest[
-        Head /@ WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 0][
+        graphicsQ /@ WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 0][
           "EventsStatesPlotsList", "IncludeBoundaryEvents" -> #],
-        {Graphics}
+        {True}
       ] & /@ {None, "Initial", "Final", All},
 
       With[{evo = WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 3]}, testUnevaluated[
@@ -1350,7 +1353,8 @@
 
       VerificationTest[
         AbsoluteOptions[#, ImageSize] & /@
-          WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 1]["EventsStatesPlotsList", ImageSize -> 123.],
+          checkGraphics @ WolframModel[
+            {{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 1]["EventsStatesPlotsList", ImageSize -> 123.],
         ConstantArray[{ImageSize -> 123.}, 2]
       ],
 
@@ -1363,6 +1367,9 @@
         evo["EventsStatesPlotsList", VertexSize -> x],
         {WolframModelPlot::invalidSize}
       ]]
-    }]
+    }],
+    "options" -> {
+      "Parallel" -> False
+    }
   |>
 |>

--- a/Tests/WolframModelEvolutionObject.wlt
+++ b/Tests/WolframModelEvolutionObject.wlt
@@ -4,8 +4,6 @@
       Attributes[Global`testUnevaluated] = Attributes[Global`testSymbolLeak] = {HoldAll};
       Global`testUnevaluated[args___] := SetReplace`PackageScope`testUnevaluated[VerificationTest, args];
       Global`testSymbolLeak[args___] := SetReplace`PackageScope`testSymbolLeak[VerificationTest, args];
-      Global`checkGraphics[args___] := SetReplace`PackageScope`checkGraphics[args];
-      Global`graphicsQ[args___] := SetReplace`PackageScope`graphicsQ[args];
 
       $largeEvolution = Hold[WolframModel[
         {{0, 1}, {0, 2}, {0, 3}} ->
@@ -600,40 +598,6 @@
         {}
       ],
 
-      (* FinalStatePlot *)
-
-      VerificationTest[
-        graphicsQ[WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 3]["FinalStatePlot"]]
-      ],
-
-      With[{evo = WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 3]}, testUnevaluated[
-        evo["FinalStatePlot", "$$$invalid$$$"],
-        {WolframModelEvolutionObject::nonopt}
-      ]],
-
-      With[{evo = WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 3]}, testUnevaluated[
-        evo["FinalStatePlot", "$$$invalid$$$" -> 3],
-        {WolframModelEvolutionObject::optx}
-      ]],
-
-      VerificationTest[
-        AbsoluteOptions[
-          checkGraphics @ WolframModel[
-            {{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 3]["FinalStatePlot", ImageSize -> 123.],
-          ImageSize],
-        {ImageSize -> 123.}
-      ],
-
-      testUnevaluated[
-        WolframModel[1 -> 2, {1}, 2, "FinalStatePlot"],
-        {WolframModel::nonHypergraphPlot}
-      ],
-
-      With[{evo = WolframModel[{{1, 2}} -> {{1, 3}, {3, 2}}, {{1, 1}}, <|"MaxEvents" -> 30|>]}, testUnevaluated[
-        evo["FinalStatePlot", VertexSize -> x],
-        {WolframModelPlot::invalidSize}
-      ]],
-
       (* UpdatedStatesList *)
 
       VerificationTest[
@@ -792,40 +756,6 @@
           2]["StatesList"],
         {{{1, 2}, {2, 3}}, {}}
       ],
-
-      (* StatesPlotsList *)
-
-      VerificationTest[
-        graphicsQ /@ WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 3]["StatesPlotsList"],
-        ConstantArray[True, 4]
-      ],
-
-      With[{evo = WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 3]}, testUnevaluated[
-        evo["StatesPlotsList", "$$$invalid$$$"],
-        {WolframModelEvolutionObject::nonopt}
-      ]],
-
-      With[{evo = WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 3]}, testUnevaluated[
-        evo["StatesPlotsList", "$$$invalid$$$" -> 3],
-        {WolframModelEvolutionObject::optx}
-      ]],
-
-      VerificationTest[
-        AbsoluteOptions[#, ImageSize] & /@
-          checkGraphics[WolframModel[
-            {{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 3]["StatesPlotsList", ImageSize -> 123.]],
-        ConstantArray[{ImageSize -> 123.}, 4]
-      ],
-
-      testUnevaluated[
-        WolframModel[1 -> 2, {1}, 2, "StatesPlotsList"],
-        {WolframModel::nonHypergraphPlot}
-      ],
-
-      With[{evo = WolframModel[{{1, 2}} -> {{1, 3}, {3, 2}}, {{1, 1}}, <|"MaxEvents" -> 30|>]}, testUnevaluated[
-        evo["StatesPlotsList", VertexSize -> x],
-        {WolframModelPlot::invalidSize}
-      ]],
 
       (* AtomsCountFinal *)
 
@@ -1320,7 +1250,85 @@
           {{1, {3} -> {6, 7}}, {4, 5, 6, 7}},
           {{DirectedInfinity[1], {4, 5, 6, 7} -> {}}, {}}
         }
+      ]
+    }]
+  |>,
+
+  "WolframModelEvolutionObjectGraphics" -> <|
+    "init" -> (
+      Attributes[Global`testUnevaluated] = {HoldAll};
+      Global`testUnevaluated[args___] := SetReplace`PackageScope`testUnevaluated[VerificationTest, args];
+      Global`checkGraphics[args___] := SetReplace`PackageScope`checkGraphics[args];
+      Global`graphicsQ[args___] := SetReplace`PackageScope`graphicsQ[args];
+    ),
+    "tests" -> {
+      (* FinalStatePlot *)
+
+      VerificationTest[
+        graphicsQ[WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 3]["FinalStatePlot"]]
       ],
+
+      With[{evo = WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 3]}, testUnevaluated[
+        evo["FinalStatePlot", "$$$invalid$$$"],
+        {WolframModelEvolutionObject::nonopt}
+      ]],
+
+      With[{evo = WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 3]}, testUnevaluated[
+        evo["FinalStatePlot", "$$$invalid$$$" -> 3],
+        {WolframModelEvolutionObject::optx}
+      ]],
+
+      VerificationTest[
+        AbsoluteOptions[
+          checkGraphics @ WolframModel[
+            {{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 3]["FinalStatePlot", ImageSize -> 123.],
+          ImageSize],
+        {ImageSize -> 123.}
+      ],
+
+      testUnevaluated[
+        WolframModel[1 -> 2, {1}, 2, "FinalStatePlot"],
+        {WolframModel::nonHypergraphPlot}
+      ],
+
+      With[{evo = WolframModel[{{1, 2}} -> {{1, 3}, {3, 2}}, {{1, 1}}, <|"MaxEvents" -> 30|>]}, testUnevaluated[
+        evo["FinalStatePlot", VertexSize -> x],
+        {WolframModelPlot::invalidSize}
+      ]],
+
+      (* StatesPlotsList *)
+
+      VerificationTest[
+        graphicsQ /@ WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 3]["StatesPlotsList"],
+        ConstantArray[True, 4]
+      ],
+
+      With[{evo = WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 3]}, testUnevaluated[
+        evo["StatesPlotsList", "$$$invalid$$$"],
+        {WolframModelEvolutionObject::nonopt}
+      ]],
+
+      With[{evo = WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 3]}, testUnevaluated[
+        evo["StatesPlotsList", "$$$invalid$$$" -> 3],
+        {WolframModelEvolutionObject::optx}
+      ]],
+
+      VerificationTest[
+        AbsoluteOptions[#, ImageSize] & /@
+          checkGraphics[WolframModel[
+            {{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 3]["StatesPlotsList", ImageSize -> 123.]],
+        ConstantArray[{ImageSize -> 123.}, 4]
+      ],
+
+      testUnevaluated[
+        WolframModel[1 -> 2, {1}, 2, "StatesPlotsList"],
+        {WolframModel::nonHypergraphPlot}
+      ],
+
+      With[{evo = WolframModel[{{1, 2}} -> {{1, 3}, {3, 2}}, {{1, 1}}, <|"MaxEvents" -> 30|>]}, testUnevaluated[
+        evo["StatesPlotsList", VertexSize -> x],
+        {WolframModelPlot::invalidSize}
+      ]],
 
       (* EventsStatesPlotsList *)
 
@@ -1367,7 +1375,7 @@
         evo["EventsStatesPlotsList", VertexSize -> x],
         {WolframModelPlot::invalidSize}
       ]]
-    }],
+    },
     "options" -> {
       "Parallel" -> False
     }

--- a/Tests/WolframModelPlot.wlt
+++ b/Tests/WolframModelPlot.wlt
@@ -63,6 +63,9 @@
 
       testColorPresence[args___] := testColor[True, args];
     ),
+    "options" -> {
+      "Parallel" -> False
+    },
     "tests" -> {
       (* Symbol Leak *)
 
@@ -665,9 +668,6 @@
         {EdgeStyle -> Red},
         {VertexCoordinateRules -> {3 -> {0, 0}, 4 -> {1, 0}}}
       }
-    },
-    "options" -> {
-      "Parallel" -> False
     }
   |>
 |>

--- a/Tests/WolframModelPlot.wlt
+++ b/Tests/WolframModelPlot.wlt
@@ -1,6 +1,12 @@
 <|
   "WolframModelPlot" -> <|
     "init" -> (
+      Attributes[Global`testUnevaluated] = Attributes[Global`testSymbolLeak] = {HoldAll};
+      Global`testUnevaluated[args___] := SetReplace`PackageScope`testUnevaluated[VerificationTest, args];
+      Global`testSymbolLeak[args___] := SetReplace`PackageScope`testSymbolLeak[VerificationTest, args];
+      Global`checkGraphics[args___] := SetReplace`PackageScope`checkGraphics[args];
+      Global`graphicsQ[args___] := SetReplace`PackageScope`graphicsQ[args];
+
       $edgeTypes = {"Ordered", "Cyclic"};
 
       $simpleHypergraphs = {
@@ -33,10 +39,6 @@
         Missing[],
         All];
 
-      Attributes[Global`testUnevaluated] = Attributes[Global`testSymbolLeak] = {HoldAll};
-      Global`testUnevaluated[args___] := SetReplace`PackageScope`testUnevaluated[VerificationTest, args];
-      Global`testSymbolLeak[args___] := SetReplace`PackageScope`testSymbolLeak[VerificationTest, args];
-
       {color, color2, color3, color4, color5} =
         BlockRandom[Table[RGBColor[RandomReal[{0, 1}, 3]], 5], RandomSeeding -> 0];
 
@@ -50,7 +52,7 @@
         Outer[
           VerificationTest[
             With[{
-                plot = WolframModelPlot[set, #1, "HyperedgeRendering" -> #2, Sequence @@ opts]},
+                plot = checkGraphics @ WolframModelPlot[set, #1, "HyperedgeRendering" -> #2, Sequence @@ opts]},
               And @@ (If[shouldExistQ, Not, Identity][FreeQ[plot, #]] & /@ colors)
             ]
           ] &,
@@ -106,9 +108,8 @@
       ],
 
       VerificationTest[
-        WolframModelPlot[{{}}],
-        {_Graphics},
-        SameTest -> MatchQ
+        graphicsQ /@ WolframModelPlot[{{}}],
+        {True}
       ],
 
       testUnevaluated[
@@ -161,13 +162,11 @@
       ],
 
       VerificationTest[
-        Head[WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, "Ordered"]],
-        Graphics
+        graphicsQ[WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, "Ordered"]]
       ],
 
       VerificationTest[
-        Head[WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, "Cyclic"]],
-        Graphics
+        graphicsQ[WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, "Cyclic"]]
       ],
 
       (* Valid options *)
@@ -205,13 +204,11 @@
       ],
 
       VerificationTest[
-        Head[WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, VertexCoordinateRules -> {1 -> {0, 0}}]],
-        Graphics
+        graphicsQ[WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, VertexCoordinateRules -> {1 -> {0, 0}}]]
       ],
 
       VerificationTest[
-        Head[WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, "Ordered", VertexCoordinateRules -> {1 -> {0, 0}}]],
-        Graphics
+        graphicsQ[WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, "Ordered", VertexCoordinateRules -> {1 -> {0, 0}}]]
       ],
 
       (* Valid GraphHighlight *)
@@ -222,38 +219,31 @@
       ],
 
       VerificationTest[
-        Head[WolframModelPlot[{{1, 2, 3}, {1, 2, 3}}, GraphHighlight -> {{1, 2, 3}}]],
-        Graphics
+        graphicsQ[WolframModelPlot[{{1, 2, 3}, {1, 2, 3}}, GraphHighlight -> {{1, 2, 3}}]]
       ],
 
       VerificationTest[
-        Head[WolframModelPlot[{{1, 2, 3}, {1, 2, 3}}, GraphHighlight -> {6}]],
-        Graphics
+        graphicsQ[WolframModelPlot[{{1, 2, 3}, {1, 2, 3}}, GraphHighlight -> {6}]]
       ],
 
       VerificationTest[
-        Head[WolframModelPlot[{{1, 2, 3}, {1, 2, 3}}, GraphHighlight -> {{1, 2}}]],
-        Graphics
+        graphicsQ[WolframModelPlot[{{1, 2, 3}, {1, 2, 3}}, GraphHighlight -> {{1, 2}}]]
       ],
 
       VerificationTest[
-        Head[WolframModelPlot[{{1, 2, 3}, {1, 2, 3}}, GraphHighlight -> {{1, 2, 3}, {1, 2, 3}}]],
-        Graphics
+        graphicsQ[WolframModelPlot[{{1, 2, 3}, {1, 2, 3}}, GraphHighlight -> {{1, 2, 3}, {1, 2, 3}}]]
       ],
 
       VerificationTest[
-        Head[WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {1}]],
-        Graphics
+        graphicsQ[WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {1}]]
       ],
 
       VerificationTest[
-        Head[WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {{1, 2, 3}}]],
-        Graphics
+        graphicsQ[WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {{1, 2, 3}}]]
       ],
 
       VerificationTest[
-        Head[WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {4, {1, 2, 3}}]],
-        Graphics
+        graphicsQ[WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {4, {1, 2, 3}}]]
       ],
 
       (* Valid GraphHighlightStyle *)
@@ -274,8 +264,7 @@
       ],
 
       VerificationTest[
-        Head[WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {1}, GraphHighlightStyle -> Black]],
-        Graphics
+        graphicsQ[WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {1}, GraphHighlightStyle -> Black]]
       ],
 
       (* Valid VertexSize and "ArrowheadLength" *)
@@ -292,26 +281,22 @@
         ],
 
         VerificationTest[
-          Head[WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, # -> 1]],
-          Graphics
+          graphicsQ[WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, # -> 1]]
         ]
       } & /@ {VertexSize, "ArrowheadLength"},
 
       VerificationTest[
-        Head[WolframModelPlot[#, "ArrowheadLength" -> Automatic]],
-        Graphics
+        graphicsQ[WolframModelPlot[#, "ArrowheadLength" -> Automatic]]
       ] & /@ {{{1, 2, 3}, {3, 4, 5}}, {{1, 1}}, {{1}}, {}},
 
       (* HypergraphPlot can still be used *)
 
       VerificationTest[
-        Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}]],
-        Graphics
+        graphicsQ[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}]]
       ],
 
       VerificationTest[
-        Head[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "Ordered"]],
-        Graphics
+        graphicsQ[HypergraphPlot[{{1, 2, 3}, {3, 4, 5}}, "Ordered"]]
       ],
 
       (* Implementation *)
@@ -319,32 +304,31 @@
       (** Simple examples **)
 
       Table[With[{hypergraph = hypergraph}, VerificationTest[
-        Head[WolframModelPlot[hypergraph, #]],
-        Graphics
+        graphicsQ[WolframModelPlot[hypergraph, #]]
       ]] & /@ $edgeTypes, {hypergraph, $simpleHypergraphs}],
 
       (** Large graphs **)
 
       VerificationTest[
-        Head @ WolframModelPlot @ SetReplace[
+        graphicsQ @ WolframModelPlot @ SetReplace[
           {{0, 1}, {0, 2}, {0, 3}},
           ToPatternRules[
             {{0, 1}, {0, 2}, {0, 3}} ->
             {{4, 5}, {5, 4}, {4, 6}, {6, 4},
               {5, 6}, {6, 5}, {4, 1}, {5, 2}, {6, 3}}],
-          #],
-        Graphics
+          #]
       ] & /@ {10, 5000},
 
       (* EdgeType *)
 
       VerificationTest[
-        diskCoordinates[WolframModelPlot[#, "Ordered"]] != diskCoordinates[WolframModelPlot[#, "Cyclic"]]
+        diskCoordinates[checkGraphics @ WolframModelPlot[#, "Ordered"]] !=
+          diskCoordinates[checkGraphics @ WolframModelPlot[#, "Cyclic"]]
       ] & /@ $layoutTestHypergraphs,
 
       VerificationTest[
         Length[Union[Cases[
-          WolframModelPlot[#, "HyperedgeRendering" -> "Subgraphs", "ArrowheadLength" -> 0],
+          checkGraphics @ WolframModelPlot[#, "HyperedgeRendering" -> "Subgraphs", "ArrowheadLength" -> 0],
           Polygon[___],
           All]]],
         0
@@ -352,7 +336,7 @@
 
       VerificationTest[
         Length[Union[Cases[
-          WolframModelPlot[#, "HyperedgeRendering" -> "Polygons", "ArrowheadLength" -> 0],
+          checkGraphics @ WolframModelPlot[#, "HyperedgeRendering" -> "Polygons", "ArrowheadLength" -> 0],
           Polygon[___],
           All]]],
         0 + Length[#]
@@ -362,7 +346,7 @@
 
       VerificationTest[
         MissingQ[FirstCase[
-          WolframModelPlot[#, VertexLabels -> None],
+          checkGraphics @ WolframModelPlot[#, VertexLabels -> None],
           Text[___],
           Missing[],
           All]]
@@ -370,7 +354,7 @@
 
       VerificationTest[
         !MissingQ[FirstCase[
-          WolframModelPlot[#, VertexLabels -> Automatic],
+          checkGraphics @ WolframModelPlot[#, VertexLabels -> Automatic],
           Text[___],
           Missing[],
           All]]
@@ -379,12 +363,12 @@
       (* Single-vertex edges *)
 
       VerificationTest[
-        WolframModelPlot[{{1}, {1, 2}}] =!= WolframModelPlot[{{1, 2}}]
+        checkGraphics @ WolframModelPlot[{{1}, {1, 2}}] =!= checkGraphics @ WolframModelPlot[{{1, 2}}]
       ],
 
       VerificationTest[
         MissingQ[FirstCase[
-          WolframModelPlot[{{1, 2}}, VertexLabels -> None],
+          checkGraphics @ WolframModelPlot[{{1, 2}}, VertexLabels -> None],
           Circle[___],
           Missing[],
           All]]
@@ -392,7 +376,7 @@
 
       VerificationTest[
         !MissingQ[FirstCase[
-          WolframModelPlot[{{1}, {1, 2}}, VertexLabels -> Automatic],
+          checkGraphics @ WolframModelPlot[{{1}, {1, 2}}, VertexLabels -> Automatic],
           Circle[___],
           Missing[],
           All]]
@@ -402,7 +386,7 @@
 
       VerificationTest[
         And @@ (MemberQ[
-            diskCoordinates[WolframModelPlot[
+            diskCoordinates[checkGraphics @ WolframModelPlot[
               {{1, 2, 3}, {3, 4, 5}, {3, 3}},
               VertexCoordinateRules -> {1 -> {0, 0}, 2 -> {1, 0}}]],
             #] & /@
@@ -410,13 +394,13 @@
       ],
 
       VerificationTest[
-        Chop @ diskCoordinates[WolframModelPlot[
+        Chop @ diskCoordinates[checkGraphics @ WolframModelPlot[
           {{1, 2, 3}, {3, 4, 5}},
           VertexCoordinateRules -> {3 -> {0, 0}}]] != Table[{0, 0}, 5]
       ],
 
       VerificationTest[
-        Chop @ diskCoordinates[WolframModelPlot[
+        Chop @ diskCoordinates[checkGraphics @ WolframModelPlot[
           {{1, 2, 3}, {3, 4, 5}},
           VertexCoordinateRules -> {3 -> {1, 0}, 3 -> {0, 0}}]] != Table[{0, 0}, 5]
       ],
@@ -424,7 +408,7 @@
       (** Same coordinates should not produce any messages **)
       VerificationTest[
         And @@ Cases[
-          WolframModelPlot[{{1, 2, 3}}, VertexCoordinateRules -> {1 -> {1, 0}, 2 -> {1, 0}}],
+          checkGraphics @ WolframModelPlot[{{1, 2, 3}}, VertexCoordinateRules -> {1 -> {1, 0}, 2 -> {1, 0}}],
           Rotate[_, {v1_, v2_}] :> v1 != {0, 0} && v2 != {0, 0},
           All]
       ],
@@ -552,32 +536,31 @@
       testColorAbsense[{{1}, {1, 2}, {2, 3, 4}}, {GraphHighlight -> {5}, GraphHighlightStyle -> color}, {color}],
 
       VerificationTest[
-        Head[WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, VertexSize -> 0.3]],
-        Graphics
+        graphicsQ[WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, VertexSize -> 0.3]]
       ],
 
       VerificationTest[
-        Head[WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, "ArrowheadLength" -> 0.3]],
-        Graphics
+        graphicsQ[WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, "ArrowheadLength" -> 0.3]]
       ],
 
       VerificationTest[
-        Head[WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, VertexSize -> 0.4, "ArrowheadLength" -> 0.3]],
-        Graphics
+        graphicsQ[WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, VertexSize -> 0.4, "ArrowheadLength" -> 0.3]]
       ],
 
       (* GraphHighlight *)
 
       VerificationTest[
-        Length[Union @ Cases[WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {#}], _ ? ColorQ, All]] >
-          Length[Union @ Cases[WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}], _ ? ColorQ, All]]
+        Length[Union @ Cases[
+            checkGraphics @ WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {#}], _ ? ColorQ, All]] >
+          Length[Union @ Cases[checkGraphics @ WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}], _ ? ColorQ, All]]
       ] & /@ {4, {1, 2, 3}},
 
       (** Test multi-edge highlighting **)
       VerificationTest[
         Differences[
           Length[Union[Cases[#, _?ColorQ, All]]] & /@
-            (WolframModelPlot[{{1, 2}, {1, 2}}, "HyperedgeRendering" -> "Subgraphs", GraphHighlight -> #] &) /@
+            (checkGraphics[WolframModelPlot[
+              {{1, 2}, {1, 2}}, "HyperedgeRendering" -> "Subgraphs", GraphHighlight -> #]] &) /@
             {{}, {{1, 2}}, {{1, 2}, {1, 2}}}],
         {1, -1}
       ],
@@ -587,7 +570,10 @@
       VerificationTest[
         With[{
             color = RGBColor[0.4, 0.6, 0.2]},
-          FreeQ[WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> #, GraphHighlightStyle -> color], color] & /@
+          FreeQ[
+              checkGraphics @ WolframModelPlot[
+                {{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> #, GraphHighlightStyle -> color],
+              color] & /@
             {{}, {4}, {{1, 2, 3}}}],
         {True, False, False}
       ],
@@ -597,7 +583,7 @@
 
       VerificationTest[
         SameQ @@ (
-          Union[Cases[WolframModelPlot[#], Disk[_, r_] :> r, All]] & /@
+          Union[Cases[checkGraphics @ WolframModelPlot[#], Disk[_, r_] :> r, All]] & /@
             {{{1}}, {{1, 2, 3}}, {{1, 2, 3}, {3, 4, 5}}, RandomInteger[10, {5, 5}]})
       ],
 
@@ -605,7 +591,7 @@
         VerificationTest[
           Length[DeleteDuplicates[
             Mean[Cases[
-                WolframModelPlot[#, "HyperedgeRendering" -> "Subgraphs"],
+                checkGraphics @ WolframModelPlot[#, "HyperedgeRendering" -> "Subgraphs"],
                 Line[pts_] :> EuclideanDistance @@ pts,
                 All]] & /@
               {{{1, 2}}, {{1, 2, 3}}, {{1, 2, 3}, {3, 4, 5}}, {{1, 2, 3}, {3, 4, 5}, {5, 6, 1}}, {{1, 2, 3, 4, 5, 1}}},
@@ -619,7 +605,7 @@
                 First[
                   Nearest[
                     Cases[
-                      WolframModelPlot[#, "HyperedgeRendering" -> "Subgraphs"],
+                      checkGraphics @ WolframModelPlot[#, "HyperedgeRendering" -> "Subgraphs"],
                       Line[pts_] :> RegionMeasure[Line[pts]],
                       All],
                     $selfLoopLength]] -
@@ -634,7 +620,7 @@
 
       (* Automatic image size *)
       VerificationTest[
-        Table[OrderedQ[(ImageSizeRaw /. AbsoluteOptions[WolframModelPlot[#], ImageSizeRaw])[[k, 1]] & /@
+        Table[OrderedQ[(ImageSizeRaw /. AbsoluteOptions[checkGraphics @ WolframModelPlot[#], ImageSizeRaw])[[k, 1]] & /@
           {{{1}}, {{1, 1}}, {{1, 2, 3}, {3, 4, 5}, {5, 6, 1}}, {{1, 2, 3}, {3, 4, 5}, {5, 6, 7}, {7, 8, 1}}}], {k, 2}],
         {True, True}
       ],
@@ -647,7 +633,7 @@
       VerificationTest[
         With[{
             sizes = (ImageSize /. AbsoluteOptions[#, ImageSize][[1]] & /@
-              WolframModel[{{x, y}, {y, z}} -> {{w, y}, {y, z}, {z, w}, {x, w}}, {{0, 0}, {0, 0}}, 10][
+              checkGraphics /@ WolframModel[{{x, y}, {y, z}} -> {{w, y}, {y, z}, {z, w}, {x, w}}, {{0, 0}, {0, 0}}, 10][
                 "StatesPlotsList", "MaxImageSize" -> #]) & /@ {100, 200}},
           AllTrue[sizes[[1]], # < 100.0001 &] &&
           !AllTrue[sizes[[1]], # > 99.9999 &] &&
@@ -658,7 +644,7 @@
       VerificationTest[
         With[{
             sizes = (ImageSize /. AbsoluteOptions[#, ImageSize][[1]] & /@
-              WolframModel[{{x, y}, {y, z}} -> {{w, y}, {y, z}, {z, w}, {x, w}}, {{0, 0}, {0, 0}}, 10][
+              checkGraphics /@ WolframModel[{{x, y}, {y, z}} -> {{w, y}, {y, z}, {z, w}, {x, w}}, {{0, 0}, {0, 0}}, 10][
                 "StatesPlotsList", "MaxImageSize" -> #]) & /@ {{100, 30}, {200, 60}}},
           AllTrue[sizes[[1, All, 1]], # < 100.0001 &] &&
           AllTrue[sizes[[1, All, 2]], # < 30.0001 &] &&
@@ -670,8 +656,8 @@
 
       (* Multiple hypergraphs *)
       VerificationTest[
-        Head /@ WolframModelPlot[{{{1, 2, 3}, {3, 4, 5}}, {{3, 4, 5}, {5, 6, 7}}, {{5, 6, 7}, {7, 8, 5}}}, ##],
-        {Graphics, Graphics, Graphics}
+        graphicsQ /@ WolframModelPlot[{{{1, 2, 3}, {3, 4, 5}}, {{3, 4, 5}, {5, 6, 7}}, {{5, 6, 7}, {7, 8, 5}}}, ##],
+        ConstantArray[True, 3]
       ] & @@@ {
         {},
         {GraphHighlight -> {3, {3, 4, 5}}},
@@ -679,6 +665,9 @@
         {EdgeStyle -> Red},
         {VertexCoordinateRules -> {3 -> {0, 0}, 4 -> {1, 0}}}
       }
+    },
+    "options" -> {
+      "Parallel" -> False
     }
   |>
 |>


### PR DESCRIPTION
## Changes
* Implements `graphicsQ` and `checkGraphics` functions.
* Both of these functions check if a given `Graphics` object would generate front-end errors (pink background ones) if displayed in the Front End.
* `graphicsQ` simply returns `True` if the given `Graphics` object is valid, and `False` otherwise.
* And `checkGraphics` prints all front-end errors as ordinary messages, and returns the `Graphics` back. This is useful to insert inside other tests without changing their structure.
* Both of these functions momentarily flash a new front-end window, but that is ok because these are meant to be used mostly on a CI server.

## Comments
* This is ***critical*** because it catches #279, it cannot be merged until both #280 and the fix for #279 are merged.
* Most of this PR are just insertions of `graphicsQ` and `checkGraphics` in all relevant tests. The only non-trivial part is the changes to `Kernel/testUtilities.m`

## Tests
* A valid `Graphics` object will yield `True` in `graphicsQ`:
```
In[] := SetReplace`PackageScope`graphicsQ[Graphics[Circle[]]]
Out[] = True
```

* `checkGraphics` will just echo back the `Graphics`:
```
In[] := SetReplace`PackageScope`checkGraphics[Graphics[Circle[]]]
```
<img width="399" alt="image" src="https://user-images.githubusercontent.com/1479325/77860528-e14f4080-71dd-11ea-9183-b7f478e1586f.png">

* `graphicsQ` yields `False` for an invalid `Graphics`:
```
In[] := SetReplace`PackageScope`graphicsQ[Graphics[Circle[123]]]
Out[] = False
```

* `checkGraphics` prints the actual error message:
```
In[] := SetReplace`PackageScope`checkGraphics[Graphics[Circle[123]]]
```
<img width="445" alt="image" src="https://user-images.githubusercontent.com/1479325/77860712-95e96200-71de-11ea-9fda-e7f407097c9f.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/281)
<!-- Reviewable:end -->
