### PR TITLE
Any highlight style

### DIFF
--- a/Kernel/WolframModelPlot.m
+++ b/Kernel/WolframModelPlot.m
@@ -63,9 +63,6 @@ General::invalidCoordinates =
 WolframModelPlot::invalidHighlight =
 	"GraphHighlight value `1` should be a list of vertices and edges.";
 
-General::invalidHighlightStyle =
-	"GraphHighlightStyle `1` should be a color.";
-
 General::invalidSize =
 	"`1` `2` should be a non-negative number.";
 
@@ -215,7 +212,6 @@ correctWolframModelPlotOptionsQ[head_, expr_, edges_, opts_] :=
 			{"HyperedgeRendering", $hyperedgeRenderings}})) &&
 	correctCoordinateRulesQ[head, OptionValue[WolframModelPlot, opts, VertexCoordinateRules]] &&
 	correctHighlightQ[OptionValue[WolframModelPlot, opts, GraphHighlight]] &&
-	correctHighlightStyleQ[head, OptionValue[WolframModelPlot, opts, GraphHighlightStyle]] &&
 	correctSizeQ[head, "Vertex size", OptionValue[WolframModelPlot, opts, VertexSize], {}] &&
 	correctSizeQ[head, "Arrowhead length", OptionValue[WolframModelPlot, opts, "ArrowheadLength"], {Automatic}] &&
 	correctPlotStyleQ[head, OptionValue[WolframModelPlot, opts, PlotStyle]] &&
@@ -237,9 +233,6 @@ correctHighlightQ[highlight_] := (
 	If[!ListQ[highlight], Message[WolframModelPlot::invalidHighlight, highlight]];
 	ListQ[highlight]
 )
-
-correctHighlightStyleQ[head_, highlightStyle_] :=
-	If[ColorQ[highlightStyle], True, Message[head::invalidHighlightStyle, highlightStyle]; False]
 
 correctSizeQ[head_, capitalizedName_, size_ ? (# >= 0 &), _] := True
 

--- a/Tests/RulePlot.wlt
+++ b/Tests/RulePlot.wlt
@@ -106,9 +106,8 @@
 
       (** GraphhighlightStyle **)
 
-      testUnevaluated[
-        RulePlot[WolframModel[{{1, 2, 3}, {3, 4, 5}} -> {{3, 4, 5}, {5, 6, 7}}], GraphHighlightStyle -> 1],
-        {RulePlot::invalidHighlightStyle}
+      VerificationTest[
+        !graphicsQ[RulePlot[WolframModel[{{1, 2, 3}, {3, 4, 5}} -> {{3, 4, 5}, {5, 6, 7}}], GraphHighlightStyle -> 1]]
       ],
 
       VerificationTest[

--- a/Tests/WolframModelPlot.wlt
+++ b/Tests/WolframModelPlot.wlt
@@ -249,25 +249,17 @@
         graphicsQ[WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {4, {1, 2, 3}}]]
       ],
 
-      (* Valid GraphHighlightStyle *)
-
-      testUnevaluated[
-        WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {1}, GraphHighlightStyle -> None],
-        {WolframModelPlot::invalidHighlightStyle}
-      ],
-
-      testUnevaluated[
-        WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {1}, GraphHighlightStyle -> 2],
-        {WolframModelPlot::invalidHighlightStyle}
-      ],
-
-      testUnevaluated[
-        WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {1}, GraphHighlightStyle -> "Dashed"],
-        {WolframModelPlot::invalidHighlightStyle}
+      VerificationTest[
+        graphicsQ[WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {1}, GraphHighlightStyle -> Black]]
       ],
 
       VerificationTest[
-        graphicsQ[WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {1}, GraphHighlightStyle -> Black]]
+        graphicsQ[WolframModelPlot[
+          {{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {1}, GraphHighlightStyle -> Directive[Black, Thick]]]
+      ],
+
+      VerificationTest[
+        !graphicsQ[WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> {1}, GraphHighlightStyle -> "Dashed"]]
       ],
 
       (* Valid VertexSize and "ArrowheadLength" *)
@@ -570,15 +562,15 @@
 
       (* GraphHighlightStyle *)
 
-      VerificationTest[
-        With[{
-            color = RGBColor[0.4, 0.6, 0.2]},
-          FreeQ[
-              checkGraphics @ WolframModelPlot[
-                {{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> #, GraphHighlightStyle -> color],
-              color] & /@
-            {{}, {4}, {{1, 2, 3}}}],
-        {True, False, False}
+      With[{color = RGBColor[0.4, 0.6, 0.2]},
+        With[{style = #},
+          VerificationTest[
+            FreeQ[checkGraphics @ WolframModelPlot[
+                {{1, 2, 3}, {3, 4, 5}}, GraphHighlight -> #, GraphHighlightStyle -> color], color] & /@
+              {{}, {4}, {{1, 2, 3}}},
+            {True, False, False}
+          ]
+        ] & /@ {color, Directive[Thick, color]}
       ],
 
       (* Scaling consistency *)


### PR DESCRIPTION
## Changes

* Allow any style to be used in `GraphHighlightStyle` (previously only single colors were allowed).

## Comments

* `GraphHighlightStyle` works on the level of `PlotStyle`, which means the style is the same for all graph elements, and there is no way to control inherited things like edge polygon opacity, etc.

## Tests

* Make highlight `Red`, `Thick`, and `Dashed`:
```
In[] := WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, 
 GraphHighlight -> {{1, 2, 3}, 4}, 
 GraphHighlightStyle -> Directive[Red, Thick, Dashed]]
```
<img width="399" alt="image" src="https://user-images.githubusercontent.com/1479325/78042721-6b171f00-7340-11ea-9f8d-257d23e86493.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/285)
<!-- Reviewable:end -->
