### PR TITLE
Add syntax highlighting to markdown files

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -137,7 +137,7 @@ One way to implement such argument checking is to make special `valid*Q` functio
 
 A better approach is to setup the function to catch exceptions, i.e.,
 
-```
+```wl
 MakeUniverse[args___] := Module[{result = Catch[makeUniverse[args]]},
   result /; result =!= $Failed
 ]
@@ -145,7 +145,7 @@ MakeUniverse[args___] := Module[{result = Catch[makeUniverse[args]]},
 
 and parse the inputs lazily, printing a message, and throwing an exception if something is wrong:
 
-```
+```wl
 failUniverse[badUniverse_] := (
   Message[MakeUniverse::bad, badUniverse];
   Throw[$Failed]
@@ -180,7 +180,7 @@ Unit tests live in the [Tests folder](/Tests). They are technically .wlt files, 
 
 Each file consists of a single [`Association`](https://reference.wolfram.com/language/ref/Association.html):
 
-```
+```wl
 <|"FunctionName" -> <|"init" -> ..., "tests" -> {VerificationTest[...], ...}, "options" -> ...|>, ...|>
 ```
 
@@ -188,14 +188,14 @@ Each file consists of a single [`Association`](https://reference.wolfram.com/lan
 
 Apart from [`VerificationTest`](https://reference.wolfram.com/language/ref/VerificationTest.html), there are other convenience testing functions defined in [testUtilities.m](/Kernel/testUtilities.m). For example, `"testUnevaluated"` can be used to test if the function returns unevaluated for given arguments. `"testSymbolLeak"` can check if internal symbols are not garbage-collected during the evaluation. Since these are `PackageScope` functions, they need to be used as, i.e., ``SetReplace`PackageScope`testUnevaluated[VerificationTest, args]``. To avoid typing `PackageScope` every time, however, it is convenient to define them in `"init"` as, i.e.,
 
-```
+```wl
 Attributes[Global`testUnevaluated] = {HoldAll};
 Global`testUnevaluated[args___] := SetReplace`PackageScope`testUnevaluated[VerificationTest, args];
 ```
 
 This way, the test itself can simply be defined as
 
-```
+```wl
 testUnevaluated[
   MakeUniverse[42],
   {MakeUniverse::badUniverse}
@@ -217,13 +217,13 @@ Some things to note are:
 * All references to functions should be links, either to [the Wolfram Language documentation](https://reference.wolfram.com/language/) or to the corresponding section in [README](/README.md).
 * Images (i.e., of output cells) should be made by selecting the relevant cells in the Front End, copying them as bitmaps, and saving them as .png files to [READMEImages](/READMEImages) directory. They should then be inserted using the code similar to this:
 
-  ```
+  ```html
   <img src="READMEImages/image.png" width="xxx">
   ```
 
   where the `width` should be computed as
 
-  ```
+  ```wl
   Round[0.6 First @ Import["$RepoRoot/READMEImages/image.png", "ImageSize"]]
   ```
 
@@ -244,7 +244,7 @@ In addition to that, here are some more-or-less established rules:
 * Use spaces instead of tabs, and use 2 spaces for indentation.
 * Close code block function brackets on the new line (for functions such as [`Module`](https://reference.wolfram.com/language/ref/Module.html), [`With`](https://reference.wolfram.com/language/ref/With.html) and [`If`](https://reference.wolfram.com/language/ref/If.html)):
 
-  ```
+  ```wl
   Module[{result = f[x]},
     result *= 2;
     result
@@ -253,7 +253,7 @@ In addition to that, here are some more-or-less established rules:
 
 * However, close the brackets of ordinary functions on the same line as the last argument:
 
-  ```
+  ```wl
   veryLongFunctionCall[
     longArgument1, longArgument2, longArgument3]
   ```

--- a/.github/ISSUE_TEMPLATE/weed_report.md
+++ b/.github/ISSUE_TEMPLATE/weed_report.md
@@ -9,7 +9,7 @@ assignees: ''
 
 ### The problem
 A clear and concise description of what is not working.
-```
+```wl
 In[] := minimal input that is not working
 ```
 image of the actual output.
@@ -18,12 +18,12 @@ image of the actual output.
 A clear and concise description of what you expected to happen.
 
 ### Version
-```
+```wl
 In[] := SystemInformation["Small"]
 ```
 image of the output
 
-```
+```wl
 In[] := $SetReplaceGitSHA
 ```
 paste the output here without quotes.

--- a/README.md
+++ b/README.md
@@ -6,26 +6,26 @@
 
 **SetReplace** is a [Wolfram Language](https://www.wolfram.com/language/) package for manipulating set substitution systems. To understand what a set substitution system does consider an unordered set of elements:
 
-```
+```wl
 {1, 2, 5, 3, 6}
 ```
 
 We can set up an operation on this set which would take any of the two elements and replace them with their sum:
 
-```
+```wl
 {a_, b_} :> {a + b}
 ```
 
 In **SetReplace**, this can be expressed as the following (the new element `1 + 2 -> 3` is put at the end)
 
-```
+```wl
 In[] := SetReplace[{1, 2, 5, 3, 6}, {a_, b_} :> {a + b}]
 Out[] = {5, 3, 6, 3}
 ```
 
 Note that this is similar to [`SubsetReplace`](https://reference.wolfram.com/language/ref/SubsetReplace.html) function of Wolfram Language (introduced in version 12.1, it replaces all non-overlapping subsets at once by default):
 
-```
+```wl
 In[] := SubsetReplace[{1, 2, 5, 3, 6}, {a_, b_} :> a + b]
 Out[] = {3, 8, 6}
 ```
@@ -36,13 +36,13 @@ A more interesting case (which we call a Wolfram model) is one where the set ele
 
 As an example consider a set:
 
-```
+```wl
 {{1, 2, 3}, {2, 4, 5}, {4, 6, 7}}
 ```
 
 We can render it as a collection of ordered hyperedges:
 
-```
+```wl
 In[] := WolframModelPlot[{{1, 2, 3}, {2, 4, 5}, {4, 6, 7}},
  VertexLabels -> Automatic]
 ```
@@ -51,14 +51,14 @@ In[] := WolframModelPlot[{{1, 2, 3}, {2, 4, 5}, {4, 6, 7}},
 
 We can then have a rule which would pick a subset of these hyperedges related through common vertices (much like a join query) and replace them with something else:
 
-```
+```wl
 {{v1_, v2_, v3_}, {v2_, v4_, v5_}} :>
  Module[{v6}, {{v5, v6, v1}, {v6, v4, v2}, {v4, v5, v3}}]
 ```
 
 Note the [`Module`](https://reference.wolfram.com/language/ref/Module.html) on the right-hand side creates a new variable (vertex) which causes the hypergraph to grow. After a single replacement we get this (the new vertex is `v11`, due to optimizations it's not always a [`Module`](https://reference.wolfram.com/language/ref/Module.html) that creates vertices, so the naming may be different):
 
-```
+```wl
 In[] := WolframModelPlot[SetReplace[{{1, 2, 3}, {2, 4, 5}, {4, 6, 7}},
   {{v1_, v2_, v3_}, {v2_, v4_, v5_}} :>
    Module[{v6}, {{v5, v6, v1}, {v6, v4, v2}, {v4, v5, v3}}]],
@@ -69,7 +69,7 @@ In[] := WolframModelPlot[SetReplace[{{1, 2, 3}, {2, 4, 5}, {4, 6, 7}},
 
 After 10 steps, we get a more complicated structure:
 
-```
+```wl
 In[] := WolframModelPlot[SetReplace[{{1, 2, 3}, {2, 4, 5}, {4, 6, 7}},
   {{v1_, v2_, v3_}, {v2_, v4_, v5_}} :>
    Module[{v6}, {{v5, v6, v1}, {v6, v4, v2}, {v4, v5, v3}}], 10],
@@ -80,7 +80,7 @@ In[] := WolframModelPlot[SetReplace[{{1, 2, 3}, {2, 4, 5}, {4, 6, 7}},
 
 And after 100 steps, it gets even more elaborate:
 
-```
+```wl
 In[] := WolframModelPlot[SetReplace[{{1, 2, 3}, {2, 4, 5}, {4, 6, 7}},
   {{v1_, v2_, v3_}, {v2_, v4_, v5_}} :>
    Module[{v6}, {{v5, v6, v1}, {v6, v4, v2}, {v4, v5, v3}}], 100]]
@@ -106,7 +106,7 @@ To build:
 1. `cd` to the root directory of the repository.
 2. Run `./build.wls` to create the paclet file. If you see an error message about c++17, make sure the C++ compiler you are using is up-to-date. If your default system compiler does not support c++17, you can choose a different one with environmental variables. The following, for instance, typically works on a Mac:
 
-    ```
+    ```bash
     COMPILER=CCompilerDriver\`ClangCompiler\`ClangCompiler COMPILER_INSTALLATION=/usr/bin ./build.wls
     ```
 
@@ -136,34 +136,34 @@ These functions are good for their simplicity and can be primarily used to obtai
 
 As was mentioned previously, `SetReplace` performs a single iteration if called with two arguments:
 
-```
+```wl
 In[] := SetReplace[set, rule]
 ```
 
 For example,
 
-```
+```wl
 In[] := SetReplace[{1, 2, 5, 3, 6}, {a_, b_} :> {a + b}]
 Out[] = {5, 3, 6, 3}
 ```
 
 It can be supplied a third argument specifying the number of replacements (the same can be achieved using [`Nest`](https://reference.wolfram.com/language/ref/Nest.html)):
 
-```
+```wl
 In[] := SetReplace[{1, 2, 5, 3, 6}, {a_, b_} :> {a + b}, 2]
 Out[] = {6, 3, 8}
 ```
 
 If the number of replacements is set to [`Infinity`](https://reference.wolfram.com/language/ref/Infinity.html) calling `SetReplace` is equivalent to `SetReplaceFixedPoint`:
 
-```
+```wl
 In[] := SetReplace[{1, 2, 5, 3, 6}, {a_, b_} :> {a + b}, Infinity]
 Out[] = {17}
 ```
 
 It is possible to use multiple rules (here the replacements `{1, 5} -> {5}` and `{2, 6} -> {8}` are made):
 
-```
+```wl
 In[] := SetReplace[{1, 2, 5, 3, 6},
  {{a_?EvenQ, b_?EvenQ} :> {a + b}, {a_?OddQ, b_?OddQ} :> {a b}}, 2]
 Out[] = {3, 5, 8}
@@ -171,26 +171,26 @@ Out[] = {3, 5, 8}
 
 `SetReplaceList` can be used to see the set after each replacement (here a list is omitted on the right-hand side of the rule, which can be done if the subset only contains a single element). Similar to `SetReplace`, if the number of steps is [`Infinity`](https://reference.wolfram.com/language/ref/Infinity.html), it's equivalent to `SetReplaceFixedPointList`:
 
-```
+```wl
 In[] := SetReplaceList[{1, 2, 5, 3, 6}, {a_, b_} :> a + b, Infinity]
 Out[] = {{1, 2, 5, 3, 6}, {5, 3, 6, 3}, {6, 3, 8}, {8, 9}, {17}}
 ```
 
 `SetReplaceAll` replaces all non-overlapping subsets:
 
-```
+```wl
 In[] := SetReplaceAll[{1, 2, 5, 3, 6}, {a_, b_} :> a + b]
 Out[] = {6, 3, 8}
 ```
 
 `SetReplaceFixedPoint` and `SetReplaceFixedPointList` perform replacements for as long as possible as previously mentioned:
 
-```
+```wl
 In[] := SetReplaceFixedPoint[{1, 2, 5, 3, 6}, {a_, b_} :> a + b]
 Out[] = {17}
 ```
 
-```
+```wl
 In[] := SetReplaceFixedPointList[{1, 2, 5, 3, 6}, {a_, b_} :> a + b]
 Out[] = {{1, 2, 5, 3, 6}, {5, 3, 6, 3}, {6, 3, 8}, {8, 9}, {17}}
 ```
@@ -201,7 +201,7 @@ All of these functions have [`Method`](#method), [`TimeConstraint`](#timeconstra
 
 **`ToPatternRules`** is a convenience function used to quickly enter rules such as the one mentioned previously:
 
-```
+```wl
 {{v1_, v2_, v3_}, {v2_, v4_, v5_}} :>
  Module[{v6}, {{v5, v6, v1}, {v6, v4, v2}, {v4, v5, v3}}]
 ```
@@ -215,7 +215,7 @@ This is the type of rule we study the most, and it satisfies the following set o
 
 `ToPatternRules` provides a more straightforward way to specify such rules by automatically assuming that all level-2 expressions on the left-hand side are patterns, and vertices used on the right that don't appear on the left are new and should be created with a [`Module`](https://reference.wolfram.com/language/ref/Module.html). For example, the rule above can simply be written as
 
-```
+```wl
 In[] := ToPatternRules[{{v1, v2, v3}, {v2, v4, v5}} ->
   {{v5, v6, v1}, {v6, v4, v2}, {v4, v5, v3}}]
 Out[] = {{v1_, v2_, v3_}, {v2_, v4_, v5_}} :>
@@ -224,7 +224,7 @@ Out[] = {{v1_, v2_, v3_}, {v2_, v4_, v5_}} :>
 
 or even simpler as
 
-```
+```wl
 In[] := ToPatternRules[{{1, 2, 3}, {2, 4, 5}} ->
   {{5, 6, 1}, {6, 4, 2}, {4, 5, 3}}]
 Out[] = {{v1_, v2_, v3_}, {v2_, v4_, v5_}} :>
@@ -235,7 +235,7 @@ This last form of the rule is the one that we use most often and is also the one
 
 `ToPatternRules` is listable in a trivial way:
 
-```
+```wl
 In[] := ToPatternRules[{{{1, 2}} -> {{1, 2}, {2, 3}},
   {{1, 2}} -> {{1, 3}, {3, 2}}}]
 Out[] = {{{v1_, v2_}} :> Module[{v3}, {{v1, v2}, {v2, v3}}],
@@ -250,13 +250,13 @@ Out[] = {{{v1_, v2_}} :> Module[{v3}, {{v1, v2}, {v2, v3}}],
 
 The most basic way to call it is
 
-```
+```wl
 In[] := WolframModel[rule, initial set, step count]
 ```
 
 For example,
 
-```
+```wl
 In[] := WolframModel[{{1, 2, 3}, {2, 4, 5}} ->
   {{5, 6, 1}, {6, 4, 2}, {4, 5, 3}},
  {{1, 2, 3}, {2, 4, 5}, {4, 6, 7}}, 10]
@@ -273,7 +273,7 @@ Note that this call is different from the [`SetReplace`](#setreplace) function i
 
 To see the information an evolution object contains, let's make one with a smaller number of generations:
 
-```
+```wl
 In[] := WolframModel[{{1, 2, 3}, {2, 4, 5}} ->
   {{5, 6, 1}, {6, 4, 2}, {4, 5, 3}},
  {{1, 2, 3}, {2, 4, 5}, {4, 6, 7}}, 3]
@@ -285,7 +285,7 @@ One can easily see its internal structure in its [`InputForm`](https://reference
 
 <img src="READMEImages/InputFormOfEvolutionObject.png" width="594">
 
-```
+```wl
 Out[] = WolframModelEvolutionObject[<|
   "CreatorEvents" -> {0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 5,
     5, 5},
@@ -313,7 +313,7 @@ In this particular example, it begins with `{1, 2, 3}`, `{2, 4, 5}` and `{4, 6, 
 
 <img src="READMEImages/StatesListOfEvolutionObject.png" width="613">
 
-```
+```wl
 Out[] = {{{1, 2, 3}, {2, 4, 5}, {4, 6, 7}},
  {{4, 6, 7}, {5, 8, 1}, {8, 4, 2}, {4, 5, 3}},
  {{7, 9, 8}, {9, 6, 4}, {6, 7, 2}, {1, 10, 4}, {10, 8, 5}, {8, 1,
@@ -338,7 +338,7 @@ A specific property can be requested from an evolution object by supplying it as
 
 <img src="READMEImages/EventsCountOfEvolutionObject.png" width="629">
 
-```
+```wl
 Out[] = 109
 ```
 
@@ -346,7 +346,7 @@ Out[] = 109
 
 <img src="READMEImages/PropertiesOfEvolutionObject.png" width="619">
 
-```
+```wl
 Out[] = {"EvolutionObject", "FinalState", "FinalStatePlot", "StatesList",
   "StatesPlotsList", "EventsStatesPlotsList",
   "AllEventsStatesEdgeIndicesList", "AllEventsStatesList",
@@ -368,7 +368,7 @@ Some properties take additional arguments, which can be supplied after the prope
 
 <img src="READMEImages/StateAfterEventOfEvolutionObject.png" width="691">
 
-```
+```wl
 Out[] = {{8, 1, 3}, {5, 12, 1}, {12, 8, 10}, {8, 5, 4}, {2, 13, 11}, {13, 7,
   6}, {7, 2, 9}, {7, 14, 6}, {14, 11, 4}, {11, 7, 8}}
 ```
@@ -377,14 +377,14 @@ A particular generation can be extracted simply by its number (including, i.e., 
 
 <img src="READMEImages/GenerationOfEvolutionObject.png" width="516">
 
-```
+```wl
 Out[] = {{6, 7, 2}, {8, 1, 3}, {4, 11, 7}, {11, 6, 9}, {6, 4, 8}, {5, 12,
   1}, {12, 8, 10}, {8, 5, 4}}
 ```
 
 If a property does not take any arguments, it can be specified directly in `WolframModel` as the fourth argument:
 
-```
+```wl
 In[] := WolframModel[{{1, 2, 3}, {2, 4, 5}} ->
   {{5, 6, 1}, {6, 4, 2}, {4, 5, 3}},
  {{1, 2, 3}, {2, 4, 5}, {4, 6, 7}}, 10, "EdgeCountList"]
@@ -393,7 +393,7 @@ Out[] = {3, 4, 6, 8, 12, 18, 24, 36, 54, 76, 112}
 
 All properties available to use directly in `WolframModel` can be looked up in `$WolframModelProperties` (there are more properties here compared to the list above because some properties are available under multiple names, and only the canonical name is listed above):
 
-```
+```wl
 In[] := $WolframModelProperties
 Out[] = {"AllEventsCount", "AllEventsDistinctElementsCount",
   "AllEventsEdgesCount", "AllEventsEdgesList",
@@ -417,7 +417,7 @@ Out[] = {"AllEventsCount", "AllEventsDistinctElementsCount",
 
 Multiple properties can also be specified in a list (only in `WolframModel`, not in `WolframModelEvolutionObject`):
 
-```
+```wl
 In[] = WolframModel[{{1, 2, 3}, {2, 4, 5}} ->
   {{5, 6, 1}, {6, 4, 2}, {4, 5, 3}},
  {{1, 2, 3}, {2, 4, 5}, {4, 6, 7}}, 10,
@@ -432,7 +432,7 @@ Out[] = {{3, 4, 6, 8, 12, 18, 24, 36, 54, 76, 112},
 
 Multiple rules can simply be specified as a list of rules:
 
-```
+```wl
 In[] := WolframModel[{{{1, 1, 2}} -> {{2, 2, 1}, {2, 3, 2}, {1, 2, 3}},
   {{1, 2, 1}, {3, 4, 2}} -> {{4, 3, 2}}}, {{1, 1, 1}}, 4]
 ```
@@ -443,7 +443,7 @@ To see which rules were used for each replacement:
 
 <img src="READMEImages/AllEventsRuleIndicesOfEvolutionObject.png" width="708">
 
-```
+```wl
 Out[] = {1, 1, 1, 1, 1, 1, 2, 1, 1, 1, 2, 1, 2}
 ```
 
@@ -451,7 +451,7 @@ Out[] = {1, 1, 1, 1, 1, 1, 2, 1, 1, 1, 2, 1, 2}
 
 Pattern rules (i.e., the kind of rules used in the [`SetReplace`](#setreplace) function) can be specified as well. As an example, previously described call to [`SetReplaceList`](#setreplace) can be reproduced as
 
-```
+```wl
 In[] := WolframModel[<|"PatternRules" -> {a_, b_} :> a + b|>,
  {1, 2, 5, 3, 6}, Infinity, "AllEventsStatesList"]
 Out[] = {{1, 2, 5, 3, 6}, {5, 3, 6, 3}, {6, 3, 8}, {8, 9}, {17}}
@@ -461,7 +461,7 @@ Out[] = {{1, 2, 5, 3, 6}, {5, 3, 6, 3}, {6, 3, 8}, {8, 9}, {17}}
 
 An initial state consisting of an appropriate number of (hyper) self-loops can be automatically produced for anonymous (non-pattern) rules. Here we evolve the system for 0 steps and ask the evolution object for the 0-th generation aka the initial state:
 
-```
+```wl
 In[] := WolframModel[{{1, 2}, {1, 2}} -> {{3, 2}, {3, 2}, {2, 1}, {1, 3}},
   Automatic, 0][0]
 Out[] = {{1, 1}, {1, 1}}
@@ -469,7 +469,7 @@ Out[] = {{1, 1}, {1, 1}}
 
 That even works for multiple rules in which case the loops are chosen in such a way that any of the rules can match:
 
-```
+```wl
 In[] := WolframModel[{{{1, 2}, {1, 2}} ->
     {{3, 2}, {3, 2}, {2, 1, 3}, {2, 3}},
    {{2, 1, 3}, {2, 3}} -> {{2, 1}, {1, 3}}}, Automatic, 0][0]
@@ -482,7 +482,7 @@ Note that because different patterns can be matched to the same symbol, this ini
 
 The standard numeric argument to `WolframModel` specifies the number of generations:
 
-```
+```wl
 In[] := WolframModel[{{1, 2, 3}, {4, 5, 6}, {2, 5}, {5, 2}} ->
   {{7, 1, 8}, {9, 3, 10}, {11, 4, 12}, {13, 6, 14}, {7, 13}, {13,
     7}, {8, 10}, {10, 8}, {9, 11}, {11, 9}, {12, 14}, {14, 12}},
@@ -494,7 +494,7 @@ In[] := WolframModel[{{1, 2, 3}, {4, 5, 6}, {2, 5}, {5, 2}} ->
 
 Alternatively, an [`Association`](https://reference.wolfram.com/language/ref/Association.html) can be used to specify a more elaborate limiting condition:
 
-```
+```wl
 In[] := WolframModel[{{1, 2, 3}, {4, 5, 6}, {2, 5}, {5, 2}} ->
   {{7, 1, 8}, {9, 3, 10}, {11, 4, 12}, {13, 6, 14}, {7, 13}, {13,
     7}, {8, 10}, {10, 8}, {9, 11}, {11, 9}, {12, 14}, {14, 12}},
@@ -509,7 +509,7 @@ Note that the final state here is "less symmetric" because its last generation i
 
 One can also see the presence of an incomplete generation by looking at the evolution object (note `5...6` which means 5 generations are complete, and 1 is not). Expanding the object's information, one can also see that in this particular case the evolution was terminated because `"MaxVertices"` (not `"MaxEvents"`) condition was reached:
 
-```
+```wl
 In[] := WolframModel[{{1, 2, 3}, {4, 5, 6}, {2, 5}, {5, 2}} ->
   {{7, 1, 8}, {9, 3, 10}, {11, 4, 12}, {13, 6, 14}, {7, 13}, {13,
     7}, {8, 10}, {10, 8}, {9, 11}, {11, 9}, {12, 14}, {14, 12}},
@@ -534,7 +534,7 @@ Note also that `"MaxGenerations"` works differently from the other limiters, as 
 
 It is also possible to set the step count to `Automatic`, in which case `WolframModel` tries to automatically pick a number of steps that showcases the evolution without taking too long. It stops the evolution sooner if the state grows quickly:
 
-```
+```wl
 In[] := WolframModel[{{1, 2, 3}, {2, 4, 5}} -> {{5, 6, 1}, {6, 4, 2}, {4, 5,
     3}},
  {{1, 2, 3}, {2, 4, 5}, {4, 6, 7}}, Automatic]
@@ -544,7 +544,7 @@ In[] := WolframModel[{{1, 2, 3}, {2, 4, 5}} -> {{5, 6, 1}, {6, 4, 2}, {4, 5,
 
 But evolves the rule much longer if it does not grow:
 
-```
+```wl
 In[] := WolframModel[<|"PatternRules" -> {{a_, b_}} :> {{a + b, a - b}}|>,
  {{1, 1}}, Automatic]
 ```
@@ -563,7 +563,7 @@ These are the properties used to extract states at a particular moment in the ev
 
 **`"FinalState"`** (aka -1) yields the state obtained after all replacements of the evolution have been made:
 
-```
+```wl
 In[] := WolframModelPlot @ WolframModel[{{1, 2, 3}, {4, 5, 6}, {1, 4}} ->
    {{2, 7, 8}, {3, 9, 10}, {5, 11, 12}, {6, 13, 14}, {8, 12}, {11,
      10}, {13, 7}, {14, 9}},
@@ -574,7 +574,7 @@ In[] := WolframModelPlot @ WolframModel[{{1, 2, 3}, {4, 5, 6}, {1, 4}} ->
 
 **`"StatesList"`** yields the list of states at each generation:
 
-```
+```wl
 In[] := WolframModelPlot /@ WolframModel[{{1, 2, 3}, {4, 5, 6}, {1, 4}} ->
    {{2, 7, 8}, {3, 9, 10}, {5, 11, 12}, {6, 13, 14}, {8, 12}, {11,
      10}, {13, 7}, {14, 9}},
@@ -585,7 +585,7 @@ In[] := WolframModelPlot /@ WolframModel[{{1, 2, 3}, {4, 5, 6}, {1, 4}} ->
 
 This is identical to using the **`"Generation"`** property mapped over all generations:
 
-```
+```wl
 In[] := WolframModelPlot /@ (WolframModel[{{1, 2, 3}, {4, 5, 6}, {1, 4}} ->
        {{2, 7, 8}, {3, 9, 10}, {5, 11, 12}, {6, 13, 14}, {8, 12}, {11,
           10}, {13, 7}, {14, 9}},
@@ -597,7 +597,7 @@ In[] := WolframModelPlot /@ (WolframModel[{{1, 2, 3}, {4, 5, 6}, {1, 4}} ->
 
 In fact `"Generation"` property can be omitted and the index of the generation can be used directly:
 
-```
+```wl
 In[] := WolframModelPlot /@ WolframModel[{{1, 2, 3}, {4, 5, 6}, {1, 4}} ->
     {{2, 7, 8}, {3, 9, 10}, {5, 11, 12}, {6, 13, 14}, {8, 12}, {11,
       10}, {13, 7}, {14, 9}},
@@ -608,7 +608,7 @@ In[] := WolframModelPlot /@ WolframModel[{{1, 2, 3}, {4, 5, 6}, {1, 4}} ->
 
 `"StatesList"` shows a compressed version of the evolution. To see how state changes with each applied replacement, use **`"AllEventsStatesList"`**:
 
-```
+```wl
 In[] := WolframModelPlot /@ WolframModel[{{1, 2, 3}, {4, 5, 6}, {1, 4}} ->
    {{2, 7, 8}, {3, 9, 10}, {5, 11, 12}, {6, 13, 14}, {8, 12}, {11,
      10}, {13, 7}, {14, 9}},
@@ -620,7 +620,7 @@ In[] := WolframModelPlot /@ WolframModel[{{1, 2, 3}, {4, 5, 6}, {1, 4}} ->
 
 Finally, to see a state after a specific event, use **`"StateAfterEvent"`** (aka `"SetAfterEvent"`):
 
-```
+```wl
 In[] := WolframModelPlot @ WolframModel[{{1, 2, 3}, {4, 5, 6}, {1, 4}} ->
     {{2, 7, 8}, {3, 9, 10}, {5, 11, 12}, {6, 13, 14}, {8, 12}, {11,
       10}, {13, 7}, {14, 9}},
@@ -636,7 +636,7 @@ In[] := WolframModelPlot @ WolframModel[{{1, 2, 3}, {4, 5, 6}, {1, 4}} ->
 
 Instead of explicitly calling [`WolframModelPlot`](#wolframmodelplot), one can use short-hand properties **`"FinalStatePlot"`** and **`"StatesPlotsList"`**:
 
-```
+```wl
 In[] := WolframModel[{{1, 2, 3}, {4, 5, 6}, {1, 4}} ->
   {{2, 7, 8}, {3, 9, 10}, {5, 11, 12}, {6, 13, 14}, {8, 12}, {11,
     10}, {13, 7}, {14, 9}},
@@ -645,7 +645,7 @@ In[] := WolframModel[{{1, 2, 3}, {4, 5, 6}, {1, 4}} ->
 
 <img src="READMEImages/FinalStatePlot.png" width="478">
 
-```
+```wl
 In[] := WolframModel[{{1, 2, 3}, {4, 5, 6}, {1, 4}} ->
   {{2, 7, 8}, {3, 9, 10}, {5, 11, 12}, {6, 13, 14}, {8, 12}, {11,
     10}, {13, 7}, {14, 9}},
@@ -656,7 +656,7 @@ In[] := WolframModel[{{1, 2, 3}, {4, 5, 6}, {1, 4}} ->
 
 These properties take the same options as [`WolframModelPlot`](#wolframmodelplot) (but one has to specify them in a call to the evolution object, not `WolframModel`):
 
-```
+```wl
 In[] := WolframModel[{{1, 2, 3}, {4, 5, 6}, {1, 4}} ->
    {{2, 7, 8}, {3, 9, 10}, {5, 11, 12}, {6, 13, 14}, {8, 12}, {11,
      10}, {13, 7}, {14, 9}},
@@ -670,7 +670,7 @@ In[] := WolframModel[{{1, 2, 3}, {4, 5, 6}, {1, 4}} ->
 
 The plotting function corresponding to [`"AllEventsStatesList"`](#states) is more interesting than the other ones. **`"EventsStatesPlotsList"`** plots not only the states, but also the events that produced them:
 
-```
+```wl
 In[] := WolframModel[{{1, 2, 3}, {4, 5, 6}, {1, 4}} ->
   {{2, 7, 8}, {3, 9, 10}, {5, 11, 12}, {6, 13, 14}, {8, 12}, {11,
     10}, {13, 7}, {14, 9}},
@@ -688,7 +688,7 @@ Here the dotted gray edges are the ones about to be deleted, whereas the red one
 
 Compare for instance the output of [`"StatesList"`](#states) for a system where only one replacement is made per generation:
 
-```
+```wl
 In[] := WolframModel[<|"PatternRules" -> {x_?OddQ, y_} :> x + y|>,
  {1, 2, 4, 6}, Infinity, "StatesList"]
 Out[] = {{1, 2, 4, 6}, {4, 6, 3}, {6, 7}, {13}}
@@ -696,7 +696,7 @@ Out[] = {{1, 2, 4, 6}, {4, 6, 3}, {6, 7}, {13}}
 
 to the output of `"AllEventsEdgesList"`:
 
-```
+```wl
 In[] := WolframModel[<|"PatternRules" -> {x_?OddQ, y_} :> x + y|>,
  {1, 2, 4, 6}, Infinity, "AllEventsEdgesList"]
 Out[] = {1, 2, 4, 6, 3, 7, 13}
@@ -710,7 +710,7 @@ Edge indices from `"AllEventsEdgesList"` are used in various other properties su
 
 **`"AllEventsStatesEdgeIndicesList"`** is similar to [`"AllEventsStatesList"`](#states), except instead of actual edges the list it returns contains the indices of edges from [`"AllEventsEdgesList"`](#all-edges-throughout-evolution):
 
-```
+```wl
 In[] := WolframModel[{{1, 2, 3}, {4, 5, 6}, {1, 4}} ->
   {{2, 7, 8}, {3, 9, 10}, {5, 11, 12}, {6, 13, 14}, {8, 12}, {11,
     10}, {13, 7}, {14, 9}},
@@ -723,7 +723,7 @@ Out[] = {{1, 2, 3, 4, 5}, {4, 5, 6, 7, 8, 9, 10, 11, 12, 13}, {5, 8, 9, 10,
 
 One can easily go back to states:
 
-```
+```wl
 In[] := WolframModelPlot /@ With[{
    evolution = WolframModel[{{1, 2, 3}, {4, 5, 6}, {1, 4}} ->
       {{2, 7, 8}, {3, 9, 10}, {5, 11, 12}, {6, 13, 14}, {8, 12}, {11,
@@ -739,7 +739,7 @@ However, this representation is useful if one needs to distinguish between ident
 
 Similarly, **`"StateEdgeIndicesAfterEvent"`** is a index analog of [`"StateAfterEvent"`](#states):
 
-```
+```wl
 In[] := WolframModel[{{1, 2, 3}, {4, 5, 6}, {1, 4}} ->
    {{2, 7, 8}, {3, 9, 10}, {5, 11, 12}, {6, 13, 14}, {8, 12}, {11,
      10}, {13, 7}, {14, 9}},
@@ -755,7 +755,7 @@ Out[] = {18, 19, 29, 34, 35, 36, 37, 39, 40, 42, 43, 44, 45, 49, 50, 51, 52,
 
 **`"AllEventsList"`** (aka `"EventsList"`) and **`"GenerationEventsList"`** both return all replacement events throughout the evolution. The only difference is how the events are arranged. `"AllEventsList"` returns the flat list of all events, whereas `"GenerationEventsList"` splits them into sublists for each generation:
 
-```
+```wl
 In[] := WolframModel[{{1, 2}} -> {{3, 4}, {3, 1}, {4, 1}, {2, 4}},
  {{1, 1}}, 2, "AllEventsList"]
 Out[] = {{1, {1} -> {2, 3, 4, 5}}, {1, {2} -> {6, 7, 8, 9}},
@@ -763,7 +763,7 @@ Out[] = {{1, {1} -> {2, 3, 4, 5}}, {1, {2} -> {6, 7, 8, 9}},
  {1, {5} -> {18, 19, 20, 21}}}
 ```
 
-```
+```wl
 In[] := WolframModel[{{1, 2}} -> {{3, 4}, {3, 1}, {4, 1}, {2, 4}},
  {{1, 1}}, 2, "GenerationEventsList"]
 Out[] = {{{1, {1} -> {2, 3, 4, 5}}},
@@ -773,7 +773,7 @@ Out[] = {{{1, {1} -> {2, 3, 4, 5}}},
 
 The format for the events is
 
-```
+```wl
 {ruleIndex, {inputEdgeIndices} -> {outputEdgeIndices}}
 ```
 
@@ -783,7 +783,7 @@ where the edge indices refer to expressions from [`"AllEventsEdgesList"`](#all-e
 
 **`"EventsStatesList"`** just produces a list of `{event, state}` pairs, where state is the complete state right after this event is applied. Events are the same as generated by [`"AllEventsList"`](#events), and the states are represented as edge indices as in [`"AllEventsStatesEdgeIndicesList"`](#states-as-edge-indices):
 
-```
+```wl
 In[] := WolframModel[{{1, 2}} -> {{3, 4}, {3, 1}, {4, 1}, {2, 4}},
  {{1, 1}}, 2, "EventsStatesList"]
 Out[] = {{{1, {1} -> {2, 3, 4, 5}}, {2, 3, 4, 5}},
@@ -801,7 +801,7 @@ An event is said to *destroy* the edges in its input, and *create* the edges in 
 
 As an example, for a simple rule that splits each edge in two, one can see that edges are created in pairs:
 
-```
+```wl
 In[] := WolframModel[{{1, 2}} -> {{1, 3}, {3, 2}},
  {{1, 1}}, 4, "EdgeCreatorEventIndices"]
 Out[] = {0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11,
@@ -810,7 +810,7 @@ Out[] = {0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11,
 
 and destroyed one-by-one:
 
-```
+```wl
 In[] := WolframModel[{{1, 2}} -> {{1, 3}, {3, 2}},
  {{1, 1}}, 4, "EdgeDestroyerEventIndices"]
 Out[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, Infinity,
@@ -827,7 +827,7 @@ An event **A** *causes* an event **B** if there exists a set element created by 
 
 For example, if we consider our simple arithmetic model `{a_, b_} :> a + b` starting from `{3, 8, 8, 8, 2, 10, 0, 9, 7}` we get a causal graph which quite clearly describes what's going on (we label each event here with explicit values for a and b):
 
-```
+```wl
 In[] := With[{
   evolution = WolframModel[<|"PatternRules" -> {a_, b_} :> a + b|>,
     {3, 8, 8, 8, 2, 10, 0, 9, 7}, Infinity]}, With[{
@@ -843,7 +843,7 @@ In[] := With[{
 
 Here is an example for a hypergraph model (admittedly considerably harder to understand). Multiedges correspond to situations where multiple set elements were both created and destroyed by the same pair of events:
 
-```
+```wl
 In[] := WolframModel[{{1, 2, 3}, {4, 5, 6}, {1, 4}} ->
   {{3, 7, 8}, {9, 2, 10}, {11, 12, 5}, {13, 14, 6}, {7, 12}, {11,
     9}, {13, 10}, {14, 8}},
@@ -854,7 +854,7 @@ In[] := WolframModel[{{1, 2, 3}, {4, 5, 6}, {1, 4}} ->
 
 **`"LayeredCausalGraph"`** generates the same graph but layers events generation-by-generation. For example, in our arithmetic causal graph, note how it's arranged differently from an example above:
 
-```
+```wl
 In[] := With[{
   evolution = WolframModel[<|"PatternRules" -> {a_, b_} :> a + b|>,
     {3, 8, 8, 8, 2, 10, 0, 9, 7}, Infinity]}, With[{
@@ -870,7 +870,7 @@ In[] := With[{
 
 Furthermore, if we include the initial condition as a "fake" event (see [`"IncludeBoundaryEvents"`](#includeboundaryevents) option for more information), note how slices through the causal graph correspond to states returned by [`"StatesList"`](#states):
 
-```
+```wl
 In[] := With[{
   evolution = WolframModel[<|"PatternRules" -> {a_, b_} :> a + b|>,
     {3, 8, 8, 8, 2, 10, 0, 9, 7}, Infinity]}, With[{
@@ -890,7 +890,7 @@ In[] := With[{
 
 <img src="READMEImages/FoliatedCausalGraph.png" width="478">
 
-```
+```wl
 In[] := WolframModel[<|"PatternRules" -> {a_, b_} :> a + b|>,
  {3, 8, 8, 8, 2, 10, 0, 9, 7}, Infinity, "StatesList"]
 Out[] = {{3, 8, 8, 8, 2, 10, 0, 9, 7}, {7, 11, 16, 12, 9}, {9, 18, 28}, {28,
@@ -903,7 +903,7 @@ Out[] = {{3, 8, 8, 8, 2, 10, 0, 9, 7}, {7, 11, 16, 12, 9}, {9, 18, 28}, {28,
 
 **`"AllEventsRuleIndices"`** returns which rule was used for each event (the same can be obtained by mapping [`First`](https://reference.wolfram.com/language/ref/First.html) over [`"AllEventsList"`](#events)):
 
-```
+```wl
 In[] := WolframModel[{{{1, 1, 2}} -> {{2, 2, 1}, {2, 3, 2}, {1, 2, 3}},
   {{1, 2, 1}, {3, 4, 2}} -> {{4, 3, 2}}},
  {{1, 1, 1}}, 4, "AllEventsRuleIndices"]
@@ -912,7 +912,7 @@ Out[] = {1, 1, 1, 1, 1, 1, 2, 1, 1, 1, 2, 1, 2}
 
 A neat example of using `"AllEventsRuleIndices"` is coloring events in a causal graph according to the rule index. With this visualization, one can see, for instance, that the outputs of the second rule in the example above are never used in any further inputs:
 
-```
+```wl
 In[] := With[{
   evolution =
    WolframModel[{{{1, 1, 2}} -> {{2, 2, 1}, {2, 3, 2}, {1, 2, 3}},
@@ -931,7 +931,7 @@ In[] := With[{
 
 **`"EdgeGenerationsList"`** (aka `"ExpressionGenerations"`) yields the list of generation numbers (numbers of predecessor layers) for each edge in [`"AllEventsEdgesList"`](#all-edges-throughout-evolution):
 
-```
+```wl
 In[] := WolframModel[{{1, 2}, {1, 3}, {1, 4}} ->
   {{2, 2}, {3, 2}, {3, 4}, {3, 5}},
  {{1, 1}, {1, 1}, {1, 1}}, 5, "EdgeGenerationsList"]
@@ -941,7 +941,7 @@ Out[] = {0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5,
 
  **`"AllEventsGenerationsList"`** (aka `"EventGenerations"`) gives the same for events. The generation of an event is defined as the generation of edges it produces as output. Here edges of different generations are colored differently:
 
-```
+```wl
 In[] := With[{
   evolution = WolframModel[{{1, 2}, {1, 3}, {1, 4}} ->
      {{2, 2}, {3, 2}, {3, 4}, {3, 5}},
@@ -959,14 +959,14 @@ In[] := With[{
 
 Event generations correspond to layers in [`"LayeredCausalGraph"`](#causal-graphs):
 
-```
+```wl
 In[] := WolframModel[{{1, 2}, {1, 3}, {1, 4}} ->
   {{2, 2}, {3, 2}, {3, 4}, {3, 5}},
  {{1, 1}, {1, 1}, {1, 1}}, 5, "AllEventsGenerationsList"]
 Out[] = {1, 2, 3, 4, 5, 5}
 ```
 
-```
+```wl
 In[] := WolframModel[{{1, 2}, {1, 3}, {1, 4}} ->
   {{2, 2}, {3, 2}, {3, 4}, {3, 5}},
  {{1, 1}, {1, 1}, {1, 1}}, 5, "LayeredCausalGraph"]
@@ -987,7 +987,7 @@ All possible values are:
 
 As an example, in our arithmetic model a `"FixedPoint"` is reached (which is why we can use [`Infinity`](https://reference.wolfram.com/language/ref/Infinity.html) as the number of steps):
 
-```
+```wl
 In[] := WolframModel[<|"PatternRules" -> {a_, b_} :> a + b|>,
   {3, 8, 8, 8, 2, 10, 0, 9, 7}, Infinity]["TerminationReason"]
 Out[] = "FixedPoint"
@@ -995,7 +995,7 @@ Out[] = "FixedPoint"
 
 And if we manually abort the evolution, we could get something like this:
 
-```
+```wl
 In[] := WolframModel[{{1, 2, 3}, {4, 5, 6}, {1, 4}} ->
   {{2, 7, 8}, {5, 9, 10}, {6, 11, 12}, {13, 3, 14}, {8, 13}, {9,
     7}, {10, 12}, {14, 11}},
@@ -1009,7 +1009,7 @@ In[] := WolframModel[{{1, 2, 3}, {4, 5, 6}, {1, 4}} ->
 
 **`"TotalGenerationsCount"`** returns the largest generation of any edge during the evolution:
 
-```
+```wl
 In[] := WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}},
  <|"MaxEvents" -> 42|>, "TotalGenerationsCount"]
 Out[] = 5
@@ -1017,7 +1017,7 @@ Out[] = 5
 
 **`"CompleteGenerationsCount"`** yields the number of generations that are "completely done". That is, no more matches can be made involving this or earlier generations. If the default [evaluation order](#eventorderingfunction) is used, this can only be either the same as `"TotalGenerationsCount"` (if we just finished a step) or one less (if we are in the middle of a step). However, it gets much more interesting if a different event order is used. For a random evolution, for instance, one can get
 
-```
+```wl
 In[] := WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}},
  <|"MaxEvents" -> 42|>, "EventOrderingFunction" -> "Random"]
 ```
@@ -1030,7 +1030,7 @@ Note, in this case, only one generation is complete, and seven are partial. That
 
 **`"GenerationComplete"`** takes a generation number as an argument, and gives [`True`](https://reference.wolfram.com/language/ref/True.html) or [`False`](https://reference.wolfram.com/language/ref/False.html) depending on whether that particular generation is complete:
 
-```
+```wl
 In[] := WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}},
   <|"MaxEvents" -> 42|>]["GenerationComplete", 5]
 Out[] = False
@@ -1042,7 +1042,7 @@ Out[] = False
 
 **`"GenerationEventsCountList"`** gives the number of events per each generation ([`Length`](https://reference.wolfram.com/language/ref/Length.html) mapped over [`"GenerationEventsList"`](#events)):
 
-```
+```wl
 In[] := WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}},
  {{1, 1}}, 5, "GenerationEventsCountList"]
 Out[] = {1, 3, 9, 27, 81}
@@ -1052,14 +1052,14 @@ Out[] = {1, 3, 9, 27, 81}
 
 **`"VertexCountList"`** and **`"EdgeCountList"`** return counts of vertices and edges respectively in each state of [`"StatesList"`](#states). They are useful to see how quickly a particular system grows:
 
-```
+```wl
 In[] := WolframModel[{{1, 2, 3}, {2, 4, 5}} ->
   {{6, 6, 3}, {2, 6, 2}, {6, 4, 2}, {5, 3, 6}},
  {{1, 1, 1}, {1, 1, 1}}, 10, "VertexCountList"]
 Out[] = {1, 2, 4, 8, 14, 27, 49, 92, 171, 324, 622}
 ```
 
-```
+```wl
 In[] := WolframModel[{{1, 2, 3}, {2, 4, 5}} ->
   {{6, 6, 3}, {2, 6, 2}, {6, 4, 2}, {5, 3, 6}},
  {{1, 1, 1}, {1, 1, 1}}, 10, "EdgeCountList"]
@@ -1074,14 +1074,14 @@ The difference is that [`"VertexCountList"`](#element-count-lists) counts expres
 
 For example, consider a rule that performs non-trivial nesting:
 
-```
+```wl
 In[] := WolframModel[<|
   "PatternRules" -> {{a_}} :> {{a + 1}, {a - 1}, {{a + 2, a - 2}}}|>,
  {{1}}, 7, "VertexCountList"]
 Out[] = {1, 3, 6, 10, 15, 21, 28, 36}
 ```
 
-```
+```wl
 In[] := WolframModel[<|"PatternRules" ->
      {{a_}} :> {{a + 1}, {a - 1}, {{a + 2, a - 2}}}|>,
    {{1}}, #, "FinalDistinctElementsCount"] & /@ Range[0, 7]
@@ -1090,7 +1090,7 @@ Out[] = {1, 4, 9, 13, 17, 21, 25, 29}
 
 To understand why this is happening, consider the state after one step:
 
-```
+```wl
 In[] := WolframModel[<|
   "PatternRules" -> {{a_}} :> {{a + 1}, {a - 1}, {{a + 2, a - 2}}}|>,
  {{1}}, 1, "FinalState"]
@@ -1105,7 +1105,7 @@ This state has 3 vertices (distinct level-2 expressions): `2`, `0`, and `{3, -1}
 
 For instance,
 
-```
+```wl
 In[] := WolframModel[{{1, 2, 3}, {2, 4, 5}} ->
   {{6, 6, 3}, {2, 6, 2}, {6, 4, 2}, {5, 3, 6}},
  {{1, 1, 1}, {1, 1, 1}}, 10,
@@ -1117,7 +1117,7 @@ Out[] = {622, 2486}
 
 **`"Rules"`** just stores the rules in the same way they were entered as an input to `WolframModel`:
 
-```
+```wl
 In[] := WolframModel[<|"PatternRules" ->
     {{a_}} :> {{a + 1}, {a - 1}, {{a + 2, a - 2}}}|>,
   {{1}}, 1]["Rules"]
@@ -1136,7 +1136,7 @@ This is useful for display in the information box of the evolution object, and i
 
 [`None`](https://reference.wolfram.com/language/ref/None.html) does not do anything, the vertices in the initial condition are left as-is, and the newly created vertices use symbol names as, i.e., `Module[{v}, v]` could generate:
 
-```
+```wl
 In[] := WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}},
  {{v1, v1}}, 2, "StatesList", "VertexNamingFunction" -> None]
 Out[] = {{{v1, v1}}, {{v1, v256479}, {v1, v256479}, {v256479, v1}}, {{v1,
@@ -1147,7 +1147,7 @@ Out[] = {{{v1, v1}}, {{v1, v256479}, {v1, v256479}, {v256479, v1}}, {{v1,
 
 [`All`](https://reference.wolfram.com/language/ref/All.html) renames all vertices as sequential integers, including the ones in the the initial condition, and including ones manually generated in [pattern rules](#pattern-rules):
 
-```
+```wl
 In[] := WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}},
  {{v1, v1}}, 2, "StatesList", "VertexNamingFunction" -> All]
 Out[] = {{{1, 1}}, {{1, 2}, {1, 2}, {2, 1}}, {{1, 3}, {1, 3}, {3, 2}, {1,
@@ -1156,7 +1156,7 @@ Out[] = {{{1, 1}}, {{1, 2}, {1, 2}, {2, 1}}, {{1, 3}, {1, 3}, {3, 2}, {1,
 
 [`Automatic`](https://reference.wolfram.com/language/ref/Automatic.html) only renames newly created vertices with non-previously-used integers, and leaves the initial condition as-is. It does nothing in the case of [pattern rules](#pattern-rules).
 
-```
+```wl
 In[] := WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}},
  {{v1, v1}}, 2, "StatesList", "VertexNamingFunction" -> Automatic]
 Out[] = {{{v1, v1}}, {{v1, 1}, {v1, 1}, {1, v1}}, {{v1, 2}, {v1, 2}, {2,
@@ -1167,7 +1167,7 @@ Out[] = {{{v1, v1}}, {{v1, 1}, {v1, 1}, {1, v1}}, {{v1, 2}, {v1, 2}, {2,
 
 In case partial generations were produced, they can be automatically dropped by setting **`"IncludePartialGenerations"`** to [`False`](https://reference.wolfram.com/language/ref/False.html). Compare for instance
 
-```
+```wl
 In[] := WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}},
  {{1, 1}}, <|"MaxEvents" -> 42|>]
 ```
@@ -1176,7 +1176,7 @@ In[] := WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}},
 
 with
 
-```
+```wl
 In[] := WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}},
  {{1, 1}}, <|"MaxEvents" -> 42|>,
  "IncludePartialGenerations" -> False]
@@ -1186,7 +1186,7 @@ In[] := WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}},
 
 One neat use of this is producing a uniformly random evolution for a complete number of generations:
 
-```
+```wl
 In[] := WolframModel[{{1, 2, 3}, {2, 4, 5}} ->
   {{6, 6, 3}, {2, 6, 2}, {6, 4, 2}, {5, 3, 6}},
  {{1, 1, 1}, {1, 1, 1}}, <|"MaxEvents" -> 10000|>, "FinalStatePlot",
@@ -1202,7 +1202,7 @@ In[] := WolframModel[{{1, 2, 3}, {2, 4, 5}} ->
 
 We have already [demonstrated](#causal-graphs) it previously for our arithmetic model. Here is an example with the final "event" included as well (event labels are kept for reference):
 
-```
+```wl
 In[] := With[{
   evolution = WolframModel[<|"PatternRules" -> {a_, b_} :> a + b|>,
     {3, 8, 8, 8, 2, 10, 0, 9, 7}, Infinity]}, With[{
@@ -1221,7 +1221,7 @@ In[] := With[{
 
 Properties like [`"AllEventsList"`](#events) are affected as well:
 
-```
+```wl
 In[] := WolframModel[<|"PatternRules" -> {a_, b_} :> a + b|>,
  {3, 8, 8, 8, 2, 10, 0, 9, 7}, Infinity, "AllEventsList",
  "IncludeBoundaryEvents" -> "Final"]
@@ -1247,7 +1247,7 @@ The C++ implementation is used by default for supported systems and is particula
 
 It should not be used, however, if vertex degrees can grow large. For example
 
-```
+```wl
 In[] := AbsoluteTiming[
  WolframModel[{{{0}} -> {{0}, {0}, {0}}, {{0}, {0}, {0}} -> {{0}}},
   {{0}}, <|"MaxEvents" -> 30|>, Method -> "LowLevel"]]
@@ -1257,7 +1257,7 @@ In[] := AbsoluteTiming[
 
 takes almost 10 seconds in C++ implementation, and less than 1/10th of a second in the Wolfram Language implementation:
 
-```
+```wl
 In[] := AbsoluteTiming[
  WolframModel[{{{0}} -> {{0}, {0}, {0}}, {{0}, {0}, {0}} -> {{0}}},
   {{0}}, <|"MaxEvents" -> 30|>, Method -> "Symbolic"]]
@@ -1274,7 +1274,7 @@ Wolfram Language implementation should be used if:
 
 **`TimeConstraint`** option allows one to stop the evolution early. If an evolution object is requested, it will return a partial result, otherwise, it will just give [`$Aborted`](https://reference.wolfram.com/language/ref/$Aborted.html):
 
-```
+```wl
 In[] := WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}},
  {{1, 1}}, Infinity, TimeConstraint -> 1]
 ```
@@ -1285,14 +1285,14 @@ In[] := WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}},
 
 In many `WolframModel` systems multiple matches are possible at any given step. As an example, two possible replacements are possible in the system below from the initial condition:
 
-```
+```wl
 In[] := WolframModel[{{1, 2}} -> {{1, 3}, {3, 2}},
  {{1, 2}, {2, 2}}, <|"MaxEvents" -> 1|>, "EventsStatesPlotsList"]
 ```
 
 <img src="READMEImages/NonoverlappingEvolutionWithAutomaticOrdering.png" width="513">
 
-```
+```wl
 In[] := WolframModel[{{1, 2}} -> {{1, 3}, {3, 2}},
  {{1, 2}, {2, 2}}, <|"MaxEvents" -> 1|>, "EventsStatesPlotsList",
  "EventOrderingFunction" -> "NewestEdge"]
@@ -1302,7 +1302,7 @@ In[] := WolframModel[{{1, 2}} -> {{1, 3}, {3, 2}},
 
 In this particular, so-called non-overlapping, system the order of replacements does not matter, as regardless of order the same final state (upto renaming of vertices) is produced for the same fixed number of generations. This will always be the case if there is only a single edge on the left-hand side of the rule:
 
-```
+```wl
 In[] := WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}},
    {{1, 2}, {2, 2}}, 3, "FinalStatePlot",
    "EventOrderingFunction" -> #] & /@ {Automatic, "Random"}
@@ -1312,14 +1312,14 @@ In[] := WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}},
 
 For some systems, however, the order of replacements does matter, and non-equivalent final states would be produced for different orders even if a fixed number of generations is requested:
 
-```
+```wl
 In[] := WolframModel[{{1, 2}, {2, 3}} -> {{4, 2}, {4, 1}, {2, 1}, {3, 4}},
  {{1, 2}, {2, 3}, {3, 4}, {4, 1}}, 5, "FinalStatePlot"]
 ```
 
 <img src="READMEImages/OverlappingEvolutionAutomaticOrdering.png" width="478">
 
-```
+```wl
 In[] := WolframModel[{{1, 2}, {2, 3}} -> {{4, 2}, {4, 1}, {2, 1}, {3, 4}},
  {{1, 2}, {2, 3}, {3, 4}, {4, 1}}, 5, "FinalStatePlot",
  "EventOrderingFunction" -> "RuleOrdering"]
@@ -1337,7 +1337,7 @@ Possible sorting criteria are:
 
 * `"LeastRecentEdge"`: this is similar to `"OldestEdge"`, but instead of greedely choosing the oldest edges, it instead avoids choosing newest ones. The difference is best demonstrated in an example:
 
-    ```
+    ```wl
     In[] := WolframModel[{{x, y}, {y, z}} -> {},
        {{1, 2}, {a, b}, {b, c}, {2, 3}},
        <|"MaxEvents" -> 1|>, "AllEventsList",
@@ -1354,7 +1354,7 @@ Possible sorting criteria are:
 
 * `"RuleOrdering"`: similarly to `"OldestEdge"` greedely chooses edges from the beginning of the list, however unlike `"OldestEdge"` which would pick the oldest edge with *any* available matches, it chooses edges in the order the left-hand side of (any) rule is written. The difference is best demonstrated in an example:
 
-    ```
+    ```wl
     In[] := WolframModel[{{x, y}, {y, z}} -> {},
        {{b, c}, {1, 2}, {a, b}, {2, 3}},
        <|"MaxEvents" -> 1|>, "AllEventsList",
@@ -1376,7 +1376,7 @@ Possible sorting criteria are:
 
 As a neat example, here is the output of all individual sorting criteria (default sorting criteria are appended to disambiguate):
 
-```
+```wl
 In[] := WolframModel[{{{1, 2}, {1, 3}, {1, 4}} -> {{5, 6}, {6, 7}, {7, 5}, {5,
          7}, {7, 6}, {6, 5}, {5, 2}, {6, 3}, {7, 4}, {2, 7}, {4, 5}},
      {{1, 2}, {1, 3}, {1, 4}, {1, 5}} -> {{2, 3}, {3, 4}}},
@@ -1398,7 +1398,7 @@ In[] := WolframModel[{{{1, 2}, {1, 3}, {1, 4}} -> {{5, 6}, {6, 7}, {7, 5}, {5,
 
 **`WolframModelPlot`** (aka `HypergraphPlot`) is a function used to visualize [`WolframModel`](#wolframmodel-and-wolframmodelevolutionobject) states. It treats lists of vertices as ordered hypergraphs, and displays each hyperedge as a polygon with arrows showing the ordering:
 
-```
+```wl
 In[] := WolframModelPlot[{{1, 2, 3}, {3, 4, 5}, {5, 6, 7, 1}}]
 ```
 
@@ -1406,7 +1406,7 @@ In[] := WolframModelPlot[{{1, 2, 3}, {3, 4, 5}, {5, 6, 7, 1}}]
 
 Edges of any arity can be mixed, the binary edges are displayed as non-filled arrows, and the unary edges are shown as circles around the vertices:
 
-```
+```wl
 In[] := WolframModelPlot[{{1, 2, 3}, {3, 4}, {4, 3}, {4, 5,
    6}, {1}, {6}, {6}}]
 ```
@@ -1415,7 +1415,7 @@ In[] := WolframModelPlot[{{1, 2, 3}, {3, 4}, {4, 3}, {4, 5,
 
 Self-loops are shown as convex polygons around the appropriate number of circular arrows:
 
-```
+```wl
 In[] := WolframModelPlot[{{1, 1, 1}, {1, 2, 3}, {3, 4, 4}}]
 ```
 
@@ -1423,7 +1423,7 @@ In[] := WolframModelPlot[{{1, 1, 1}, {1, 2, 3}, {3, 4, 4}}]
 
 Note the difference between a hyper-self-loop and two binary edges pointing in opposite directions:
 
-```
+```wl
 In[] := WolframModelPlot[{{1, 2, 1}, {2, 3}, {3, 2}}]
 ```
 
@@ -1431,7 +1431,7 @@ In[] := WolframModelPlot[{{1, 2, 1}, {2, 3}, {3, 2}}]
 
 Multiedges are shown in a darker color (because of overlayed partially transparent polygons), or as separate polygons depending on the layout (and are admittedly sometimes hard to understand):
 
-```
+```wl
 In[] := WolframModelPlot[{{1, 2, 3}, {3, 4, 5}, {3, 4, 5}, {1, 6, 6}, {1, 6,
    6}}]
 ```
@@ -1440,7 +1440,7 @@ In[] := WolframModelPlot[{{1, 2, 3}, {3, 4, 5}, {3, 4, 5}, {1, 6, 6}, {1, 6,
 
 `WolframModelPlot` is listable, multiple hypergraphs can be plotted at the same time:
 
-```
+```wl
 In[] := WolframModelPlot[{{{1, 2, 3}},
   {{1, 2, 3}, {3, 4, 5}},
   {{1, 2, 3}, {3, 4, 5}, {5, 6, 7}}}]
@@ -1454,7 +1454,7 @@ Many [`WolframModel`](#wolframmodel-and-wolframmodelevolutionobject) properties,
 
 By default, `WolframModelPlot` assumes the hypergraph edges are ordered. It is also possible to treat edges as cyclic instead (i.e., assume [`RotateLeft`](https://reference.wolfram.com/language/ref/RotateLeft.html) and [`RotateRight`](https://reference.wolfram.com/language/ref/RotateRight.html) don't change the edge), in which case `"Cyclic"` should be used as the second argument to `WolframModelPlot`:
 
-```
+```wl
 In[] := WolframModelPlot[{{1, 2, 3}, {3, 4, 5}, {5, 6, 7, 1}}, "Cyclic"]
 ```
 
@@ -1464,7 +1464,7 @@ In[] := WolframModelPlot[{{1, 2, 3}, {3, 4, 5}, {5, 6, 7, 1}}, "Cyclic"]
 
 Vertices and edges can be highlighted with the **`GraphHighlight`** option:
 
-```
+```wl
 In[] := WolframModelPlot[{{1, 2, 3}, {3, 4, 5}, {5, 6, 7, 1}, {7, 8, 2}, {4,
    9}, {9}}, GraphHighlight -> {{1, 2, 3}, 4, {9}}]
 ```
@@ -1473,7 +1473,7 @@ In[] := WolframModelPlot[{{1, 2, 3}, {3, 4, 5}, {5, 6, 7, 1}, {7, 8, 2}, {4,
 
 For a hypergraph with multiedges, only the specified number of edges will be highlighted:
 
-```
+```wl
 In[] := WolframModelPlot[{{1, 2, 3}, {1, 2, 3}, {3, 4}, {3, 4}, {3,
    4}, {4}, {4}}, GraphHighlight -> {{1, 2, 3}, {3, 4}, {3, 4}, {4}}]
 ```
@@ -1482,7 +1482,7 @@ In[] := WolframModelPlot[{{1, 2, 3}, {1, 2, 3}, {3, 4}, {3, 4}, {3,
 
 The style of the highlight can be specified with **`GraphHighlightStyle`**:
 
-```
+```wl
 In[] := WolframModelPlot[{{1, 2, 3}, {3, 4, 5}, {5, 6, 7, 1}, {7, 8, 2}, {4,
    9}, {9}}, GraphHighlight -> {{1, 2, 3}, 4, {9}},
  GraphHighlightStyle -> Directive[Darker @ Green, Thick]]
@@ -1494,7 +1494,7 @@ In[] := WolframModelPlot[{{1, 2, 3}, {3, 4, 5}, {5, 6, 7, 1}, {7, 8, 2}, {4,
 
 By default, `WolframModelPlot` represents each hyperedge as a polygon. It is possible instead of drop the polygons (and the vertex layout adjustments that come with them), and simply split each hyperedge into a collection of binary edges by setting **`"HyperedgeRendering"`** to `"Subgraphs"`. This looses information (`{{1, 2}, {2, 3}}` and `{{1, 2, 3}}` would look the same), but might be useful if one does not care to see the separation between hyperedges:
 
-```
+```wl
 In[] := WolframModelPlot[{{1, 2, 3}, {3, 4, 5}, {5, 6, 7, 1}, {7, 8, 2}, {4,
    9}, {9}}, "HyperedgeRendering" -> "Subgraphs",
  VertexLabels -> Automatic]
@@ -1506,7 +1506,7 @@ In[] := WolframModelPlot[{{1, 2, 3}, {3, 4, 5}, {5, 6, 7, 1}, {7, 8, 2}, {4,
 
 It is possible to manually specify some or all coordinates for the vertices:
 
-```
+```wl
 In[] := WolframModelPlot[{{1, 2, 3}, {2, 4, 5}, {2, 6, 7, 8}, {8, 9, 1}},
  VertexCoordinateRules -> {1 -> {0, 0}, 2 -> {1, 0}, 3 -> {0, 1}},
  Axes -> True]
@@ -1516,14 +1516,14 @@ In[] := WolframModelPlot[{{1, 2, 3}, {2, 4, 5}, {2, 6, 7, 8}, {8, 9, 1}},
 
 Unfortunately, due to limitations of [`GraphEmbedding`](https://reference.wolfram.com/language/ref/GraphEmbedding.html), specifying coordinates of two or more vertices breaks the scaling of distances. As a result, vertices and arrowheads might appear too small or too large and need to be manually adjusted. This might also affect [`RulePlot`](#ruleplot-of-wolframmodel) in some cases.
 
-```
+```wl
 In[] := WolframModelPlot[{{1, 2, 3}, {2, 4, 5}, {2, 6, 7, 8}, {8, 9, 1}},
  VertexCoordinateRules -> {1 -> {0, 0}, 2 -> {1, 0}}]
 ```
 
 <img src="READMEImages/IncorrectlyScaledPlot.png" width="466">
 
-```
+```wl
 In[] := WolframModelPlot[{{1, 2, 3}, {2, 4, 5}, {2, 6, 7, 8}, {8, 9, 1}},
  VertexCoordinateRules -> {1 -> {0, 0}, 2 -> {1, 0}},
  VertexSize -> 0.03, "ArrowheadLength" -> 0.06]
@@ -1535,7 +1535,7 @@ In[] := WolframModelPlot[{{1, 2, 3}, {2, 4, 5}, {2, 6, 7, 8}, {8, 9, 1}},
 
 `"VertexLabels" -> Automatic` displays labels for vertices, similar to [`GraphPlot`](https://reference.wolfram.com/language/ref/GraphPlot.html):
 
-```
+```wl
 In[] := WolframModelPlot[{{1, 2, 3}, {2, 4, 5}, {2, 6, 7, 8}, {8, 9, 1}},
  VertexLabels -> Automatic]
 ```
@@ -1546,7 +1546,7 @@ In[] := WolframModelPlot[{{1, 2, 3}, {2, 4, 5}, {2, 6, 7, 8}, {8, 9, 1}},
 
 The size of vertices and the length of arrowheads (in the internal graphics units), can be adjusted with **`VertexSize`** and **`"ArrowheadLength"`** options respectively:
 
-```
+```wl
 In[] := WolframModelPlot[{{1, 2, 3, 4}, {1, 5, 6}, {2, 7, 8}, {4, 6, 9}},
  VertexSize -> 0.1, "ArrowheadLength" -> 0.3]
 ```
@@ -1557,7 +1557,7 @@ Note that unlike [`GraphPlot`](https://reference.wolfram.com/language/ref/GraphP
 
 These options can also be used to get rid of vertices and arrowheads altogether:
 
-```
+```wl
 In[] := WolframModelPlot[{{1, 2, 3}, {3, 4, 5}, {5, 6, 7}, {7, 8, 9}, {9, 10,
    1}}, "Cyclic", "ArrowheadLength" -> 0, VertexSize -> 0,
  VertexStyle -> Transparent]
@@ -1567,7 +1567,7 @@ In[] := WolframModelPlot[{{1, 2, 3}, {3, 4, 5}, {5, 6, 7}, {7, 8, 9}, {9, 10,
 
 As a neat example, one can even draw unordered hypergraphs:
 
-```
+```wl
 In[] := WolframModelPlot[{{1, 2, 2}, {2, 3, 3}, {3, 1, 1}},
  "ArrowheadLength" -> 0, EdgeStyle -> <|{_, _, _ ..} -> Transparent|>,
   "EdgePolygonStyle" -> <|{_, _, _ ..} ->
@@ -1581,14 +1581,14 @@ In[] := WolframModelPlot[{{1, 2, 2}, {2, 3, 3}, {3, 1, 1}},
 
 **`"MaxImageSize"`** allows one to specify the image size while allowing for automatic reduction for very small hypergraphs. To demonstrate that, consider the difference:
 
-```
+```wl
 In[] := WolframModelPlot[{{{1}}, {{1, 1}}, {{1, 2, 3}}},
  "MaxImageSize" -> 100]
 ```
 
 <img src="READMEImages/PlotWithMaxImageSize.png" width="254">
 
-```
+```wl
 In[] := WolframModelPlot[{{{1}}, {{1, 1}}, {{1, 2, 3}}}, ImageSize -> 100]
 ```
 
@@ -1600,7 +1600,7 @@ There are four styling options: `PlotStyle`, `VertexStyle`, `EdgeStyle` and `"Ed
 
 **`PlotStyle`** controls the overall style for everything, `VertexStyle` and `EdgeStyle` inherit from it:
 
-```
+```wl
 In[] := WolframModelPlot[{{1, 2, 3}, {3, 4, 5}, {5, 6, 7, 1}, {7, 8, 2}, {4,
    9}, {9}}, PlotStyle -> Directive[Blue, Dotted]]
 ```
@@ -1609,7 +1609,7 @@ In[] := WolframModelPlot[{{1, 2, 3}, {3, 4, 5}, {5, 6, 7, 1}, {7, 8, 2}, {4,
 
 **`VertexStyle`** works similar to [`GraphPlot`](https://reference.wolfram.com/language/ref/GraphPlot.html):
 
-```
+```wl
 In[] := WolframModelPlot[{{1, 2, 3}, {3, 4, 5}, {5, 6, 7, 1}, {7, 8, 2}, {4,
    9}, {9}}, PlotStyle -> Directive[Blue, Dotted], VertexStyle -> Red]
 ```
@@ -1618,7 +1618,7 @@ In[] := WolframModelPlot[{{1, 2, 3}, {3, 4, 5}, {5, 6, 7, 1}, {7, 8, 2}, {4,
 
 **`EdgeStyle`** controls edge lines, and `"EdgePolygonStyle"` inherits from it (automatically adding transparency):
 
-```
+```wl
 In[] := WolframModelPlot[{{1, 2, 3}, {3, 4, 5}, {5, 6, 7, 1}, {7, 8, 2}, {4,
    9}, {9}}, PlotStyle -> Directive[Blue, Dotted], VertexStyle -> Red,
   EdgeStyle -> Darker @ Green]
@@ -1628,7 +1628,7 @@ In[] := WolframModelPlot[{{1, 2, 3}, {3, 4, 5}, {5, 6, 7, 1}, {7, 8, 2}, {4,
 
 Finally, **`"EdgePolygonStyle"`** controls the hyperedge polygons:
 
-```
+```wl
 In[] := WolframModelPlot[{{1, 2, 3}, {3, 4, 5}, {5, 6, 7, 1}, {7, 8, 2}, {4,
    9}, {9}}, PlotStyle -> Directive[Blue, Dotted], VertexStyle -> Red,
   EdgeStyle -> Darker @ Green,
@@ -1640,7 +1640,7 @@ In[] := WolframModelPlot[{{1, 2, 3}, {3, 4, 5}, {5, 6, 7, 1}, {7, 8, 2}, {4,
 
 It is possible to specify styles separately for each edge and vertex. Vertex styles are specified in the same order as `Union @* Catenate` evaluated on the list of edges:
 
-```
+```wl
 In[] := WolframModelPlot[{{1, 2, 3}, {3, 4, 5}, {5, 6, 7, 1}, {7, 8, 2}, {4,
    9}, {9}}, EdgeStyle -> ColorData[97] /@ Range[6],
  VertexStyle -> ColorData[98] /@ Range[9]]
@@ -1650,7 +1650,7 @@ In[] := WolframModelPlot[{{1, 2, 3}, {3, 4, 5}, {5, 6, 7, 1}, {7, 8, 2}, {4,
 
 Alternatively, one can specify different styles for different patterns of elements. In this case, styles are specified as [`Association`](https://reference.wolfram.com/language/ref/Association.html)s with patterns for keys. This can be used to, for example, differently color edges of different arities:
 
-```
+```wl
 In[] := WolframModelPlot[WolframModel[{{1, 2, 3}, {4, 5, 6}, {2, 5}, {5, 2}} ->
    {{7, 1, 8}, {9, 3, 10}, {11, 4, 12}, {13, 6, 14}, {7, 13}, {13,
      7}, {8, 10}, {10, 8}, {9, 11}, {11, 9}, {12, 14}, {14, 12}},
@@ -1665,7 +1665,7 @@ In[] := WolframModelPlot[WolframModel[{{1, 2, 3}, {4, 5, 6}, {2, 5}, {5, 2}} ->
 
 All [`Graphics`](https://reference.wolfram.com/language/ref/Graphics.html) options are supported as well, such as [`Background`](https://reference.wolfram.com/language/ref/Background.html), [`PlotRange`](https://reference.wolfram.com/language/ref/PlotRange.html), [`Axes`](https://reference.wolfram.com/language/ref/Axes.html), etc.:
 
-```
+```wl
 In[] := WolframModelPlot[WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}},
   {{1, 2}, {2, 3}, {3, 1}}, 7, "FinalState"], Background -> Black,
  PlotStyle -> White, GridLines -> Automatic,
@@ -1678,7 +1678,7 @@ In[] := WolframModelPlot[WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}},
 
 **`RulePlot`** can be used to get a [`WolframModelPlot`](#wolframmodelplot)-based visual representation of hypergraph substitution rules:
 
-```
+```wl
 In[] := RulePlot[WolframModel[{{1, 2}, {1, 2}} ->
    {{3, 2}, {3, 2}, {2, 1}, {1, 3}}]]
 ```
@@ -1687,7 +1687,7 @@ In[] := RulePlot[WolframModel[{{1, 2}, {1, 2}} ->
 
 The shared elements between rule sides (vertices `1` and `2` in the example above) are put at the same positions in the `RulePlot` and highlighted in a darker shade of blue. Shared edges are highlighted as well:
 
-```
+```wl
 In[] := RulePlot[WolframModel[{{1, 2, 3}} -> {{1, 2, 3}, {3, 4, 5}}]]
 ```
 
@@ -1695,7 +1695,7 @@ In[] := RulePlot[WolframModel[{{1, 2, 3}} -> {{1, 2, 3}, {3, 4, 5}}]]
 
 Multiple rules can be plotted:
 
-```
+```wl
 In[] := RulePlot[WolframModel[{{{1, 1, 2}} ->
     {{2, 2, 1}, {2, 3, 2}, {1, 2, 3}},
    {{1, 2, 1}, {3, 4, 2}} -> {{4, 3, 2}}}]]
@@ -1705,7 +1705,7 @@ In[] := RulePlot[WolframModel[{{{1, 1, 2}} ->
 
 Sometimes an incorrectly scaled layout might be produced due to the issue discussed above in [`VertexCoordinateRules`](#vertexcoordinaterules):
 
-```
+```wl
 In[] := RulePlot[WolframModel[{{1, 2}, {1, 3}, {1, 4}} ->
    {{2, 2}, {2, 2}, {2, 5}, {3, 2}}]]
 ```
@@ -1714,7 +1714,7 @@ In[] := RulePlot[WolframModel[{{1, 2}, {1, 3}, {1, 4}} ->
 
 `VertexCoordinateRules` can be used in that case to specify the layout manually:
 
-```
+```wl
 In[] := RulePlot[WolframModel[{{1, 2}, {1, 3}, {1, 4}} ->
    {{2, 2}, {2, 2}, {2, 5}, {3, 2}}],
  VertexCoordinateRules -> {1 -> {0, 0}, 2 -> {1, 0}, 3 -> {0, 1},
@@ -1727,7 +1727,7 @@ Some of the [`WolframModelPlot`](#wolframmodelplot) options are supported, speci
 
 There are also two additional `RulePlot`-specific style options. **`Spacings`** controls the amount of empty space between the rule parts and the frame (or the space where the frame would be if it's not shown):
 
-```
+```wl
 In[] := RulePlot[WolframModel[{{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}},
    {{1, 2}, {1, 2}} -> {{1, 3}, {3, 2}}}], Spacings -> 0.03]
 ```
@@ -1736,7 +1736,7 @@ In[] := RulePlot[WolframModel[{{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}},
 
 **`"RulePartsAspectRatio"`** is used to control the aspect ratio of rule sides. As an example, it can be used to force rule parts to be square:
 
-```
+```wl
 In[] := RulePlot[WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}],
  "RulePartsAspectRatio" -> 1]
 ```
@@ -1753,7 +1753,7 @@ In[] := RulePlot[WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}],
 
 **`WolframModelRuleValue`** computes simple properties of rules, which can be determined without running the evolution. Only anonymous (not pattern) rules are supported at the moment. The full list of supported properties can be obtained with **`$WolframModelRuleProperties`**:
 
-```
+```wl
 In[] := $WolframModelRuleProperties
 Out[] = {"ConnectedInput", "ConnectedInputOutputUnion", "ConnectedOutput",
   "MaximumArity", "NodeCounts", "NodesDroppedAdded", "Signature",
@@ -1764,7 +1764,7 @@ Out[] = {"ConnectedInput", "ConnectedInputOutputUnion", "ConnectedOutput",
 
 **`TransformationCount`** is a very simple property that returns the number of rules in the system:
 
-```
+```wl
 In[] := WolframModelRuleValue[{{{1, 1, 2}} -> {{2, 2, 1}, {2, 3, 2}, {1, 2,
      3}},
   {{1, 2, 1}, {3, 4, 2}} -> {{4, 3, 2}}}, "TransformationCount"]
@@ -1775,7 +1775,7 @@ Out[] = 2
 
 Arity is the length of an edge. The maximum length of any edge in the rules can be determined with **`MaximumArity`**:
 
-```
+```wl
 In[] := WolframModelRuleValue[{{1, 2, 3}, {4, 5, 6}, {2, 5}, {5, 2}} ->
   {{7, 1, 8}, {9, 3, 10}, {11, 4, 12}, {13, 6, 14}, {7, 13}, {13,
     7}, {8, 10}, {10, 8}, {9, 11}, {11, 9}, {12, 14}, {14,
@@ -1785,7 +1785,7 @@ Out[] = 3
 
 For the summary of arities for all edges, one can use **`RuleSignature`**:
 
-```
+```wl
 In[] := WolframModelRuleValue[{{1, 2, 3}, {4, 5, 6}, {2, 5}, {5, 2}} ->
   {{7, 1, 8}, {9, 3, 10}, {11, 4, 12}, {13, 6, 14}, {7, 13}, {13,
     7}, {8, 10}, {10, 8}, {9, 11}, {11, 9}, {12, 14}, {14,
@@ -1796,7 +1796,7 @@ In[] := WolframModelRuleValue[{{1, 2, 3}, {4, 5, 6}, {2, 5}, {5, 2}} ->
 
 In this example, there are 2 binary and 2 ternary edges in the input, and 8 binary and 4 ternary edges in the output. The more machine-readable form of this can be obtained with **`Signature`** property:
 
-```
+```wl
 In[] := WolframModelRuleValue[{{1, 2, 3}, {4, 5, 6}, {2, 5}, {5, 2}} ->
   {{7, 1, 8}, {9, 3, 10}, {11, 4, 12}, {13, 6, 14}, {7, 13}, {13,
     7}, {8, 10}, {10, 8}, {9, 11}, {11, 9}, {12, 14}, {14,
@@ -1808,7 +1808,7 @@ Out[] = {{2, 2}, {2, 3}} -> {{8, 2}, {4, 3}}
 
 One can count the vertices involved in the left- and right-hand sides of the rule with **`"NodeCounts"`**. For example, this rule has 5 vertices in the input, and 6 in the output:
 
-```
+```wl
 In[] := WolframModelRuleValue[{{1, 2, 3}, {2, 4, 5}} -> {{5, 6, 1}, {6, 4,
     2}, {4, 5, 3}}, "NodeCounts"]
 Out[] = 5 -> 6
@@ -1816,7 +1816,7 @@ Out[] = 5 -> 6
 
 **`NodesDroppedAdded`** gives the counts of vertices that appear only on the left- and right-hand sides of the rule. Here for example, the first rule creates a vertex, and the second rule drops a vertex:
 
-```
+```wl
 In[] := WolframModelRuleValue[{{{1, 1, 2}} -> {{2, 2, 1}, {2, 3, 2}, {1, 2,
      3}},
   {{1, 2, 1}, {3, 4, 2}} -> {{4, 3, 2}}}, "NodesDroppedAdded"]
@@ -1831,7 +1831,7 @@ There are three types of rule connectedness.
 
 **`ConnectedInput`** checks if the left-hand side of the rule is a connected hypergraph. If it's [`True`](https://reference.wolfram.com/language/ref/True.html), the rule is local, and [`"LowLevel"` implementation](#method) can be used for it:
 
-```
+```wl
 In[] := WolframModelRuleValue[{{1, 2, 3}, {3, 4, 5}} -> {{2, 3, 1}, {4, 3,
     2}, {5, 6, 7}}, "ConnectedInput"]
 Out[] = True
@@ -1839,7 +1839,7 @@ Out[] = True
 
 **`ConnectedOutput`** does the same for the output:
 
-```
+```wl
 In[] := WolframModelRuleValue[{{1, 2, 3}, {3, 4, 5}} -> {{2, 3, 1}, {4, 3,
     2}, {5, 6, 7}}, "ConnectedOutput"]
 Out[] = False
@@ -1847,7 +1847,7 @@ Out[] = False
 
 **`ConnectedInputOutputUnion`** yields [`True`](https://reference.wolfram.com/language/ref/True.html) if the input is connected to the output. Note that it does not require either the input or the output to be connected within themselves, but neither of them can have pieces disconnected from the rest of the rule:
 
-```
+```wl
 In[] := WolframModelRuleValue[{{1, 2, 3}, {3, 4, 5}} -> {{2, 3, 1}, {4, 3,
     2}, {5, 6, 7}}, "ConnectedInputOutputUnion"]
 Out[] = True
@@ -1855,7 +1855,7 @@ Out[] = True
 
 For multiple-rule systems, each rule needs to be connected for these properties to yield [`True`](https://reference.wolfram.com/language/ref/True.html):
 
-```
+```wl
 In[] := WolframModelRuleValue[{{{1, 2}} -> {{1, 3}, {3, 2}},
   {{1, 2}} -> {{1, 2}, {3, 3}}}, "ConnectedOutput"]
 Out[] = False
@@ -1865,7 +1865,7 @@ Out[] = False
 
 **`GeneralizedGridGraph`** is similar to [`GridGraph`](https://reference.wolfram.com/language/ref/GridGraph.html), but it allows for additional specifiers in each direction of the grid:
 
-```
+```wl
 In[] := GeneralizedGridGraph[{5 -> "Directed", 5 -> "Circular"}]
 ```
 
@@ -1873,7 +1873,7 @@ In[] := GeneralizedGridGraph[{5 -> "Directed", 5 -> "Circular"}]
 
 Possible specifiers are `"Directed"` and `"Circular"`, and they can be combined:
 
-```
+```wl
 In[] := GeneralizedGridGraph[{3 -> {"Directed", "Circular"}, 6}]
 ```
 
@@ -1881,7 +1881,7 @@ In[] := GeneralizedGridGraph[{3 -> {"Directed", "Circular"}, 6}]
 
 Same options as [`GridGraph`](https://reference.wolfram.com/language/ref/GridGraph.html) are supported. In addition `"VertexNamingFunction" -> "Coordinates"` names vertices according to their position in a grid:
 
-```
+```wl
 In[] := GeneralizedGridGraph[{4, 5, 2},
  "VertexNamingFunction" -> "Coordinates", VertexLabels -> Automatic]
 ```
@@ -1890,7 +1890,7 @@ In[] := GeneralizedGridGraph[{4, 5, 2},
 
 Finally, it's possible to use different `EdgeStyle` in different directions by specifying it as a list:
 
-```
+```wl
 In[] := GeneralizedGridGraph[{4 -> "Directed", 5, 2},
  "VertexNamingFunction" -> "Coordinates",
  EdgeStyle -> Darker /@ {Red, Green, Blue}]
@@ -1902,14 +1902,14 @@ In[] := GeneralizedGridGraph[{4 -> "Directed", 5, 2},
 
 **`HypergraphAutomorphismGroup`** does the same thing as [`GraphAutomorphismGroup`](https://reference.wolfram.com/language/ref/GraphAutomorphismGroup.html), but for ordered hypergraphs:
 
-```
+```wl
 In[] := HypergraphAutomorphismGroup[{{1, 2, 3}, {1, 2, 4}}]
 Out[] = PermutationGroup[{Cycles[{{3, 4}}]}]
 ```
 
 A more complicated example:
 
-```
+```wl
 In[] := GroupOrder[
  HypergraphAutomorphismGroup[
   EchoFunction[
@@ -1919,7 +1919,7 @@ In[] := GroupOrder[
 
 <img src="READMEImages/SymmetricHypergraphPlot.png" width="451">
 
-```
+```wl
 Out[] = 24
 ```
 
@@ -1931,7 +1931,7 @@ The output format is a list of triples `{unified hypergraph, first argument edge
 
 As an example, consider a simple case of two adjacent binary edges:
 
-```
+```wl
 In[] := HypergraphUnifications[{{1, 2}, {2, 3}}, {{1, 2}, {2, 3}}]
 Out[] = {{{{3, 1}, {3, 4}, {2, 3}}, <|1 -> 3, 2 -> 1|>, <|1 -> 3, 2 -> 2|>},
  {{{2, 3}, {3, 1}}, <|1 -> 1, 2 -> 2|>, <|1 -> 1, 2 -> 2|>},
@@ -1945,7 +1945,7 @@ In the first output here `{{{3, 1}, {3, 4}, {2, 3}}, <|1 -> 3, 2 -> 1|>, <|1 -> 
 
 All unifications can be visualized with **`HypergraphUnificationsPlot`**:
 
-```
+```wl
 In[] := HypergraphUnificationsPlot[{{1, 2}, {2, 3}}, {{1, 2}, {2, 3}}]
 ```
 
@@ -1955,7 +1955,7 @@ Vertex labels here show the vertex names in the input graphs to which the unific
 
 A more complicated example with edges of various arities is
 
-```
+```wl
 In[] := HypergraphUnificationsPlot[{{1, 2, 3}, {4, 5, 6}, {1, 4}},
  {{1, 2, 3}, {4, 5, 6}, {1, 4}}, VertexLabels -> Automatic]
 ```
@@ -1968,7 +1968,7 @@ In[] := HypergraphUnificationsPlot[{{1, 2, 3}, {4, 5, 6}, {1, 4}},
 
 For example, here is the default style used to draw polygons in [`WolframModelPlot`](#wolframmodelplot):
 
-```
+```wl
 In[] := WolframPhysicsProjectStyleData["SpatialGraph", "EdgePolygonStyle"]
 ```
 
@@ -1976,7 +1976,7 @@ In[] := WolframPhysicsProjectStyleData["SpatialGraph", "EdgePolygonStyle"]
 
 The full specification is `WolframPhysicsProjectStyleData[theme, plot type, style element]`, however either the last or the last two elements can be omitted to obtain a full [`Association`](https://reference.wolfram.com/language/ref/Association.html) of styles. The `theme` argument can be omitted to get the result for the default plot theme (only `"Light"` theme is supported at the moment). Here are all styles used in [`"CausalGraph"`](#causal-graphs) for example:
 
-```
+```wl
 In[] := WolframPhysicsProjectStyleData["CausalGraph"]
 ```
 
@@ -1988,7 +1988,7 @@ This function is useful if one needs to produce "fake" example plots using style
 
 There are two constants containing information about the build. **`$SetReplaceGitSHA`** is a git SHA of the currently-used version of *SetReplace*:
 
-```
+```wl
 In[] := $SetReplaceGitSHA
 Out[] = "320b91b5ca1d91b9b7890aa181ad457de3e38939"
 ```
@@ -1997,7 +1997,7 @@ If the build directory were not clean, it would have "\*" at the end.
 
 **`$SetReplaceBuildTime`** gives a date object of when the paclet was created:
 
-```
+```wl
 In[] := $SetReplaceBuildTime
 ```
 


### PR DESCRIPTION
## Changes
* Adds language specifiers to code snippets in markdown files to enable syntax highlighting on GitHub.
* This affects the weed report template, contributing guidelines, and README.

## Comments
* This PR is very simple, it just adds `wl` to a bunch of lines (also `html` and `bash` in one place each).
* If you are reading this after 4/18/2020 12 AM EDT, please merge this pull request after review (if not requesting any changes), don't wait for @maxitg.

## Examples
* Code snippets before:
```
In[] := WolframModel[{{1, 2, 3}, {2, 4, 5}} ->
  {{5, 6, 1}, {6, 4, 2}, {4, 5, 3}},
 {{1, 2, 3}, {2, 4, 5}, {4, 6, 7}}, 10]
```
* Now:
```wl
In[] := WolframModel[{{1, 2, 3}, {2, 4, 5}} ->
  {{5, 6, 1}, {6, 4, 2}, {4, 5, 3}},
 {{1, 2, 3}, {2, 4, 5}, {4, 6, 7}}, 10]
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/313)
<!-- Reviewable:end -->
