### PR TITLE
connectedHypergraphQ

### DIFF
--- a/Kernel/utilities.m
+++ b/Kernel/utilities.m
@@ -1,15 +1,14 @@
 Package["SetReplace`"]
 
-PackageScope["vertexList"]
 PackageScope["fromCounts"]
 PackageScope["multisetIntersection"]
 PackageScope["multisetUnion"]
 PackageScope["multisetComplement"]
 PackageScope["multisetFilterRules"]
+PackageScope["toCanonicalHypergraphForm"]
+PackageScope["vertexList"]
 PackageScope["indexHypergraph"]
 PackageScope["connectedHypergraphQ"]
-
-vertexList[edges_] := Sort[Union[Catenate[edges]]]
 
 fromCounts[association_] := Catenate @ KeyValueMap[ConstantArray] @ association
 
@@ -24,12 +23,20 @@ multisetFilterRules[rules_, filter_] := Catenate @ MapThread[
   {Normal @ KeySort @ KeyTake[Merge[Association /@ Join[rules, # -> Nothing & /@ filter], # &], filter],
     Values @ KeySort @ Counts[filter]}]
 
-indexHypergraph[e_] := With[{vertices = vertexList[e]}, Replace[e, Thread[vertices -> Range[Length[vertices]]], {2}]]
+toCanonicalHypergraphForm[edge : Except[_List]] := toCanonicalHypergraphForm[{edge}]
 
-connectedHypergraphQ[edge : Except[_List]] := connectedHypergraphQ[{edge}]
+toCanonicalHypergraphForm[edges_List] := toCanonicalEdgeForm /@ edges
 
-connectedHypergraphQ[edges_List] := ConnectedGraphQ[Graph[Catenate[toNormalEdges /@ edges]]]
+toCanonicalEdgeForm[edge : Except[_List]] := {edge}
 
-toNormalEdges[vertex : Except[_List]] := toNormalEdges[{vertex}]
+toCanonicalEdgeForm[edge_List] := edge
 
-toNormalEdges[edge_List] := UndirectedEdge @@@ Partition[edge, 2, 1, 1]
+vertexList[edges_] := Sort[Union[Catenate[toCanonicalHypergraphForm[edges]]]]
+
+indexHypergraph[e_] := With[{vertices = vertexList[e]},
+  Replace[toCanonicalHypergraphForm[e], Thread[vertices -> Range[Length[vertices]]], {2}]
+]
+
+connectedHypergraphQ[edges_] := ConnectedGraphQ[Graph[Catenate[toNormalEdges /@ toCanonicalHypergraphForm[edges]]]]
+
+toNormalEdges[edge_] := UndirectedEdge @@@ Partition[edge, 2, 1, 1]

--- a/Kernel/utilities.m
+++ b/Kernel/utilities.m
@@ -7,6 +7,7 @@ PackageScope["multisetUnion"]
 PackageScope["multisetComplement"]
 PackageScope["multisetFilterRules"]
 PackageScope["indexHypergraph"]
+PackageScope["connectedHypergraphQ"]
 
 vertexList[edges_] := Sort[Union[Catenate[edges]]]
 
@@ -24,3 +25,11 @@ multisetFilterRules[rules_, filter_] := Catenate @ MapThread[
     Values @ KeySort @ Counts[filter]}]
 
 indexHypergraph[e_] := With[{vertices = vertexList[e]}, Replace[e, Thread[vertices -> Range[Length[vertices]]], {2}]]
+
+connectedHypergraphQ[edge : Except[_List]] := connectedHypergraphQ[{edge}]
+
+connectedHypergraphQ[edges_List] := ConnectedGraphQ[Graph[Catenate[toNormalEdges /@ edges]]]
+
+toNormalEdges[vertex : Except[_List]] := toNormalEdges[{vertex}]
+
+toNormalEdges[edge_List] := UndirectedEdge @@@ Partition[edge, 2, 1, 1]

--- a/Tests/utilities.wlt
+++ b/Tests/utilities.wlt
@@ -4,6 +4,7 @@
       Global`multisetComplement = SetReplace`PackageScope`multisetComplement;
       Global`multisetFilterRules = SetReplace`PackageScope`multisetFilterRules;
       Global`multisetUnion = SetReplace`PackageScope`multisetUnion;
+      Global`connectedHypergraphQ = SetReplace`PackageScope`connectedHypergraphQ;
     ),
     "tests" -> {
       (* multisetComplement *)
@@ -155,6 +156,73 @@
       VerificationTest[
         multisetUnion[{{1, 5}, {1, 4}, {1, 5}, 3, 5}, {{1, 5}, 2, 2, 3, 4}],
         {{1, 5}, {1, 5}, {1, 4}, 3, 5, 2, 2, 4}
+      ],
+
+      (* connectedHypergraphQ *)
+
+      VerificationTest[
+        connectedHypergraphQ[1],
+        True
+      ],
+
+      VerificationTest[
+        connectedHypergraphQ[{1}],
+        True
+      ],
+
+      VerificationTest[
+        connectedHypergraphQ[{1, 2}],
+        False
+      ],
+
+      VerificationTest[
+        connectedHypergraphQ[{1, {1, 2}}],
+        True
+      ],
+
+      VerificationTest[
+        connectedHypergraphQ[{{1, 3}, {1, 2}}],
+        True
+      ],
+
+      VerificationTest[
+        connectedHypergraphQ[{{1, 2}, {2, 3}}],
+        True
+      ],
+
+      VerificationTest[
+        connectedHypergraphQ[{{{1, 0}, {2, 0}}, {{2, 0}, {3, 0}}}],
+        True
+      ],
+
+      VerificationTest[
+        connectedHypergraphQ[{{{1, 0}, {2, 0}}, {{3, 0}, {4, 0}}}],
+        False
+      ],
+
+      VerificationTest[
+        connectedHypergraphQ[{{1}, {2, 3}}],
+        False
+      ],
+
+      VerificationTest[
+        connectedHypergraphQ[{{1}, {1, 2}}],
+        True
+      ],
+
+      VerificationTest[
+        connectedHypergraphQ[{{1, 2, 3}, {2, 4, 5}}],
+        True
+      ],
+
+      VerificationTest[
+        connectedHypergraphQ[{{10, 17, 14}, {15, 8, 9}, {18, 15, 14}, {3, 12, 18}, {0, 16, 5}, {8, 13, 14}}],
+        False
+      ],
+
+      VerificationTest[
+        connectedHypergraphQ[{{13, 1, 14}, {13, 2, 16}, {16, 14, 18}, {6, 10, 15}, {1, 13, 15}, {13, 13, 15}}],
+        True
       ]
     }
   |>


### PR DESCRIPTION
## Changes

* Implements `connectedHypergraphQ`.

# Comments

* This will be used to test if a rule is connected.

## Tests

* Yields `False` for a disconnected hypergraph:
```
In[] := SetReplace`PackageScope`connectedHypergraphQ[
 EchoFunction[
   WolframModelPlot]@{{10, 17, 14}, {15, 8, 9}, {18, 15, 14}, {3, 12, 
    18}, {0, 16, 5}, {8, 13, 14}}]
```
<img width="345" alt="image" src="https://user-images.githubusercontent.com/1479325/78251236-11892e80-74bf-11ea-9763-183ef44e4221.png">

* Yields `True` for a connected one:
```
In[] := SetReplace`PackageScope`connectedHypergraphQ[
 EchoFunction[
   WolframModelPlot]@{{13, 1, 14}, {13, 2, 16}, {16, 14, 18}, {6, 10, 
    15}, {1, 13, 15}, {13, 13, 15}}]
```
<img width="399" alt="image" src="https://user-images.githubusercontent.com/1479325/78251297-2239a480-74bf-11ea-93d3-1b04c6436d26.png">

* Can handle a simplified unary edge syntax as well:
```
In[] := SetReplace`PackageScope`connectedHypergraphQ[{1, {1, 2}}]
Out[] = True
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/289)
<!-- Reviewable:end -->
