### PR TITLE
Clean up usage messages

### DIFF
--- a/Kernel/HypergraphUnifications.m
+++ b/Kernel/HypergraphUnifications.m
@@ -6,7 +6,7 @@ PackageExport["HypergraphUnifications"]
 
 HypergraphUnifications::usage = usageString[
   "HypergraphUnifications[`e1`, `e2`] yields a list of edge pairings ",
-  "between isomophic subgraphs of both `e1` and `e2`."];
+  "to hypergraphs containing both `e1` and `e2` as rule input matches."];
 
 SyntaxInformation[HypergraphUnifications] = {"ArgumentsPattern" -> {_, _}};
 

--- a/Kernel/HypergraphUnificationsPlot.m
+++ b/Kernel/HypergraphUnificationsPlot.m
@@ -5,7 +5,8 @@ PackageExport["HypergraphUnificationsPlot"]
 (* Documentation *)
 
 HypergraphUnificationsPlot::usage = usageString[
-  "HypergraphUnificationsPlot[`e1`, `e2`] yields a list of plots of all ways to unify hypergraphs `e1` and `e2`."];
+  "HypergraphUnificationsPlot[`e1`, `e2`] yields a list of plots of all ",
+  "hypergraphs containing both `e1` and `e2` as rule input matches."];
 
 SyntaxInformation[HypergraphUnificationsPlot] = {"ArgumentsPattern" -> {_, _, OptionsPattern[]}};
 

--- a/Kernel/ToPatternRules.m
+++ b/Kernel/ToPatternRules.m
@@ -31,10 +31,7 @@ PackageScope["toPatternRules"]
 
 
 ToPatternRules::usage = usageString[
-	"ToPatternRules[`r`] converts a list of anonymous rules `r` into a list of ",
-	"rules that can be supplied into SetReplace.",
-	"\n",
-	"As an example, try ToPatternRules[{{{1, 2}} -> {{1, 2, 3}}}]."];
+	"ToPatternRules[`r`] converts a list of anonymous rules `r` to explicit pattern rules."];
 
 
 (* ::Section:: *)

--- a/Kernel/WolframModelRuleValue.m
+++ b/Kernel/WolframModelRuleValue.m
@@ -6,7 +6,7 @@ PackageExport["$WolframModelRuleProperties"]
 (* Documentation *)
 
 WolframModelRuleValue::usage = usageString[
-  "WolframModelRuleValue[`r`, `p`] yields a value for property `p` of Wolfram model rule `r`.",
+  "WolframModelRuleValue[`r`, `p`] yields a value for property `p` of Wolfram model rule `r`.\n",
   "WolframModelRuleValue[`r`] yields values of all available properties."];
 
 $WolframModelRuleProperties::usage = usageString[

--- a/Kernel/WolframPhysicsProjectStyleData.m
+++ b/Kernel/WolframPhysicsProjectStyleData.m
@@ -7,8 +7,9 @@ PackageExport["WolframPhysicsProjectStyleData"]
 WolframPhysicsProjectStyleData::usage = usageString[
   "WolframPhysicsProjectStyleData[] yields an association describing default styles used in Wolfram Physics Project.\n",
   "WolframPhysicsProjectStyleData[`theme`] gives styles for a particular `theme`.\n",
-  "WolframPhysicsProjectStyleData[`g`, `e`] gives a value for a particular style element `e` from group `g`.\n",
-  "WolframPhysicsProjectStyleData[`theme`, `g`, `e`] gives a value for an element `e` from group `g` of `theme`."];
+  "WolframPhysicsProjectStyleData[`t`] gives styles for a particular plot type `t`.\n",
+  "WolframPhysicsProjectStyleData[`t`, `e`] gives a value for a particular style element `e` of plot type `t`.\n",
+  "WolframPhysicsProjectStyleData[`theme`, `t`, `e`] gives a value for an element `e` of plot type `t` for `theme`."];
 
 SyntaxInformation[WolframPhysicsProjectStyleData] = {"ArgumentsPattern" -> {_., _., _.}};
 


### PR DESCRIPTION
## Changes
* Clarifies usage messages for `HypergraphUnifications`, `HypergraphUnificationsPlot`, `ToPatternRules`, `WolframModelRuleValue`, and `WolframPhysicsProjectStyleData`.

## Comments
* Only changes usage strings. It does not affect functionality.

## Examples
* Check the new usage messages:
```
In[] := ?HypergraphUnifications
```
<img width="496" alt="image" src="https://user-images.githubusercontent.com/1479325/79180045-f2e83900-7dd6-11ea-8dc5-c11c8b819d4b.png">

```
In[] := ?HypergraphUnificationsPlot
```
<img width="495" alt="image" src="https://user-images.githubusercontent.com/1479325/79180063-fd0a3780-7dd6-11ea-990a-399a21cc1cad.png">

```
In[] := ?ToPatternRules
```
<img width="509" alt="image" src="https://user-images.githubusercontent.com/1479325/79179888-a56bcc00-7dd6-11ea-86ec-7ac3e3bee09c.png">

```
In[] := ?WolframModelRuleValue
```
<img width="535" alt="image" src="https://user-images.githubusercontent.com/1479325/79180084-072c3600-7dd7-11ea-8656-0d9e2c0a9d2f.png">

```
In[] := ?WolframPhysicsProjectStyleData
```
<img width="713" alt="image" src="https://user-images.githubusercontent.com/1479325/79180105-114e3480-7dd7-11ea-9626-adc11a9f1f78.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/302)
<!-- Reviewable:end -->
