### PR TITLE
HypergraphUnificationsPlot

### DIFF
--- a/Kernel/HypergraphUnificationsPlot.m
+++ b/Kernel/HypergraphUnificationsPlot.m
@@ -25,7 +25,7 @@ $color2 = Blue;
 
 HypergraphUnificationsPlot::emptyEdge = "Empty edges are not supported.";
 
-hypergraphUnificationsPlot[e1_List, e2_List, opts : OptionsPattern[]] := Module[{
+hypergraphUnificationsPlot[e1_, e2_, opts : OptionsPattern[]] := Module[{
     unifications, automaticVertexLabelsList, vertexLabels, edgeStyle},
   If[Length[Cases[Join[e1, e2], {}]] > 0,
     Message[HypergraphUnificationsPlot::emptyEdge];

--- a/Kernel/HypergraphUnificationsPlot.m
+++ b/Kernel/HypergraphUnificationsPlot.m
@@ -26,23 +26,25 @@ $color2 = Blue;
 HypergraphUnificationsPlot::emptyEdge = "Empty edges are not supported.";
 
 hypergraphUnificationsPlot[e1_List, e2_List, opts : OptionsPattern[]] := Module[{
-    unifications, automaticVertexLabelsList},
+    unifications, automaticVertexLabelsList, vertexLabels, edgeStyle},
   If[Length[Cases[Join[e1, e2], {}]] > 0,
     Message[HypergraphUnificationsPlot::emptyEdge];
     Throw[$Failed];
   ];
   unifications = Check[HypergraphUnifications[e1, e2], Throw[$Failed]];
   automaticVertexLabelsList = unificationVertexLabels[e1, e2] @@@ unifications;
+  {vertexLabels, edgeStyle} =
+    Check[OptionValue[HypergraphUnificationsPlot, {opts}, #], Throw[$Failed]] & /@ {VertexLabels, EdgeStyle};
   MapThread[
     Check[WolframModelPlot[
       #1,
-      VertexLabels -> Replace[OptionValue[HypergraphUnificationsPlot, {opts}, VertexLabels], Automatic -> #4],
-      EdgeStyle -> ReplacePart[
+      VertexLabels -> Replace[vertexLabels, Automatic -> #4],
+      EdgeStyle -> Replace[edgeStyle, Automatic -> ReplacePart[
         Table[Automatic, Length[#]],
         Join[
           Thread[Intersection[Values[#2], Values[#3]] -> Blend[{$color1, $color2}]],
-          Thread[Values[#2] -> $color1], Thread[Values[#3] -> $color2]]],
-      opts], Throw[$Failed]] &,
+          Thread[Values[#2] -> $color1], Thread[Values[#3] -> $color2]]]],
+        opts], Throw[$Failed]] &,
     {unifications[[All, 1]], unifications[[All, 2]], unifications[[All, 3]], automaticVertexLabelsList}]
 ]
 

--- a/Kernel/HypergraphUnificationsPlot.m
+++ b/Kernel/HypergraphUnificationsPlot.m
@@ -1,0 +1,59 @@
+Package["SetReplace`"]
+
+PackageExport["HypergraphUnificationsPlot"]
+
+(* Documentation *)
+
+HypergraphUnificationsPlot::usage = usageString[
+  "HypergraphUnificationsPlot[`e1`, `e2`] yields a list of plots of all ways to unify hypergraphs `e1` and `e2`."];
+
+SyntaxInformation[HypergraphUnificationsPlot] = {"ArgumentsPattern" -> {_, _, OptionsPattern[]}};
+
+Options[HypergraphUnificationsPlot] := Options[WolframModelPlot];
+
+(* Implementation *)
+
+HypergraphUnificationsPlot[args___] := Module[{result = Catch[hypergraphUnificationsPlot[args]]},
+  result /; result =!= $Failed
+]
+
+hypergraphUnificationsPlot[args___] /; !Developer`CheckArgumentCount[HypergraphUnificationsPlot[args], 2, 2] :=
+  Throw[$Failed]
+
+$color1 = Red;
+$color2 = Blue;
+
+HypergraphUnificationsPlot::emptyEdge = "Empty edges are not supported.";
+
+hypergraphUnificationsPlot[e1_List, e2_List, opts : OptionsPattern[]] := Module[{
+    unifications, automaticVertexLabelsList},
+  If[Length[Cases[Join[e1, e2], {}]] > 0,
+    Message[HypergraphUnificationsPlot::emptyEdge];
+    Throw[$Failed];
+  ];
+  unifications = Check[HypergraphUnifications[e1, e2], Throw[$Failed]];
+  automaticVertexLabelsList = unificationVertexLabels[e1, e2] @@@ unifications;
+  MapThread[
+    Check[WolframModelPlot[
+      #1,
+      VertexLabels -> Replace[OptionValue[HypergraphUnificationsPlot, {opts}, VertexLabels], Automatic -> #4],
+      EdgeStyle -> ReplacePart[
+        Table[Automatic, Length[#]],
+        Join[
+          Thread[Intersection[Values[#2], Values[#3]] -> Blend[{$color1, $color2}]],
+          Thread[Values[#2] -> $color1], Thread[Values[#3] -> $color2]]],
+      opts], Throw[$Failed]] &,
+    {unifications[[All, 1]], unifications[[All, 2]], unifications[[All, 3]], automaticVertexLabelsList}]
+]
+
+unificationVertexLabels[e1_, e2_][unification_, edgeMapping1_, edgeMapping2_] := Module[{labels1, labels2},
+  {labels1, labels2} =
+    Merge[Reverse /@ Union[Catenate[Thread /@ Thread[#1[[Keys[#2]]] -> unification[[Values[#2]]]]]], Identity] & @@@
+      {{e1, edgeMapping1}, {e2, edgeMapping2}};
+  Normal @ AssociationMap[
+    Row[
+      Catenate[
+        Function[{unif, color}, Style[#, color] & /@ Lookup[unif, #, {}]] @@@ {{labels1, $color1}, {labels2, $color2}}],
+      ","] &,
+    vertexList[unification]]
+]

--- a/Tests/HypergraphUnificationsPlot.wlt
+++ b/Tests/HypergraphUnificationsPlot.wlt
@@ -1,0 +1,119 @@
+<|
+  "HypergraphUnificationsPlot" -> <|
+    "init" -> (
+      Attributes[Global`testUnevaluated] = Attributes[Global`testSymbolLeak] = {HoldAll};
+      Global`testUnevaluated[args___] := SetReplace`PackageScope`testUnevaluated[VerificationTest, args];
+      Global`testSymbolLeak[args___] := SetReplace`PackageScope`testSymbolLeak[VerificationTest, args];
+      Global`checkGraphics[args___] := SetReplace`PackageScope`checkGraphics[args];
+      Global`graphicsQ[args___] := SetReplace`PackageScope`graphicsQ[args];
+    ),
+    "tests" -> {
+      testSymbolLeak[
+        HypergraphUnificationsPlot[{{1, 2}, {2, 3}, {3, 4, 5}}, {{a, b}, {b, c}, {c, d, e}}]
+      ],
+      
+      testUnevaluated[
+        HypergraphUnificationsPlot[],
+        {HypergraphUnificationsPlot::argrx}
+      ],
+
+      testUnevaluated[
+        HypergraphUnificationsPlot[1],
+        {HypergraphUnificationsPlot::argr}
+      ],
+
+      testUnevaluated[
+        HypergraphUnificationsPlot[1, 2, 3],
+        {HypergraphUnificationsPlot::argrx}
+      ],
+
+      testUnevaluated[
+        HypergraphUnificationsPlot[{1}, 2],
+        {HypergraphUnifications::hypergraphNotList}
+      ],
+
+      testUnevaluated[
+        HypergraphUnificationsPlot[{1}, {2}],
+        {HypergraphUnifications::edgeNotList}
+      ],
+
+      testUnevaluated[
+        HypergraphUnificationsPlot[{{1, 2, 3}}, {{a, b, c}}, "$$invalid$$" -> 0],
+        {OptionValue::nodef}
+      ],
+
+      VerificationTest[
+        graphicsQ /@ HypergraphUnificationsPlot[{{1}}, {{2}}],
+        ConstantArray[True, Length[HypergraphUnifications[{{1}}, {{2}}]]]
+      ],
+
+      VerificationTest[
+        HypergraphUnificationsPlot[{}, {}, VertexLabels -> Automatic],
+        {}
+      ],
+
+      testUnevaluated[
+        HypergraphUnificationsPlot[{{}}, {{1}}, VertexLabels -> Automatic],
+        {HypergraphUnificationsPlot::emptyEdge}
+      ],
+
+      testUnevaluated[
+        HypergraphUnificationsPlot[{{}}, {{}}, VertexLabels -> Automatic],
+        {HypergraphUnificationsPlot::emptyEdge}
+      ],
+
+      VerificationTest[
+        graphicsQ /@ HypergraphUnificationsPlot[{{1, 2, 3}, {3, 4, 5}}, {{a, b, c}}, VertexSize -> 0.3],
+        {True, True}
+      ],
+
+      testUnevaluated[
+        HypergraphUnificationsPlot[{{1, 2, 3}, {3, 4, 5}}, {{a, b, c}}, VertexSize -> -1],
+        {WolframModelPlot::invalidSize}
+      ],
+
+      VerificationTest[
+        0 < Length @ Cases[
+          Cases[
+            checkGraphics @ HypergraphUnificationsPlot[{{x, y}, {x, z}}, {{a, b}, {b, c}}, VertexLabels -> Automatic],
+            _Text,
+            All],
+          #,
+          All]
+      ] & /@ {_Style, _Row, ","},
+
+      VerificationTest[
+        Cases[
+          Cases[
+            checkGraphics @ HypergraphUnificationsPlot[{{x, y}, {x, z}}, {{a, b}, {b, c}}, VertexLabels -> 1],
+            _Text,
+            All],
+          _Style,
+          All],
+        {}
+      ],
+
+      With[{color = RGBColor[0.76, 0.65, 0.73]},
+        VerificationTest[
+          Length @ Cases[
+            checkGraphics @
+              HypergraphUnificationsPlot[{{x, y}, {x, z}}, {{a, b}, {b, c}}, EdgeStyle -> color],
+            color,
+            All] > 0
+        ]
+      ],
+
+      VerificationTest[
+        Greater @@ (
+          Length @ Union @ Cases[
+              checkGraphics @ HypergraphUnificationsPlot[{{x, y}, {x, z}}, {{a, b}, {b, c}}, EdgeStyle -> #],
+              _ ? ColorQ,
+              All] & /@
+            {Automatic, RGBColor[0.252, 0.351, 0.143]})
+      ]
+    },
+     "options" -> {
+       "Parallel" -> False
+     }
+  |>
+|>


### PR DESCRIPTION
## Changes

* Implements `HypergraphUnificationsPlot`.
* Visualizes the result of `HypergraphUnifications` by differently coloring unification components.
* `VertexLabels -> Automatic` labels vertices according to the corresponding vertices of the unification arguments.

## Tests

* Show unifications for two binary hypergraphs:
```
In[] := HypergraphUnificationsPlot[{{x, y}, {x, z}}, {{a, b}, {b, c}}]
```
<img width="622" alt="image" src="https://user-images.githubusercontent.com/1479325/78164514-d8e24a00-7417-11ea-9f9b-8e36cea637ac.png">

* Include vertex labels:
```
In[] := HypergraphUnificationsPlot[{{x, y}, {x, z}}, {{a, b}, {b, c}}, 
 VertexLabels -> Automatic]
```
<img width="622" alt="image" src="https://user-images.githubusercontent.com/1479325/78164551-e5ff3900-7417-11ea-9c85-65cdb9d0d313.png">

* A more complicated example:
```
In[] := HypergraphUnificationsPlot[{{1, 2}, {2, 3, 4}, {4, 5}}, {{x, y, 
   z}, {z, a, b}, {z, w}}, VertexLabels -> Automatic]
```
<img width="622" alt="image" src="https://user-images.githubusercontent.com/1479325/78164635-07602500-7418-11ea-8484-dbb2cfd2d4c9.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/288)
<!-- Reviewable:end -->
