### PR TITLE
Fix style parsing for empty hypergraphs

### DIFF
--- a/Kernel/WolframModelPlot.m
+++ b/Kernel/WolframModelPlot.m
@@ -220,9 +220,17 @@ correctWolframModelPlotOptionsQ[head_, expr_, edges_, opts_] :=
 	correctSizeQ[head, "Arrowhead length", OptionValue[WolframModelPlot, opts, "ArrowheadLength"], {Automatic}] &&
 	correctPlotStyleQ[head, OptionValue[WolframModelPlot, opts, PlotStyle]] &&
 	correctStyleLengthQ[
-		head, "vertices", MatchQ[edges, {$hypergraphPattern...}], Length[vertexList[edges]], OptionValue[WolframModelPlot, opts, VertexStyle]] &&
+		head,
+		"vertices",
+		MatchQ[edges, {$hypergraphPattern..}],
+		Length[vertexList[edges]],
+		OptionValue[WolframModelPlot, opts, VertexStyle]] &&
 	And @@ (correctStyleLengthQ[
-		head, "edges", MatchQ[edges, {$hypergraphPattern...}], Length[edges], OptionValue[WolframModelPlot, opts, #]] & /@ {EdgeStyle, "EdgePolygonStyle"})
+		head,
+		"edges",
+		MatchQ[edges, {$hypergraphPattern..}],
+		Length[edges],
+		OptionValue[WolframModelPlot, opts, #]] & /@ {EdgeStyle, "EdgePolygonStyle"})
 
 correctCoordinateRulesQ[head_, coordinateRules_] :=
 	If[!MatchQ[coordinateRules,

--- a/Tests/WolframModelEvolutionObject.wlt
+++ b/Tests/WolframModelEvolutionObject.wlt
@@ -1374,7 +1374,7 @@
       With[{evo = WolframModel[{{1, 2}} -> {{1, 3}, {3, 2}}, {{1, 1}}, <|"MaxEvents" -> 30|>]}, testUnevaluated[
         evo["EventsStatesPlotsList", VertexSize -> x],
         {WolframModelPlot::invalidSize}
-      ],
+      ]],
 
       VerificationTest[
         graphicsQ /@ WolframModel[{{1, 2}} -> {}, {{1, 2}}, Infinity, "EventsStatesPlotsList"],
@@ -1384,7 +1384,7 @@
       VerificationTest[
         graphicsQ /@ WolframModel[{} -> {{1, 2}}, {}, <|"MaxEvents" -> 1|>, "EventsStatesPlotsList"],
         {True, True}
-      ]]
+      ]
     },
     "options" -> {
       "Parallel" -> False

--- a/Tests/WolframModelEvolutionObject.wlt
+++ b/Tests/WolframModelEvolutionObject.wlt
@@ -1374,6 +1374,16 @@
       With[{evo = WolframModel[{{1, 2}} -> {{1, 3}, {3, 2}}, {{1, 1}}, <|"MaxEvents" -> 30|>]}, testUnevaluated[
         evo["EventsStatesPlotsList", VertexSize -> x],
         {WolframModelPlot::invalidSize}
+      ],
+
+      VerificationTest[
+        graphicsQ /@ WolframModel[{{1, 2}} -> {}, {{1, 2}}, Infinity, "EventsStatesPlotsList"],
+        {True, True}
+      ],
+
+      VerificationTest[
+        graphicsQ /@ WolframModel[{} -> {{1, 2}}, {}, <|"MaxEvents" -> 1|>, "EventsStatesPlotsList"],
+        {True, True}
       ]]
     },
     "options" -> {

--- a/Tests/WolframModelPlot.wlt
+++ b/Tests/WolframModelPlot.wlt
@@ -550,6 +550,11 @@
         graphicsQ[WolframModelPlot[{{1, 2, 3}, {3, 4, 5}}, VertexSize -> 0.4, "ArrowheadLength" -> 0.3]]
       ],
 
+      (* weed #286 *)
+      VerificationTest[
+        graphicsQ[WolframModelPlot[{}, VertexStyle -> {}, EdgeStyle -> {}]]
+      ],
+
       (* GraphHighlight *)
 
       VerificationTest[


### PR DESCRIPTION
## Changes

* Fixes #286.
* Fixes style parsing for empty hypergraphs.
* This also fixes `"EventsStatesPlotsList"` for empty states.

## Comments

* All it took was removing a dot from `{$hypergraphPattern...}` (the rest is code style and tests).
* This fixes the vertex icons weed in MultiwaySystem.

## Tests

* This now works correctly:
```
In[] := WolframModelPlot[{}, VertexStyle -> {}]
```
<img width="291" alt="image" src="https://user-images.githubusercontent.com/1479325/78150591-7ed88900-7405-11ea-9ab7-67f5d27edb8a.png">

* And so are the `"EventsStatesPlotsList"`s:
```
In[] := WolframModel[{{1, 2}} -> {}, {{1, 
   2}}, \[Infinity], "EventsStatesPlotsList"]
```
<img width="335" alt="image" src="https://user-images.githubusercontent.com/1479325/78150635-9152c280-7405-11ea-9956-aebe8c4cc5db.png">

```
In[] := WolframModel[{} -> {{1, 2}}, {}, <|
  "MaxEvents" -> 1|>, "EventsStatesPlotsList"]
```
<img width="335" alt="image" src="https://user-images.githubusercontent.com/1479325/78150662-9c0d5780-7405-11ea-8633-5ceaab8b9ae2.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/287)
<!-- Reviewable:end -->
