### PR TITLE
Fix created edge style

### DIFF
--- a/Kernel/style.m
+++ b/Kernel/style.m
@@ -68,7 +68,7 @@ $styleNames = KeySort /@ KeySort @ <|
   "EvolutionObject" -> <|"Icon" -> $evolutionObjectIcon|>,
   "SpatialGraph" -> <|
     "DestroyedEdgeStyle" -> $destroyedEdgeStyle,
-    "CreatedEdgeStyle" -> $destroyedEdgeStyle,
+    "CreatedEdgeStyle" -> $createdEdgeStyle,
     "DestroyedAndCreatedEdgeStyle" -> $destroyedAndCreatedEdgeStyle,
     "VertexSize" -> $vertexSize,
     "ArrowheadLengthFunction" -> $arrowheadLengthFunction,


### PR DESCRIPTION
## Changes
* Fix a typo in `style.m`, where `"CreatedEdgeStyle"` was set to `$destroyedEdgeStyle` instead of `$createdEdgeStyle`.

## Comments
* This only affects `WolframPhysicsProjectStyleData`.
* It does not affect `"EventsStatesPlotsList"`.

## Examples
* Created edge style is now correct:
```
In[] := WolframPhysicsProjectStyleData["SpatialGraph", "CreatedEdgeStyle"]
```
<img width="274" alt="image" src="https://user-images.githubusercontent.com/1479325/78902345-ad7ae300-7a47-11ea-8582-a1f827dbd8d3.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/296)
<!-- Reviewable:end -->
