### PR TITLE
SetReplace 0.3

### DIFF
--- a/PacletInfo.m
+++ b/PacletInfo.m
@@ -2,7 +2,7 @@
 
 Paclet[
 	Name -> "SetReplace",
-	Version -> "0.2",
+	Version -> "0.3",
 	MathematicaVersion -> "12.1+",
 	Description -> "SetReplace implements WolframModel and other functions used in the Wolfram Physics Project.",
 	Creator -> "Wolfram Research",

--- a/scripts/buildInit.wl
+++ b/scripts/buildInit.wl
@@ -79,8 +79,8 @@ updateVersion[] /; Names["GitLink`*"] =!= {} := Module[{
   Check[
     versionInformation = Import[FileNameJoin[{$repoRoot, "scripts", "version.wl"}]];
     gitRepo = GitOpen[$repoRoot];
-    minorVersionNumber = Length[GitRange[
-      gitRepo, Except[versionInformation["Checkpoint"]], GitMergeBase[gitRepo, "HEAD", "master"]]];
+    minorVersionNumber = Max[0, Length[GitRange[
+      gitRepo, Except[versionInformation["Checkpoint"]], GitMergeBase[gitRepo, "HEAD", "master"]]] - 1];
     pacletInfoFilename = FileNameJoin[{$buildDirectory, "PacletInfo.m"}];
     pacletInfo = Association @@ Import[pacletInfoFilename];
     versionString = pacletInfo[Version] <> "." <> ToString[minorVersionNumber];,

--- a/scripts/version.wl
+++ b/scripts/version.wl
@@ -1,3 +1,3 @@
 <|
-  "Checkpoint" -> "7feedcadedb382eeb028be8a3b8d9cbc6fee28b1"
+  "Checkpoint" -> "f6160cdc94253625db7405a34b6c09002ac5f251"
 |>

--- a/scripts/version.wl
+++ b/scripts/version.wl
@@ -1,3 +1,3 @@
 <|
-  "Checkpoint" -> "f6160cdc94253625db7405a34b6c09002ac5f251"
+  "Checkpoint" -> "58de7583018f3688e4f94cdd3bac1500df95f9df"
 |>


### PR DESCRIPTION
## Changes
* Bumps version number to 0.3 :tada:, and sets the checkpoint to 58de7583018f3688e4f94cdd3bac1500df95f9df.
* Decreases the minor version counting by one so that the version immediately after merging this PR is 0.3.0, not 0.3.1.

## Comments
* Once this is merged, a new release should be created with the cross-platform paclet attached.

## Examples
* Build the paclet and check the version is correct:
```
>> ./build.wls && ls *.paclet      
Build done.
SetReplace-0.3.0.paclet
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/304)
<!-- Reviewable:end -->
