### PR TITLE
Fix style inheritance

### DIFF
--- a/Kernel/WolframModelPlot.m
+++ b/Kernel/WolframModelPlot.m
@@ -197,10 +197,8 @@ toListStyleSpec[spec_Association, elements_] := Replace[elements, Reverse[Join[{
 
 toListStyleSpec[spec_List, _] := spec
 
-parseStyles[newSpec : Except[_List | _Association], elements_, Automatic, oldToNewTransform_] := newSpec
-
 parseStyles[newSpec_, elements_, oldSpec_, oldToNewTransform_] /;
-		AllTrue[{oldSpec, newSpec}, MatchQ[#, _List | _Association | Automatic] &] :=
+		AnyTrue[{oldSpec, newSpec}, MatchQ[#, _List | _Association] &] :=
 	MapThread[
 		If[#2 === Automatic, #1, Replace[#1, Automatic -> oldToNewTransform[#2]]] &,
 		toListStyleSpec[#, elements] & /@ {newSpec, oldSpec}]

--- a/Tests/WolframModelPlot.wlt
+++ b/Tests/WolframModelPlot.wlt
@@ -688,6 +688,32 @@
           {GraphHighlight -> {2}, GraphHighlightStyle -> color1, VertexStyle -> color2},
           {color1, color2}
         ]
+      ],
+
+      (* Style inheritance *)
+      SeedRandom[288];
+      With[{
+          colors = Table[RandomColor[5]], edgeColor = RandomColor[], extraColor = RandomColor[],
+          set = {{1, 2, 3}, {3, 4, 5}}},
+        {testColorPresence[set, #, #2, Replace[#4, All -> Sequence[]]],
+            testColorAbsense[set, #, #3, Replace[#4, All -> Sequence[]]]} & @@@ {
+          {{PlotStyle -> colors[[1]], EdgeStyle -> edgeColor, VertexStyle -> colors[[2]]},          {colors[[2]]},    {colors[[1]]}, All},
+          {{PlotStyle -> colors[[1]], EdgeStyle -> edgeColor, VertexStyle -> Automatic},            {colors[[1]]},    {},            All},
+          {{PlotStyle -> colors[[1]], EdgeStyle -> edgeColor, VertexStyle -> <|3 -> colors[[2]]|>}, colors[[1 ;; 2]], {},            All},
+          {{PlotStyle -> extraColor,  EdgeStyle -> edgeColor, VertexStyle -> colors},               colors,           {extraColor},  All},
+          {{PlotStyle -> Automatic,                           VertexStyle -> colors[[1]]},          {colors[[1]]},    {},            All},
+          {{PlotStyle -> Automatic,                           VertexStyle -> Automatic},            {},               {},            All},
+          {{PlotStyle -> Automatic,                           VertexStyle -> <|3 -> colors[[1]]|>}, {colors[[1]]},    {},            All},
+          {{PlotStyle -> Automatic,                           VertexStyle -> colors},               colors,           {},            All},
+          {{PlotStyle -> <|3 -> colors[[1]]|>,                VertexStyle -> colors[[2]]},          {colors[[2]]},    {colors[[1]]}, All},
+          {{PlotStyle -> <|3 -> colors[[1]]|>,                VertexStyle -> Automatic},            {colors[[1]]},    {},            All},
+          {{PlotStyle -> <|3 -> colors[[1]]|>,                VertexStyle -> <|4 -> colors[[2]]|>}, colors[[1 ;; 2]], {},            All},
+          {{PlotStyle -> <|3 -> extraColor|>,                 VertexStyle -> colors},               colors,           {extraColor},  All},
+          {{EdgeStyle -> colors[[1 ;; 2]],   "EdgePolygonStyle" -> colors[[3]]},                    colors[[1 ;; 3]], {},            {"Polygons"}},
+          {{EdgeStyle -> colors[[1 ;; 2]],   "EdgePolygonStyle" -> Automatic},                      colors[[1 ;; 2]], {},            {"Polygons"}},
+          {{EdgeStyle -> colors[[1 ;; 2]],   "EdgePolygonStyle" -> <|{1, 2, 3} -> colors[[3]]|>},   colors[[1 ;; 3]], {},            {"Polygons"}},
+          {{EdgeStyle -> colors[[1 ;; 2]],   "EdgePolygonStyle" -> colors[[3 ;; 4]]},               colors[[1 ;; 4]], {},            {"Polygons"}}
+        }
       ]
     }
   |>

--- a/Tests/WolframModelPlot.wlt
+++ b/Tests/WolframModelPlot.wlt
@@ -678,7 +678,17 @@
         {VertexSize -> 0.1, "ArrowheadLength" -> 0.2},
         {EdgeStyle -> Red},
         {VertexCoordinateRules -> {3 -> {0, 0}, 4 -> {1, 0}}}
-      }
+      },
+
+      (* GraphHighlight and style interaction *)
+
+      With[{color1 = RGBColor[0.46, 0.51, 0.87], color2 = RGBColor[0.13, 0.64, 0.27]},
+        testColorPresence[
+          {{1, 2}},
+          {GraphHighlight -> {2}, GraphHighlightStyle -> color1, VertexStyle -> color2},
+          {color1, color2}
+        ]
+      ]
     }
   |>
 |>


### PR DESCRIPTION
## Changes
* Resolves #279.
* Adds tests for style inheritance.

## Comments
* Tests don't currently work in that they don't test the `Graphics` object produced is valid. Correct tests are in #281.
* This needs to be merged first, however, in order to fix CI failure in #281.
* This is ***P0 critical***, as `WolframModelPlot` currently fails in many cases.

## Tests
* The previously failing example now works correctly:
```
In[] := WolframModelPlot[{{1, 2}}, GraphHighlight -> {2}, PlotStyle -> Black]
```
<img width="283" alt="image" src="https://user-images.githubusercontent.com/1479325/77862649-e6ff5300-71ea-11ea-852a-525d7d534912.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/282)
<!-- Reviewable:end -->
