### PR TITLE
Cleaned up code to make it more C++11/14 enabled

### DIFF
--- a/libSetReplace/Expression.hpp
+++ b/libSetReplace/Expression.hpp
@@ -1,17 +1,13 @@
 #ifndef Expression_hpp
 #define Expression_hpp
 
-#include <functional>
-#include <memory>
-#include <vector>
-#include <unordered_set>
-
 #include "IDTypes.hpp"
 
+#include <functional>
+#include <memory>
+#include <unordered_set>
+
 namespace SetReplace {
-    /** @brief List of atoms without references to events, as can be used in, i.e., rule specification.
-     */
-    using AtomsVector = std::vector<Atom>;
     
     /** @brief Expression, as a part of the set, i.e., (hyper)edges in the graph.
      */
@@ -40,7 +36,8 @@ namespace SetReplace {
         /** @brief Creates an empty index.
          * @param getAtomsVector datasource function that returns the list of atoms for a requested expression.
          */
-        AtomsIndex(const std::function<AtomsVector(ExpressionID)>& getAtomsVector);
+        AtomsIndex(std::function<AtomsVector(ExpressionID)> getAtomsVector);
+        ~AtomsIndex();
         
         /** @brief Removes expressions with specified IDs from the index.
          */
@@ -52,11 +49,13 @@ namespace SetReplace {
         
         /** @brief Returns the list of expressions containing a specified atom.
          */
-        const std::unordered_set<ExpressionID> expressionsContainingAtom(const Atom atom) const;
+        std::unordered_set<ExpressionID> expressionsContainingAtom(const Atom atom) const;
+        
+        const std::function<AtomsVector(ExpressionID)>& getAtomsVector() const;
         
     private:
         class Implementation;
-        std::shared_ptr<Implementation> implementation_;
+        std::unique_ptr<Implementation> implementation_;
     };
 }
 

--- a/libSetReplace/IDTypes.hpp
+++ b/libSetReplace/IDTypes.hpp
@@ -2,6 +2,7 @@
 #define IDTypes_h
 
 #include <cstdint>
+#include <vector>
 
 namespace SetReplace {
     /** @brief Identifiers for atoms, which are the elements of expressions, i.e., vertices in the graph.
@@ -28,6 +29,10 @@ namespace SetReplace {
      */
     using Generation = int64_t;
     constexpr Generation initialGeneration = 0;
+
+    /** @brief List of atoms without references to events, as can be used in, i.e., rule specification.
+     */
+    using AtomsVector = std::vector<Atom>;
 }
 
 #endif /* IDTypes_h */

--- a/libSetReplace/Match.hpp
+++ b/libSetReplace/Match.hpp
@@ -1,12 +1,11 @@
 #ifndef Match_hpp
 #define Match_hpp
 
-#include <vector>
-#include <set>
-
 #include "IDTypes.hpp"
 #include "Expression.hpp"
 #include "Rule.hpp"
+
+#include <set>
 
 namespace SetReplace {
     /** @brief Match is a potential event that has not actualized yet.
@@ -51,16 +50,17 @@ namespace SetReplace {
         /** @brief Creates a new matcher object.
          * @details This is an O(1) operation, does not do any matching yet.
          */
-        Matcher(const std::vector<Rule>& rules,
+        Matcher(std::vector<Rule> rules,
                 AtomsIndex& atomsIndex,
-                const std::function<AtomsVector(ExpressionID)> getAtomsVector,
+                const std::function<AtomsVector(ExpressionID)>& getAtomsVector,
                 const OrderingSpec orderingSpec,
                 const unsigned int randomSeed = 0);
+        ~Matcher();
         
         /** @brief Finds and adds to the index all matches involving specified expressions.
          * @details Calls shouldAbort() frequently, and throws Error::Aborted if that returns true. Otherwise might take significant time to evaluate depending on the system.
          */
-        void addMatchesInvolvingExpressions(const std::vector<ExpressionID>& expressionIDs, const std::function<bool()> shouldAbort);
+        void addMatchesInvolvingExpressions(const std::vector<ExpressionID>& expressionIDs, const std::function<bool()>& shouldAbort);
         
         /** @brief Removes matches containing specified expression IDs from the index.
          */
@@ -73,23 +73,23 @@ namespace SetReplace {
         /** @brief Returns the match that should be substituted next.
          * @details Throws Error::NoMatches if there are no matches.
          */
-        MatchPtr nextMatch() const;
+        const MatchPtr& nextMatch() const;
         
         /** @brief Replaces patterns in atomsToReplace with explicit atoms.
          * @param inputPatterns patterns corresponding to patternMatches.
          * @param patternMatches explicit atoms corresponding to patterns in inputPatterns.
          * @param atomsToReplace patterns, which would be replaced the same way as inputPatterns are matched to patternMatches.
          */
-        static bool substituteMissingAtomsIfPossible(const std::vector<AtomsVector> inputPatterns,
-                                                     const std::vector<AtomsVector> patternMatches,
+        static bool substituteMissingAtomsIfPossible(const std::vector<AtomsVector>& inputPatterns,
+                                                     const std::vector<AtomsVector>& patternMatches,
                                                      std::vector<AtomsVector>& atomsToReplace);
         
         /** @brief Returns the set of expression IDs matched in any match. */
-        const std::vector<MatchPtr> allMatches() const;
+        std::vector<MatchPtr> allMatches() const;
         
     private:
         class Implementation;
-        std::shared_ptr<Implementation> implementation_;
+        std::unique_ptr<Implementation> implementation_;
     };
 }
 

--- a/libSetReplace/Rule.hpp
+++ b/libSetReplace/Rule.hpp
@@ -1,16 +1,14 @@
 #ifndef Rule_hpp
 #define Rule_hpp
 
-#include <vector>
-
-#include "Expression.hpp"
+#include "IDTypes.hpp"
 
 namespace SetReplace {
     /** @brief Substitution rule used in the evolution.
      */
     struct Rule {
-        const std::vector<AtomsVector> inputs;
-        const std::vector<AtomsVector> outputs;
+        std::vector<AtomsVector> inputs;
+        std::vector<AtomsVector> outputs;
     };
 }
 

--- a/libSetReplace/Set.hpp
+++ b/libSetReplace/Set.hpp
@@ -1,13 +1,13 @@
 #ifndef Set_hpp
 #define Set_hpp
 
-#include <functional>
-#include <memory>
-#include <vector>
-
 #include "Expression.hpp"
 #include "Match.hpp"
 #include "Rule.hpp"
+
+#include <functional>
+#include <memory>
+#include <vector>
 
 namespace SetReplace {
     /** @brief Set is the set of expressions (i.e., the graph, the Universe) that is being evolved.
@@ -52,22 +52,24 @@ namespace SetReplace {
          * @param orderingSpec in which order to apply events.
          * @param randomSeed the seed to use for selecting matches in random evaluation case.
          */
-        Set(const std::vector<Rule>& rules,
+        Set(std::vector<Rule> rules,
             const std::vector<AtomsVector>& initialExpressions,
             const Matcher::OrderingSpec orderingSpec,
             const unsigned int randomSeed = 0);
+        
+        ~Set();
         
         /** @brief Perform a single substitution, create the corresponding event, and output expressions.
          * @param shouldAbort function that should return true if Wolfram Language abort is in progress.
          * @return 1 if substitution was made, 0 if no matches were found.
          */
-        int64_t replaceOnce(const std::function<bool()> shouldAbort);
+        int64_t replaceOnce(const std::function<bool()>& shouldAbort);
         
         /** @brief Run replaceOnce() stepSpec.maxEvents times, or until the next expression violates constraints imposed by stepSpec.
          * @param shouldAbort function that should return true if Wolfram Language abort is in progress.
          * @return The number of subtitutions made, could be between 0 and stepSpec.maxEvents.
          */
-        int64_t replace(const StepSpecification stepSpec, const std::function<bool()> shouldAbort);
+        int64_t replace(const StepSpecification stepSpec, const std::function<bool()>& shouldAbort);
         
         /** @brief List of all expressions in the set, past and present.
          */
@@ -76,7 +78,7 @@ namespace SetReplace {
         /** @brief Returns the largest generation that has both been reached, and has no matches that would produce expressions with that or lower generation.
          * @details Takes O(matches count) + as long as it would take to do the next step (because new expressions need to be indexed).
          */
-        Generation maxCompleteGeneration(const std::function<bool()> shouldAbort);
+        Generation maxCompleteGeneration(const std::function<bool()>& shouldAbort);
         
         /** @brief Yields termination reason for the previous evaluation, or TerminationReason::NotTerminated if no evaluation was done yet.
          */

--- a/libSetReplace/SetReplace.cpp
+++ b/libSetReplace/SetReplace.cpp
@@ -1,21 +1,26 @@
+#include "SetReplace.hpp"
+
+#include "Set.hpp"
+
 #include <chrono>
 #include <random>
 #include <string>
 #include <unordered_map>
 
-#include "SetReplace.hpp"
+namespace SetReplace { namespace {
+    // in C++ all the declarations in an anonymous namespace are equivalent to the 'static'
+    // keyword in C (ie. they get static linkage and mangling).
+    // as such, they become local to the translation unit they're defined in, enabling
+    // more opportunities to get optimized (ie. inlining) by the compiler
 
-#include "Set.hpp"
-
-mint getData(mint* data, mint length, mint index) {
-    if (index >= length || index < 0) {
-        throw LIBRARY_FUNCTION_ERROR;
-    } else {
-        return data[index];
+    mint getData(mint* data, mint length, mint index) {
+        if (index >= length || index < 0) {
+            throw LIBRARY_FUNCTION_ERROR;
+        } else {
+            return data[index];
+        }
     }
-}
 
-namespace SetReplace {
     // These are global variables that keep all sets returned to Wolfram Language until they are destroyed.
     // Pointers are not returned directly for security reasons.
     using SetID = int64_t;
@@ -190,7 +195,7 @@ namespace SetReplace {
             thisSetID = distribution(randomGenerator);
         } while (sets_.count(thisSetID) > 0);
         try {
-            sets_.insert({thisSetID, Set(rules, initialExpressions, orderingSpec, randomSeed)});
+            sets_.insert({thisSetID, Set(std::move(rules), initialExpressions, orderingSpec, randomSeed)});
         } catch (...) {
             return LIBRARY_FUNCTION_ERROR;
         }
@@ -199,7 +204,7 @@ namespace SetReplace {
         return LIBRARY_NO_ERROR;
     }
 
-    int setDelete(WolframLibraryData libData, mint argc, MArgument *argv, MArgument result) {
+    int setDelete(WolframLibraryData /*libData*/, mint argc, MArgument *argv, MArgument /*result*/) {
         if (argc != 1) {
             return LIBRARY_FUNCTION_ERROR;
         }
@@ -226,7 +231,7 @@ namespace SetReplace {
         }
     }
 
-    int setReplace(WolframLibraryData libData, mint argc, MArgument *argv, MArgument result) {
+    int setReplace(WolframLibraryData libData, mint argc, MArgument *argv, MArgument /*result*/) {
         if (argc != 2) {
             return LIBRARY_FUNCTION_ERROR;
         }
@@ -286,7 +291,7 @@ namespace SetReplace {
         return LIBRARY_NO_ERROR;
     }
 
-    int terminationReason(WolframLibraryData libData, mint argc, MArgument *argv, MArgument result) {
+    int terminationReason(WolframLibraryData /*libData*/, mint argc, MArgument *argv, MArgument result) {
         if (argc != 1) {
             return LIBRARY_FUNCTION_ERROR;
         }
@@ -332,17 +337,17 @@ namespace SetReplace {
         
         return LIBRARY_NO_ERROR;
     }
-}
+}}
 
 EXTERN_C mint WolframLibrary_getVersion() {
     return WolframLibraryVersion;
 }
 
-EXTERN_C int WolframLibrary_initialize(WolframLibraryData libData) {
+EXTERN_C int WolframLibrary_initialize(WolframLibraryData /*libData*/) {
     return 0;
 }
 
-EXTERN_C void WolframLibrary_uninitialize(WolframLibraryData libData) {
+EXTERN_C void WolframLibrary_uninitialize(WolframLibraryData /*libData*/) {
     return;
 }
 


### PR DESCRIPTION
## Changes

* pass retained ctor params by value and std::move into place in order to enable move semantics (passing by const ref in those cases is a pessimization)
* return movable types by value instead of const value, to enable move semantics. Returning by const value is a pessimization in those cases, and useless in every case except for return by const ref
* use unique_ptr instead of shared_ptr for pimpl members, where possible
* pass shared_ptr by const ref instead of by value in cases when ownership is not transferred/shared, to avoid useless refcounting
* pass vectors and std::functions by const ref instead of const value
* use static (ie. translation unit local) linkage for all the non-exported symbols in SetReplace.cpp

## Comments
* the net effect of all these shallow changes is a 20k (~12%) reduction in binary size, as well as presumably an (yet-unmeasured) increase in performance

## Examples
* Add explicit inputs and outputs (as screenshots in case of graphics) showcasing new functionality.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/325)
<!-- Reviewable:end -->
