### PR TITLE
Improved vertex labels

### DIFF
--- a/Kernel/WolframModelPlot.m
+++ b/Kernel/WolframModelPlot.m
@@ -460,6 +460,27 @@ applyStyle[style : Except[_List], shapes_] := With[{trimmedShapes = DeleteCases[
 
 applyStyle[style_List, shapes_] := Replace[DeleteCases[Transpose[{style, shapes}], {_, {}}], {} -> Nothing]
 
+vertexLabelsGraphics[embedding_, vertexSize_, vertexLabels_] := Module[{
+		pointsToVertices, edges, vertexCoordinatesDiagonal, graphPlotVertexSize},
+	pointsToVertices =
+		Association[Reverse /@ Catenate[Function[{v, pts}, v -> # & /@ Cases[pts, _Point]] @@@ embedding[[1]]]];
+	edges =
+		Cases[embedding[[2]], Line[{pt1_, ___, pt2_}] :> UndirectedEdge @@ pointsToVertices /@ Point /@ {pt1, pt2}, All];
+	vertexCoordinatesDiagonal = EuclideanDistance @@ Transpose[CoordinateBounds[First /@ Keys[pointsToVertices]]];
+	graphPlotVertexSize = If[vertexCoordinatesDiagonal == 0,
+		2 vertexSize,
+		{"Scaled", 2 vertexSize / vertexCoordinatesDiagonal}
+	];
+	GraphPlot[
+		Graph[Values[pointsToVertices], edges],
+		VertexCoordinates -> Thread[Values[pointsToVertices] -> First /@ Keys[pointsToVertices]],
+		VertexLabels -> vertexLabels,
+		GraphLayout -> "SpringElectricalEmbedding", (* smart vertex placement does not seem to work otherwise *)
+		VertexSize -> graphPlotVertexSize,
+		VertexShapeFunction -> None,
+		EdgeShapeFunction -> None]
+]
+
 drawEmbedding[
 			styles_,
 			vertexLabels_,
@@ -482,11 +503,7 @@ drawEmbedding[
 					Cases[#, Point[pts_] :> Circle[pts, getSingleVertexEdgeRadius[pts]], All] & /@ embedding[[2, All, 2]]]}],
 		If[vertexLabels === None,
 			Graphics[{}],
-			GraphPlot[
-				Graph[embedding[[1, All, 1]], {}],
-				VertexCoordinates -> embedding[[1, All, 2, 1, 1]],
-				VertexLabels -> vertexLabels,
-				VertexShapeFunction -> None,
-				EdgeShapeFunction -> None]]
+			vertexLabelsGraphics[embedding, vertexSize, vertexLabels]
+		]
 	]
 ]


### PR DESCRIPTION
## Changes

* Improves placement of vertex labels.
* `VertexLabels` are now placed with an edge-aware `GraphPlot`, which does edge avoidance in some cases.
* `VertexLabels` are now aware of `VertexSize` which prevents them from being too close and overlapping vertices in some cases.

## Comments

* (Obviously) changes all graphics where vertex labels were included.
* Makes an issue of vertex labels escaping outside `RulePlot` frame more likely. Unfortunately, there is no good solution for this within a current setup because vertex labels change size depending on image size.
* Does not affect performance for `VertexLabels -> None`. Slightly affects performance otherwise (but vertex labels are not particularly useful for large graphs).

## Tests

* Before (048311f4139cd7146e3879c710b02cc0c90a72e5):
```
In[] := WolframModelPlot[{{{1, 2, 3}, {3, 4, 5}, {5, 6, 7, 1}}, {{1, 2}, {2, 
    10}, {2, 6}, {6, 11}, {2, 4}, {4, 12}, {4, 7}, {7, 13}, {2, 
    3}, {3, 14}, {3, 8}, {8, 15}, {3, 5}, {5, 16}, {5, 9}, {9, 
    17}}, {{1}}, {{1, 1}}, {{1, 2, 3}}}, VertexLabels -> Automatic]
```
<img width="428" alt="image" src="https://user-images.githubusercontent.com/1479325/78031755-f63ce880-7331-11ea-90a6-8080f18a7b28.png">

```
In[] := RulePlot[WolframModel[{{1, 2}, {1, 2}} -> {{3, 2}, {3, 2}, {2, 1}, {1,
      3}}], VertexLabels -> Automatic]
```
<img width="358" alt="image" src="https://user-images.githubusercontent.com/1479325/78031996-53d13500-7332-11ea-9912-1590c1281b36.png">

* Now:
```
In[] := WolframModelPlot[{{{1, 2, 3}, {3, 4, 5}, {5, 6, 7, 1}}, {{1, 2}, {2, 
    10}, {2, 6}, {6, 11}, {2, 4}, {4, 12}, {4, 7}, {7, 13}, {2, 
    3}, {3, 14}, {3, 8}, {8, 15}, {3, 5}, {5, 16}, {5, 9}, {9, 
    17}}, {{1}}, {{1, 1}}, {{1, 2, 3}}}, VertexLabels -> Automatic]
```
<img width="428" alt="image" src="https://user-images.githubusercontent.com/1479325/78031832-179dd480-7332-11ea-9901-e9516932da2b.png">

* Affects `RulePlot` as well:
```
In[] := RulePlot[WolframModel[{{1, 2}, {1, 2}} -> {{3, 2}, {3, 2}, {2, 1}, {1,
      3}}], VertexLabels -> Automatic]
```
<img width="358" alt="image" src="https://user-images.githubusercontent.com/1479325/78032139-8bd87800-7332-11ea-9392-0e17490b94cb.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/284)
<!-- Reviewable:end -->
