### PR TITLE
Add header cstdint to IDTypes providing int64_t

### DIFF
--- a/libSetReplace/IDTypes.hpp
+++ b/libSetReplace/IDTypes.hpp
@@ -1,6 +1,8 @@
 #ifndef IDTypes_h
 #define IDTypes_h
 
+#include <cstdint>
+
 namespace SetReplace {
     /** @brief Identifiers for atoms, which are the elements of expressions, i.e., vertices in the graph.
      * @details Positive IDs refer to specific atoms, negative IDs refer to patterns (as, for instance, can be used in the rules).


### PR DESCRIPTION
To be self-consistent and include all the headers IDTypes.hpp needs.

I am guessing IDTypes.hpp is included
in a compilation unit where cstdint is included.

cpp-reference: https://en.cppreference.com/w/cpp/types/integer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/308)
<!-- Reviewable:end -->
