### PR TITLE
Fix compilation on 32-bit Windows.

### DIFF
--- a/libSetReplace/SetReplace.cpp
+++ b/libSetReplace/SetReplace.cpp
@@ -137,9 +137,9 @@ namespace SetReplace {
         appendToTensor({static_cast<mint>(expressions.size())});
         for (size_t expressionIndex = 0; expressionIndex < expressions.size(); ++expressionIndex) {
             appendToTensor({
-                expressions[expressionIndex].creatorEvent,
-                expressions[expressionIndex].destroyerEvent,
-                expressions[expressionIndex].generation,
+                static_cast<mint>(expressions[expressionIndex].creatorEvent),
+                static_cast<mint>(expressions[expressionIndex].destroyerEvent),
+                static_cast<mint>(expressions[expressionIndex].generation),
                 static_cast<mint>(atomsPointer)});
             atomsPointer += expressions[expressionIndex].atoms.size();
         }
@@ -147,10 +147,18 @@ namespace SetReplace {
         // Put fake event at the end so that the length of final expression can be determined on WL side.
         constexpr EventID fakeEvent = -3;
         constexpr Generation fakeGeneration = -1;
-        appendToTensor({fakeEvent, fakeEvent, fakeGeneration, static_cast<mint>(atomsPointer)});
+        appendToTensor({
+            static_cast<mint>(fakeEvent),
+            static_cast<mint>(fakeEvent),
+            static_cast<mint>(fakeGeneration),
+            static_cast<mint>(atomsPointer)});
         
         for (size_t expressionIndex = 0; expressionIndex < expressions.size(); ++expressionIndex) {
-            appendToTensor(expressions[expressionIndex].atoms);
+            std::vector<mint> atoms(expressions[expressionIndex].atoms.size());
+            for (int i = 0; i < expressions[expressionIndex].atoms.size(); ++i) {
+                atoms[i] = static_cast<mint>(expressions[expressionIndex].atoms[i]);
+            }
+            appendToTensor(atoms);
         }
         
         return output;


### PR DESCRIPTION
## Changes
* Restores compilation on 32-bit Windows, which was previously broken.

## Comments
* `mint` on 32-bit Windows is a 32-bit `int`, whereas event and vertex IDs are 64 bit.
* This caused a compilation error for the code that passed the result from C++ code back to WL.
* I'm now doing a `static_cast` of these 64-bit numbers to 32-bit `mint`s, which would generally do the right thing except for the cases where the evolution produces more than 2 billion vertices/edges/events, which is not possible on a 32-bit machine anyway due to 4 GB memory limit.

## Tests
* Would be great to test this on a 32-bit Windows machine, but I don't have any. We'll eventually need to use CI for such things, but for now, at least we know the 64-bit version is not broken, and the paclet can be compiled for 32-bit Windows.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/292)
<!-- Reviewable:end -->
