### PR TITLE
Reduced number of hash table lookups and memory allocations

### DIFF
--- a/libSetReplace/Expression.cpp
+++ b/libSetReplace/Expression.cpp
@@ -49,11 +49,8 @@ namespace SetReplace {
         }
         
         const std::unordered_set<ExpressionID> expressionsContainingAtom(const Atom atom) const {
-            if (index_.count(atom)) {
-                return index_.at(atom);
-            } else {
-                return {};
-            }
+            const auto resultIterator = index_.find(atom);
+            return resultIterator != index_.end() ? resultIterator->second : std::unordered_set<ExpressionID>();
         }
     };
     

--- a/libSetReplace/Expression.cpp
+++ b/libSetReplace/Expression.cpp
@@ -18,14 +18,14 @@ namespace SetReplace {
                 expressionsToDelete.insert(expression);
             }
             
-            std::unordered_set<Atom> involedAtoms;
+            std::unordered_set<Atom> involvedAtoms;
             for (const auto& expression : expressionIDs) {
                 for (const auto& atom : getAtomsVector_(expression)) {
-                    involedAtoms.insert(atom);
+                    involvedAtoms.insert(atom);
                 }
             }
             
-            for (const auto& atom : involedAtoms) {
+            for (const auto& atom : involvedAtoms) {
                 auto expressionIterator = index_[atom].begin();
                 while (expressionIterator != index_[atom].end()) {
                     if (expressionsToDelete.count(*expressionIterator)) {
@@ -65,7 +65,7 @@ namespace SetReplace {
         implementation_->removeExpressions(expressionIDs);
     }
     
-    void AtomsIndex::addExpressions(const std::vector<ExpressionID> &expressionIDs) {
+    void AtomsIndex::addExpressions(const std::vector<ExpressionID>& expressionIDs) {
         implementation_->addExpressions(expressionIDs);
     }
     

--- a/libSetReplace/Expression.cpp
+++ b/libSetReplace/Expression.cpp
@@ -26,14 +26,16 @@ namespace SetReplace {
             }
             
             for (const auto& atom : involvedAtoms) {
-                auto& currentExpressions = index_[atom];
-                for (const auto& expression : expressionsToDelete) {
-                    if (currentExpressions.empty()) {
-                        break;
+                auto expressionIterator = index_[atom].begin();
+                while (expressionIterator != index_[atom].end()) {
+                    if (expressionsToDelete.count(*expressionIterator)) {
+                        expressionIterator = index_[atom].erase(expressionIterator);
                     }
-                    currentExpressions.erase(expression);
+                    else {
+                        ++expressionIterator;
+                    }
                 }
-                if (currentExpressions.empty()) {
+                if (index_[atom].empty()) {
                     index_.erase(atom);
                 }
             }

--- a/libSetReplace/Match.cpp
+++ b/libSetReplace/Match.cpp
@@ -66,14 +66,14 @@ namespace SetReplace {
         
         static int compareSortedIDs(const MatchPtr a, const MatchPtr b, const bool reverseOrder) {
             std::vector<ExpressionID> aExpressions = a->inputExpressions;
-            std::sort(aExpressions.begin(), aExpressions.end());
-            
             std::vector<ExpressionID> bExpressions = b->inputExpressions;
-            std::sort(bExpressions.begin(), bExpressions.end());
-            
-            if (reverseOrder) {
-                std::reverse(aExpressions.begin(), aExpressions.end());
-                std::reverse(bExpressions.begin(), bExpressions.end());
+
+            if (!reverseOrder) {
+                std::sort(aExpressions.begin(), aExpressions.end(), std::less<Atom>());
+                std::sort(bExpressions.begin(), bExpressions.end(), std::less<Atom>());
+            } else {
+                std::sort(aExpressions.begin(), aExpressions.end(), std::greater<Atom>());
+                std::sort(bExpressions.begin(), bExpressions.end(), std::greater<Atom>());
             }
             return compareVectors(aExpressions, bExpressions);
         }

--- a/libSetReplace/Match.cpp
+++ b/libSetReplace/Match.cpp
@@ -415,7 +415,7 @@ namespace SetReplace {
     
     bool Matcher::substituteMissingAtomsIfPossible(const std::vector<AtomsVector> inputPatterns,
                                                    const std::vector<AtomsVector> patternMatches,
-                                                   std::vector<AtomsVector> &atomsToReplace) {
+                                                   std::vector<AtomsVector>& atomsToReplace) {
         if (inputPatterns.size() != patternMatches.size()) return false;
         
         std::unordered_map<Atom, Atom> match;

--- a/libSetReplace/SetReplace.cpp
+++ b/libSetReplace/SetReplace.cpp
@@ -61,15 +61,15 @@ namespace SetReplace {
             return getData(tensorData, tensorLength, readIndex++);
         };
         
-        const mint setLength = getSetData();
-        std::vector<AtomsVector> set;
-        for (mint expressionIndex = 0; expressionIndex < setLength; ++expressionIndex) {
+        std::vector<AtomsVector> set(getSetData());
+        for (auto& atomsVector : set) {
             const mint expressionLength = getSetData();
-            set.push_back(AtomsVector());
+            atomsVector.resize(expressionLength);
             for (mint atomIndex = 0; atomIndex < expressionLength; ++atomIndex) {
-                set[expressionIndex].push_back(static_cast<Atom>(getSetData()));
+                atomsVector[atomIndex] = static_cast<Atom>(getSetData());
             }
         }
+
         return set;
     }
 
@@ -77,10 +77,11 @@ namespace SetReplace {
         mint tensorLength = libData->MTensor_getFlattenedLength(orderingSpecTensor);
         mint* tensorData = libData->MTensor_getIntegerData(orderingSpecTensor);
         Matcher::OrderingSpec result;
+        result.reserve(tensorLength);
         for (mint i = 0; i < tensorLength; i += 2) {
-            result.push_back({
+            result.emplace_back(std::make_pair<Matcher::OrderingFunction, Matcher::OrderingDirection>(
                 static_cast<Matcher::OrderingFunction>(getData(tensorData, tensorLength, i)),
-                static_cast<Matcher::OrderingDirection>(getData(tensorData, tensorLength, i + 1))});
+                static_cast<Matcher::OrderingDirection>(getData(tensorData, tensorLength, i + 1))));
         }
         return result;
     }
@@ -321,7 +322,7 @@ namespace SetReplace {
             mint position[1];
             for (size_t event = 1; event < ruleIDs.size(); ++event) {
                 position[0] = ++writeIndex;
-                libData->MTensor_setInteger(output, position, ruleIDs[event] + 1);
+                libData->MTensor_setInteger(output, position, static_cast<mint>(ruleIDs[event]) + 1);
             }
             
             MArgument_setMTensor(result, output);


### PR DESCRIPTION
## Changes
* Optimized some cases of hash table lookups such that they occur less
* Reduced number of `std::vector::push_back` calls in favor of either `std::vector::reserve`+`std::vector::emplace_back` or `std::vector::resize`+`std::vector::operator[]` to reduce number of memory allocations
* A few other small changes, such as spelling/code style consistency

## Comments
* No functionality is changed

## Examples
The following is a basic example of reducing hash table lookups (worst case O(n) with size of container)

Before:
```c++
if (index_.count(atom)) {
    return index_.at(atom);
} else {
    return {};
}
```
After:
```c++
const auto resultIterator = index_.find(atom);
return resultIterator != index_.end() ? resultIterator->second : std::unordered_set<ExpressionID>();
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/311)
<!-- Reviewable:end -->
