### PR TITLE
Fix automatic time constraint

### DIFF
--- a/Kernel/WolframModel.m
+++ b/Kernel/WolframModel.m
@@ -127,7 +127,8 @@ fromStepsSpec[init_, {Automatic, factor_}, timeConstraint_] := {
 	<|$maxEvents -> Round[factor $automaticMaxEvents],
 		$maxFinalExpressions -> Max[Round[factor $automaticMaxFinalExpressions], Length[init]]|>,
 	Automatic, (* termination reason *)
-	{TimeConstraint -> Min[timeConstraint, factor $automaticStepsTimeConstraint], "IncludePartialGenerations" -> False},
+	{TimeConstraint -> Min[timeConstraint, Replace[factor, 0 | 0. -> 1] $automaticStepsTimeConstraint],
+		"IncludePartialGenerations" -> False},
 	$$noAbort
 }
 

--- a/Tests/WolframModel.wlt
+++ b/Tests/WolframModel.wlt
@@ -865,6 +865,31 @@
         0
       ],
 
+      (* time constraint should scale as well *)
+      VerificationTest[
+        #1 < #2 / 2 & @@ (
+          First[AbsoluteTiming[
+              WolframModel[{{1, 1}, {1, 1}, {1, 1}} -> {{1, 1}, {1, 1}, {1, 1}, {1, 1}}, Automatic, #]]] & /@
+            {{Automatic, 0.2}, Automatic})
+      ],
+
+      (* even non-evolution properties should return if an automatic time constraint is triggered *)
+      VerificationTest[
+        ListQ @ WolframModel[{{1, 1}, {1, 1}, {1, 1}} -> {{1, 1}, {1, 1}, {1, 1}, {1, 1}}, Automatic, #, "FinalState"]
+      ] & /@ {Automatic, {Automatic, 0.2}},
+
+      (* even if the time constraint is manually specified *)
+      VerificationTest[
+        ListQ @ WolframModel[
+          {{1, 1}, {1, 1}, {1, 1}} -> {{1, 1}, {1, 1}, {1, 1}, {1, 1}},
+          Automatic,
+          Automatic,
+          "FinalState",
+          TimeConstraint ->
+            First[AbsoluteTiming[
+              WolframModel[{{1, 1}, {1, 1}, {1, 1}} -> {{1, 1}, {1, 1}, {1, 1}, {1, 1}}, Automatic, Automatic]]] / 2]
+      ],
+
       (** Properties **)
 
       VerificationTest[


### PR DESCRIPTION
## Changes
* Fixes #294.
* Fixes scaling of time constraint if using `Automatic` steps (so that, i.e., `{Automatic, 0.2}` is 5 times faster than `Automatic`).
* `WolframModel` now returns even non-evolution-object if a time constraint is triggered in the course of `Automatic` steps evaluation, even if time constraint is specified manually.

## Comments
* It's ok to return incomplete results in the case of `Automatic` steps, as `Automatic` steps behavior is undefined anyway.

## Examples
* Time constraint scaling now works correctly:
```
In[] := AbsoluteTiming[
    WolframModel[{{1, 1}, {1, 1}, {1, 1}} -> {{1, 1}, {1, 1}, {1, 
        1}, {1, 1}}, Automatic, {Automatic, #}]] & /@ {0.04, 0.2, 
   1} // Grid
```
<img width="482" alt="image" src="https://user-images.githubusercontent.com/1479325/78813892-b910d000-799b-11ea-900e-ffc89f3e200f.png">

* And results are now correctly returned for properties after time constraint is triggered:
```
In[] := WolframModel[{{1, 1}, {1, 1}, {1, 1}} -> {{1, 1}, {1, 1}, {1, 1}, {1, 
      1}}, Automatic, Automatic, "FinalStatePlot", 
   TimeConstraint -> #] & /@ {0.04, 0.2, 1}
```
<img width="566" alt="image" src="https://user-images.githubusercontent.com/1479325/78814017-f9704e00-799b-11ea-873f-2828405e66e6.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/295)
<!-- Reviewable:end -->
