### PR TITLE
RulePlot hypergraph styles

### DIFF
--- a/Tests/RulePlot.wlt
+++ b/Tests/RulePlot.wlt
@@ -269,19 +269,20 @@
       (** Style options **)
 
       SeedRandom[911];
-      With[{color = RandomColor[]}]
-      VerificationTest[
-        !FreeQ[checkGraphics @ RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], ##], color]
-      ] & /@ {
-        {PlotStyle -> color},
-        {PlotStyle -> <|1 -> color|>},
-        {VertexStyle -> color},
-        {VertexStyle -> <|1 -> color|>},
-        {EdgeStyle -> color},
-        {EdgeStyle -> <|{1, 2, 3} -> color|>},
-        {"EdgePolygonStyle" -> color},
-        {"EdgePolygonStyle" -> <|{1, 2, 3} -> color|>}
-      },
+      With[{color = RandomColor[]},
+        VerificationTest[
+          !FreeQ[checkGraphics @ RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], #], color]
+        ] & /@ {
+          PlotStyle -> color,
+          PlotStyle -> <|1 -> color|>,
+          VertexStyle -> color,
+          VertexStyle -> <|1 -> color|>,
+          EdgeStyle -> color,
+          EdgeStyle -> <|{1, 2, 3} -> color|>,
+          "EdgePolygonStyle" -> color,
+          "EdgePolygonStyle" -> <|{1, 2, 3} -> color|>
+        }
+      ],
 
       testUnevaluated[
         RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], PlotStyle -> {1}],

--- a/Tests/RulePlot.wlt
+++ b/Tests/RulePlot.wlt
@@ -266,6 +266,50 @@
         {{1, {2, 3}}, {1, 2}}
       },
 
+      (** Style options **)
+
+      SeedRandom[911];
+      With[{color = RandomColor[]}]
+      VerificationTest[
+        !FreeQ[checkGraphics @ RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], ##], color]
+      ] & /@ {
+        {PlotStyle -> color},
+        {PlotStyle -> <|1 -> color|>},
+        {VertexStyle -> color},
+        {VertexStyle -> <|1 -> color|>},
+        {EdgeStyle -> color},
+        {EdgeStyle -> <|{1, 2, 3} -> color|>},
+        {"EdgePolygonStyle" -> color},
+        {"EdgePolygonStyle" -> <|{1, 2, 3} -> color|>}
+      },
+
+      testUnevaluated[
+        RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], PlotStyle -> {1}],
+        RulePlot::invalidPlotStyle
+      ],
+
+      testUnevaluated[
+        RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], # -> {1}],
+        RulePlot::elementwiseStyle
+      ] & /@ {VertexStyle, EdgeStyle, "EdgePolygonStyle"},
+
+      VerificationTest[
+        FirstCase[
+          checkGraphics @ RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], VertexSize -> 0.213],
+          Disk[_, r_] :> r,
+          0, (* default *)
+          All],
+        0.213
+      ],
+
+      VerificationTest[
+        4 == #2 / #1 & @@ (FirstCase[
+          checkGraphics @ RulePlot[WolframModel[{{1, 2}} -> {{2, 3}}], "ArrowheadLength" -> #],
+          p_Polygon :> Area[p],
+          0,
+          All] & /@ {0.1, 0.2})
+      ],
+
       (* Scaling consistency *)
 
       (** Vertex amplification **)


### PR DESCRIPTION
## Changes
* Partly implements #152.
* Adds `PlotStyle`, `VertexStyle`, `EdgeStyle`, `"EdgePolygonStyle"`, `VertexSize` and `"ArrowheadLength"` options to `RulePlot` of `WolframModel`.

## Comments
* Tests are not failing because test functions from #281 are not merged yet, even though they are used here. Without those functions, failing graphics are missed.
* Style options are currently broken due to #279. #282 will need to be merged first.

## Tests
* Use a different `PlotStyle`:
```
In[] := RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], 
 PlotStyle -> RGBColor[0.01, 0.40, 0.98]]
```
<img width="358" alt="image" src="https://user-images.githubusercontent.com/1479325/78604570-feac8c00-7827-11ea-9d7e-a5acd17c89f5.png">

* `VertexSize` can now be adjusted:
```
In[] := RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], 
   VertexSize -> #] & /@ {0, 0.1, 0.2}
```
<img width="558" alt="image" src="https://user-images.githubusercontent.com/1479325/77865958-e670b780-71fe-11ea-90b6-d18cd6657ad5.png">

* So can be `"ArrowheadLength"`:
```
In[] := RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], 
   "ArrowheadLength" -> #] & /@ {0, 0.2, 0.4}
```
<img width="558" alt="image" src="https://user-images.githubusercontent.com/1479325/77865974-f7212d80-71fe-11ea-9f2b-7133ffec39d5.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/283)
<!-- Reviewable:end -->
