### PR TITLE
Cpp optimizations

### DIFF
--- a/libSetReplace/Expression.cpp
+++ b/libSetReplace/Expression.cpp
@@ -55,7 +55,7 @@ namespace SetReplace {
     };
 
     AtomsIndex::AtomsIndex(const std::function<AtomsVector(ExpressionID)>& getAtomsVector)
-        : implementation_(new Implementation(getAtomsVector)) {}
+        : implementation_(std::make_shared<Implementation>(getAtomsVector)) {}
 
     void AtomsIndex::removeExpressions(const std::vector<ExpressionID>& expressionIDs) {
         implementation_->removeExpressions(expressionIDs);

--- a/libSetReplace/Expression.cpp
+++ b/libSetReplace/Expression.cpp
@@ -2,45 +2,46 @@
 
 #include <algorithm>
 #include <unordered_map>
+#include <utility>
 
 namespace SetReplace {
     class AtomsIndex::Implementation {
-    private:
+     private:
         const std::function<AtomsVector(ExpressionID)> getAtomsVector_;
         std::unordered_map<Atom, std::unordered_set<ExpressionID>> index_;
-        
-    public:
-        Implementation(const std::function<AtomsVector(ExpressionID)>& getAtomsVector) : getAtomsVector_(getAtomsVector) {}
-        
+
+     public:
+        explicit Implementation(std::function<AtomsVector(ExpressionID)> getAtomsVector)
+            : getAtomsVector_(std::move(getAtomsVector)) {}
+
         void removeExpressions(const std::vector<ExpressionID>& expressionIDs) {
             const std::unordered_set<ExpressionID> expressionsToDelete(expressionIDs.begin(), expressionIDs.end());
-            
+
             std::unordered_set<Atom> involvedAtoms;
             for (const auto& expression : expressionIDs) {
                 const auto atomsVector = getAtomsVector_(expression);
                 // Increase set capacity to reduce number of memory allocations
                 involvedAtoms.reserve(involvedAtoms.size() + atomsVector.size());
-                for (const auto& atom : atomsVector) {
-                    involvedAtoms.insert(atom);
-                }
+                involvedAtoms.insert(atomsVector.begin(), atomsVector.end());
             }
-            
+
             for (const auto& atom : involvedAtoms) {
-                auto expressionIterator = index_[atom].begin();
-                while (expressionIterator != index_[atom].end()) {
-                    if (expressionsToDelete.count(*expressionIterator)) {
-                        expressionIterator = index_[atom].erase(expressionIterator);
-                    }
-                    else {
-                        ++expressionIterator;
+                auto& atomExpressionSet = index_[atom];
+                auto atomExpressionIterator = atomExpressionSet.begin();
+                const auto atomExpressionSetEnd = atomExpressionSet.cend();
+                while (atomExpressionIterator != atomExpressionSetEnd) {
+                    if (expressionsToDelete.count(*atomExpressionIterator)) {
+                        atomExpressionIterator = atomExpressionSet.erase(atomExpressionIterator);
+                    } else {
+                        ++atomExpressionIterator;
                     }
                 }
-                if (index_[atom].empty()) {
+                if (atomExpressionSet.empty()) {
                     index_.erase(atom);
                 }
             }
         }
-        
+
         void addExpressions(const std::vector<ExpressionID>& expressionIDs) {
             for (const auto expressionID : expressionIDs) {
                 for (const auto atom : getAtomsVector_(expressionID)) {
@@ -48,26 +49,25 @@ namespace SetReplace {
                 }
             }
         }
-        
-        const std::unordered_set<ExpressionID> expressionsContainingAtom(const Atom atom) const {
+
+        std::unordered_set<ExpressionID> expressionsContainingAtom(const Atom atom) const {
             const auto resultIterator = index_.find(atom);
             return resultIterator != index_.end() ? resultIterator->second : std::unordered_set<ExpressionID>();
         }
     };
-    
-    AtomsIndex::AtomsIndex(const std::function<AtomsVector(ExpressionID)>& getAtomsVector) {
-        implementation_ = std::make_shared<Implementation>(getAtomsVector);
-    }
-    
+
+    AtomsIndex::AtomsIndex(const std::function<AtomsVector(ExpressionID)>& getAtomsVector)
+        : implementation_(new Implementation(getAtomsVector)) {}
+
     void AtomsIndex::removeExpressions(const std::vector<ExpressionID>& expressionIDs) {
         implementation_->removeExpressions(expressionIDs);
     }
-    
+
     void AtomsIndex::addExpressions(const std::vector<ExpressionID>& expressionIDs) {
         implementation_->addExpressions(expressionIDs);
     }
-    
-    const std::unordered_set<ExpressionID> AtomsIndex::expressionsContainingAtom(const Atom atom) const {
+
+    std::unordered_set<ExpressionID> AtomsIndex::expressionsContainingAtom(const Atom atom) const {
         return implementation_->expressionsContainingAtom(atom);
     }
 }

--- a/libSetReplace/Expression.cpp
+++ b/libSetReplace/Expression.cpp
@@ -19,9 +19,7 @@ namespace SetReplace {
 
             std::unordered_set<Atom> involvedAtoms;
             for (const auto& expression : expressionIDs) {
-                const auto atomsVector = getAtomsVector_(expression);
-                // Increase set capacity to reduce number of memory allocations
-                involvedAtoms.reserve(involvedAtoms.size() + atomsVector.size());
+                const auto& atomsVector = getAtomsVector_(expression);
                 involvedAtoms.insert(atomsVector.begin(), atomsVector.end());
             }
 
@@ -43,8 +41,8 @@ namespace SetReplace {
         }
 
         void addExpressions(const std::vector<ExpressionID>& expressionIDs) {
-            for (const auto expressionID : expressionIDs) {
-                for (const auto atom : getAtomsVector_(expressionID)) {
+            for (const auto& expressionID : expressionIDs) {
+                for (const auto& atom : getAtomsVector_(expressionID)) {
                     index_[atom].insert(expressionID);
                 }
             }

--- a/libSetReplace/Expression.hpp
+++ b/libSetReplace/Expression.hpp
@@ -12,27 +12,27 @@ namespace SetReplace {
     /** @brief List of atoms without references to events, as can be used in, i.e., rule specification.
      */
     using AtomsVector = std::vector<Atom>;
-    
+
     /** @brief Expression, as a part of the set, i.e., (hyper)edges in the graph.
      */
     struct SetExpression {
         /** @brief Ordered list of atoms the expression contains.
          */
         AtomsVector atoms;
-        
+
         /** @brief Substitution event that has this expression as part of its output.
          */
         EventID creatorEvent;
-        
+
         /** @brief Substitution event that has this expression as part of its input.
          */
         EventID destroyerEvent = finalStateEvent;
-        
+
         /** @brief Layer of the causal network this expression belongs to.
          */
         Generation generation;
     };
-    
+
     /** @brief AtomsIndex keeps references to set expressions accessible by atoms, which is useful for matching.
      */
     class AtomsIndex {
@@ -40,21 +40,21 @@ namespace SetReplace {
         /** @brief Creates an empty index.
          * @param getAtomsVector datasource function that returns the list of atoms for a requested expression.
          */
-        AtomsIndex(const std::function<AtomsVector(ExpressionID)>& getAtomsVector);
-        
+        explicit AtomsIndex(const std::function<AtomsVector(ExpressionID)>& getAtomsVector);
+
         /** @brief Removes expressions with specified IDs from the index.
          */
         void removeExpressions(const std::vector<ExpressionID>& expressionIDs);
-        
+
         /** @brief Adds expressions with specified IDs to the index.
          */
         void addExpressions(const std::vector<ExpressionID>& expressionIDs);
-        
+
         /** @brief Returns the list of expressions containing a specified atom.
          */
-        const std::unordered_set<ExpressionID> expressionsContainingAtom(const Atom atom) const;
-        
-    private:
+        std::unordered_set<ExpressionID> expressionsContainingAtom(Atom atom) const;
+
+     private:
         class Implementation;
         std::shared_ptr<Implementation> implementation_;
     };

--- a/libSetReplace/Match.cpp
+++ b/libSetReplace/Match.cpp
@@ -4,16 +4,22 @@
 #include <map>
 #include <random>
 #include <unordered_map>
+#include <utility>
 
 namespace SetReplace {
     class MatchComparator {
-    private:
+     private:
         const Matcher::OrderingSpec orderingSpec_;
-        
-    public:
-        MatchComparator(const Matcher::OrderingSpec& orderingSpec) : orderingSpec_(orderingSpec) {}
-        
-        bool operator()(const MatchPtr a, const MatchPtr b) const {
+
+        template<typename T>
+        static int compare(T a, T b) {
+            return a < b ? -1 : static_cast<bool>(a > b);
+        }
+
+     public:
+        MatchComparator(Matcher::OrderingSpec orderingSpec) : orderingSpec_(std::move(orderingSpec)) {}
+
+        bool operator()(const MatchPtr& a, const MatchPtr& b) const {
             for (const auto& ordering : orderingSpec_) {
                 int comparison = compare(a, b, ordering.first);
                 if (comparison != 0) {
@@ -31,62 +37,57 @@ namespace SetReplace {
             }
             return false;
         }
-        
-        static int compare(const MatchPtr a, const MatchPtr b, const Matcher::OrderingFunction ordering) {
+
+        static int compare(const MatchPtr& a, const MatchPtr& b, const Matcher::OrderingFunction& ordering) {
             switch (ordering) {
                 case Matcher::OrderingFunction::SortedExpressionIDs:
                     return compareSortedIDs(a, b, false);
-                    
+
                 case Matcher::OrderingFunction::ReverseSortedExpressionIDs:
                     return compareSortedIDs(a, b, true);
-                    
+
                 case Matcher::OrderingFunction::ExpressionIDs:
                     return compareUnsortedIDs(a, b);
-                    
+
                 case Matcher::OrderingFunction::RuleID:
-                    if (a->rule < b->rule) return -1;
-                    else if (a->rule > b->rule) return +1;
-                    else return 0;
-                    
+                    return compare(a->rule, b->rule);
+
                 default:
                     throw Matcher::Error::InvalidOrderingFunction;
             }
         }
-        
+
         static int compareVectors(const std::vector<ExpressionID>& first, const std::vector<ExpressionID>& second) {
-            for (size_t i = 0; i < std::min(first.size(), second.size()); ++i) {
-                if (first[i] < second[i]) return -1;
-                else if (first[i] > second[i]) return +1;
-            }
-            
-            if (first.size() < second.size()) return -1;
-            else if (first.size() > second.size()) return 1;
-            else return 0;
+            const auto mismatchingIterators = std::mismatch(first.begin(), first.end(), second.begin(), second.end());
+            if (mismatchingIterators.first != first.end())
+                return compare(*mismatchingIterators.first, *mismatchingIterators.second);
+            else
+                return compare(first.size(), second.size());
         }
-        
-        static int compareSortedIDs(const MatchPtr a, const MatchPtr b, const bool reverseOrder) {
-            std::vector<ExpressionID> aExpressions = a->inputExpressions;
-            std::vector<ExpressionID> bExpressions = b->inputExpressions;
+
+        static int compareSortedIDs(const MatchPtr& a, const MatchPtr& b, const bool reverseOrder) {
+            std::vector<ExpressionID> aExpressions(a->inputExpressions.begin(), a->inputExpressions.end());
+            std::vector<ExpressionID> bExpressions(b->inputExpressions.begin(), b->inputExpressions.end());
 
             if (!reverseOrder) {
-                std::sort(aExpressions.begin(), aExpressions.end(), std::less<Atom>());
-                std::sort(bExpressions.begin(), bExpressions.end(), std::less<Atom>());
+                std::sort(aExpressions.begin(), aExpressions.end(), std::less<>());
+                std::sort(bExpressions.begin(), bExpressions.end(), std::less<>());
             } else {
-                std::sort(aExpressions.begin(), aExpressions.end(), std::greater<Atom>());
-                std::sort(bExpressions.begin(), bExpressions.end(), std::greater<Atom>());
+                std::sort(aExpressions.begin(), aExpressions.end(), std::greater<>());
+                std::sort(bExpressions.begin(), bExpressions.end(), std::greater<>());
             }
             return compareVectors(aExpressions, bExpressions);
         }
-        
-        static int compareUnsortedIDs(const MatchPtr a, const MatchPtr& b) {
+
+        static int compareUnsortedIDs(const MatchPtr& a, const MatchPtr& b) {
             return compareVectors(a->inputExpressions, b->inputExpressions);
         }
     };
 
     // Hashes the values of the matches, not the pointer itself.
     class MatchHasher {
-    public:
-        size_t operator()(MatchPtr ptr) const {
+     public:
+        size_t operator()(const MatchPtr& ptr) const {
             std::size_t result = 0;
             hash_combine(result, ptr->rule);
             for (const auto expression : ptr->inputExpressions) {
@@ -94,10 +95,10 @@ namespace SetReplace {
             }
             return result;
         }
-        
-    private:
+
+     private:
         // https://stackoverflow.com/a/2595226
-        template <class T>
+        template<class T>
         static void hash_combine(std::size_t& seed, const T& value) {
             std::hash<T> hasher;
             seed ^= hasher(value) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
@@ -105,63 +106,64 @@ namespace SetReplace {
     };
 
     class MatchEquality {
-    public:
-        size_t operator()(MatchPtr a, MatchPtr b) const {
-            if (a->rule != b->rule || a->inputExpressions.size() != b->inputExpressions.size()) return false;
-            for (size_t i = 0; i < a->inputExpressions.size(); ++i) {
-                if (a->inputExpressions[i] != b->inputExpressions[i]) return false;
-            }
-            return true;
+     public:
+        size_t operator()(const MatchPtr& a, const MatchPtr& b) const {
+            return (a->rule == b->rule) && (a->inputExpressions.size() == b->inputExpressions.size()) &&
+                (std::mismatch(a->inputExpressions.begin(), a->inputExpressions.end(),
+                               b->inputExpressions.begin(), b->inputExpressions.end())
+                    .first == a->inputExpressions.end());
         }
     };
-    
+
     class Matcher::Implementation {
-    private:
+     private:
         const std::vector<Rule>& rules_;
         AtomsIndex& atomsIndex_;
         const std::function<AtomsVector(ExpressionID)> getAtomsVector_;
-        
+
         // Matches are arranged in buckets. Each bucket contains matches that are equivalent in terms of the ordering
         // function, however, buckets themselves are ordered according to that function.
         // To select next match, we select a random element from the first bucket.
         // That in particular means the random ordering function will automatically be used if ordering
         // specification is incomplete.
-        
+
         // We use MatchPtr instead of Match to save memory, however, they are hashed and sorted according to their
         // dereferenced values in the corresponding classes above.
-        
+
         // We cannot directly select a random element from an unordered_map, which is why we use a vector here.
-        using Bucket = std::pair<std::unordered_map<MatchPtr, size_t, MatchHasher, MatchEquality>, std::vector<MatchPtr>>;
+        using Bucket = std::pair<std::unordered_map<MatchPtr, size_t, MatchHasher, MatchEquality>,
+                                 std::vector<MatchPtr>>;
         std::map<MatchPtr, Bucket, MatchComparator> matchQueue_;
         std::unordered_map<ExpressionID, std::unordered_set<MatchPtr, MatchHasher, MatchEquality>> expressionToMatches_;
-        
+
         // A frequent operation here is detection of duplicate matches. Hashing is much faster than searching for
         // duplicates in a std::map, so we separately keep a flat hash table of all matches to speed that up.
         // That's purely an optimization.
         std::unordered_set<MatchPtr, MatchHasher, MatchEquality> allMatches_;
-        
+
         std::mt19937 randomGenerator_;
         MatchPtr nextMatch_;
-        
-    public:
+
+     public:
         Implementation(const std::vector<Rule>& rules,
                        AtomsIndex& atomsIndex,
-                       const std::function<AtomsVector(ExpressionID)> getAtomsVector,
-                       const OrderingSpec orderingSpec,
+                       std::function<AtomsVector(ExpressionID)> getAtomsVector,
+                       const OrderingSpec& orderingSpec,
                        const unsigned int randomSeed) :
             rules_(rules),
             atomsIndex_(atomsIndex),
-            getAtomsVector_(getAtomsVector),
+            getAtomsVector_(std::move(getAtomsVector)),
             matchQueue_(orderingSpec),
             randomGenerator_(randomSeed) {}
-        
-        void addMatchesInvolvingExpressions(const std::vector<ExpressionID>& expressionIDs, const std::function<bool()> shouldAbort) {
+
+        void addMatchesInvolvingExpressions(const std::vector<ExpressionID>& expressionIDs,
+                                            const std::function<bool()>& shouldAbort) {
             for (size_t i = 0; i < rules_.size(); ++i) {
                 addMatchesForRule(expressionIDs, static_cast<RuleID>(i), shouldAbort);
             }
             chooseNextMatch();
         }
-        
+
         // Note, deletion changes the ordering of allMatchIterators_, therefore
         // deletion should be done in deterministic order, otherwise, the random replacements will not be deterministic
         void removeMatchesInvolvingExpressions(const std::vector<ExpressionID>& expressionIDs) {
@@ -171,93 +173,98 @@ namespace SetReplace {
                 {OrderingFunction::ExpressionIDs, OrderingDirection::Normal},
                 {OrderingFunction::RuleID, OrderingDirection::Normal}};
             std::set<MatchPtr, MatchComparator> matchesToDelete(fullOrderingSpec);
-            
+
             for (const auto& expression : expressionIDs) {
                 const auto& matches = expressionToMatches_[expression];
                 for (const auto& matchPtr : matches) {
                     matchesToDelete.insert(matchPtr);
                 }
             }
-            
+
             for (const auto& match : matchesToDelete) {
                 deleteMatch(match);
             }
-            
+
             chooseNextMatch();
         }
-        
+
         bool empty() const {
             return matchQueue_.empty();
         }
-        
+
         MatchPtr nextMatch() const {
             return nextMatch_;
         }
-        
-        const std::vector<MatchPtr> allMatches() const {
+
+        std::vector<MatchPtr> allMatches() const {
             std::vector<MatchPtr> result;
             for (const auto& exampleAndBucket : matchQueue_) {
+                result.reserve(result.size() + exampleAndBucket.second.second.size());
                 for (const auto& matchPtr : exampleAndBucket.second.second) {
-                    result.push_back(matchPtr);
+                    result.emplace_back(matchPtr);
                 }
             }
             return result;
         }
-        
-    private:
-        void addMatchesForRule(const std::vector<ExpressionID>& expressionIDs, const RuleID& ruleID, const std::function<bool()> shouldAbort) {
+
+     private:
+        void addMatchesForRule(const std::vector<ExpressionID>& expressionIDs,
+                               const RuleID& ruleID,
+                               const std::function<bool()>& shouldAbort) {
             for (size_t i = 0; i < rules_[ruleID].inputs.size(); ++i) {
-                Match emptyMatch{ruleID, std::vector<ExpressionID>(rules_[ruleID].inputs.size(), -1)};
+                const Match emptyMatch{ruleID, std::vector<ExpressionID>(rules_[ruleID].inputs.size(), -1)};
                 completeMatchesStartingWithInput(emptyMatch, rules_[ruleID].inputs, i, expressionIDs, shouldAbort);
             }
         }
-        
+
         void completeMatchesStartingWithInput(const Match& incompleteMatch,
                                               const std::vector<AtomsVector>& partiallyMatchedInputs,
                                               const size_t nextInputIdx,
                                               const std::vector<ExpressionID>& potentialExpressionIDs,
-                                              const std::function<bool()> shouldAbort) {
+                                              const std::function<bool()>& shouldAbort) {
             for (const auto expressionID : potentialExpressionIDs) {
                 if (isExpressionUnused(incompleteMatch, expressionID)) {
-                    attemptMatchExpressionToInput(incompleteMatch, partiallyMatchedInputs, nextInputIdx, expressionID, shouldAbort);
+                    attemptMatchExpressionToInput(incompleteMatch,
+                                                  partiallyMatchedInputs,
+                                                  nextInputIdx,
+                                                  expressionID,
+                                                  shouldAbort);
                 }
             }
         }
-        
+
         static bool isExpressionUnused(const Match& match, const ExpressionID expressionID) {
-            for (size_t i = 0; i < match.inputExpressions.size(); ++i) {
-                if (match.inputExpressions[i] == expressionID) return false;
-            }
-            return true;
+            return std::find(match.inputExpressions.begin(),
+                             match.inputExpressions.end(), expressionID) == match.inputExpressions.end();
         }
-        
+
         void attemptMatchExpressionToInput(const Match& incompleteMatch,
                                            const std::vector<AtomsVector>& partiallyMatchedInputs,
                                            const size_t nextInputIdx,
                                            const ExpressionID potentialExpressionID,
-                                           const std::function<bool()> shouldAbort) {
+                                           const std::function<bool()>& shouldAbort) {
             // If WL wants to abort, abort
             if (shouldAbort()) {
                 throw Error::Aborted;
             }
-            
+
             const auto& input = partiallyMatchedInputs[nextInputIdx];
             const auto& expressionAtoms = getAtomsVector_(potentialExpressionID);
-            
+
             // edges (expressions) of different sizes, cannot match
             if (input.size() != expressionAtoms.size()) return;
-            
+
             Match newMatch = incompleteMatch;
             newMatch.inputExpressions[nextInputIdx] = potentialExpressionID;
-            
+
             auto newInputs = partiallyMatchedInputs;
             if (!Matcher::substituteMissingAtomsIfPossible({input}, {expressionAtoms}, newInputs)) return;
-            
+
             if (isMatchComplete(newMatch)) {
                 insertMatch(newMatch);
                 return;
             }
-            
+
             const auto nextInputIdxAndCandidateExpressions = nextBestInputAndExpressionsToTry(newMatch, newInputs);
             if (nextInputIdxAndCandidateExpressions.first >= 0) {
                 completeMatchesStartingWithInput(newMatch,
@@ -267,18 +274,14 @@ namespace SetReplace {
                                                  shouldAbort);
             }
         }
-        
+
         void insertMatch(const Match& newMatch) {
             // careful, don't create different pointers to the same match!
             const auto matchPtr = std::make_shared<Match>(newMatch);
-            
-            if (allMatches_.count(matchPtr)) {
+
+            if (!allMatches_.insert(matchPtr).second)
                 return;
-            }
-            else {
-                allMatches_.insert(matchPtr);
-            }
-            
+
             auto bucketIt = matchQueue_.find(matchPtr); // works because comparison is smart
             if (bucketIt == matchQueue_.end()) {
                 bucketIt = matchQueue_.insert({matchPtr, {{}, {}}}).first;
@@ -287,23 +290,23 @@ namespace SetReplace {
             if (!bucket.first.count(matchPtr)) { // works because hashing is smart
                 bucket.second.push_back(matchPtr);
                 bucket.first[matchPtr] = bucket.second.size() - 1;
-                
+
                 const auto& expressions = matchPtr->inputExpressions;
                 for (const auto expression : expressions) {
                     expressionToMatches_[expression].insert(matchPtr);
                 }
             }
         }
-        
-        void deleteMatch(const MatchPtr matchPtr) {
+
+        void deleteMatch(const MatchPtr& matchPtr) {
             allMatches_.erase(matchPtr);
-            
+
             const auto& expressions = matchPtr->inputExpressions;
             for (const auto expression : expressions) {
                 expressionToMatches_[expression].erase(matchPtr);
                 if (expressionToMatches_[expression].empty()) expressionToMatches_.erase(expression);
             }
-            
+
             auto& bucket = matchQueue_[matchPtr];
             const auto bucketIndex = bucket.first.at(matchPtr);
             // O(1) order-non-preserving deletion from a vector
@@ -313,24 +316,22 @@ namespace SetReplace {
             bucket.second.pop_back();
             if (bucket.first.empty()) matchQueue_.erase(matchPtr);
         }
-        
+
         static bool isMatchComplete(const Match& match) {
-            for (size_t i = 0; i < match.inputExpressions.size(); ++i) {
-                if (match.inputExpressions[i] < 0) return false;
-            }
-            return true;
+            return std::find_if(match.inputExpressions.begin(), match.inputExpressions.end(),
+                                [](const auto& ex) -> bool { return ex < 0; }) == match.inputExpressions.end();
         }
-        
+
         std::pair<size_t, std::vector<ExpressionID>> nextBestInputAndExpressionsToTry(const Match& incompleteMatch,
                                                                                       const std::vector<AtomsVector>& partiallyMatchedInputs) const {
             size_t nextInputIdx = -1;
             std::vector<ExpressionID> nextExpressionsToTry;
-            
+
             // For each input, we will see how many expressions in the set contain atoms appearing in this input.
             // The fewer there are, the less branching we will have to do.
             for (size_t i = 0; i < partiallyMatchedInputs.size(); ++i) {
                 if (incompleteMatch.inputExpressions[i] != -1) continue;
-                
+
                 std::unordered_set<Atom> appearingAtoms;
                 bool allAtomsArePatterns = true;
                 for (const auto atom : partiallyMatchedInputs[i]) {
@@ -339,11 +340,11 @@ namespace SetReplace {
                         allAtomsArePatterns = false;
                     }
                 }
-                
+
                 // this input does not have any specific atom references,
                 // there is nothing we can do unless we want to enumerate the entire set
                 if (allAtomsArePatterns) continue;
-                
+
                 // For each expression, we will count how many of the input atoms appear in it.
                 // We will then only use expressions that have all the required atoms.
                 std::unordered_map<ExpressionID, int64_t> inputAtomsCountByExpression;
@@ -352,7 +353,7 @@ namespace SetReplace {
                         inputAtomsCountByExpression[expression]++;
                     }
                 }
-                
+
                 // Here we will collect all expressions that contain all the required atoms.
                 std::vector<ExpressionID> potentialExpressions;
                 for (const auto& expressionAndCount : inputAtomsCountByExpression) {
@@ -360,7 +361,7 @@ namespace SetReplace {
                         potentialExpressions.push_back(expressionAndCount.first);
                     }
                 }
-                
+
                 // If there are fewer expressions, that is what we'll want to try first.
                 // Note, if there are zero matching expressions, it means the match is not possible, because none of the expressions contain all the atoms needed.
                 if (nextInputIdx == -1 || potentialExpressions.size() < nextExpressionsToTry.size()) {
@@ -368,7 +369,7 @@ namespace SetReplace {
                     nextInputIdx = i;
                 }
             }
-            
+
             if (nextInputIdx == -1) {
                 // We could not find any potential inputs, which means, all inputs not already matched are fully patterns,
                 // and don't have any specific atom references.
@@ -388,68 +389,64 @@ namespace SetReplace {
             nextMatch_ = allPossibleMatches[distribution(randomGenerator_)];
         }
     };
-    
+
     Matcher::Matcher(const std::vector<Rule>& rules,
                      AtomsIndex& atomsIndex,
-                     const std::function<AtomsVector(ExpressionID)> getAtomsVector,
-                     const OrderingSpec orderingSpec,
-                     const unsigned int randomSeed) {
-        implementation_ = std::make_shared<Implementation>(rules, atomsIndex, getAtomsVector, orderingSpec, randomSeed);
-    }
-    
-    void Matcher::addMatchesInvolvingExpressions(const std::vector<ExpressionID>& expressionIDs, const std::function<bool()> shouldAbort) {
+                     const std::function<AtomsVector(ExpressionID)>& getAtomsVector,
+                     const OrderingSpec& orderingSpec,
+                     const unsigned int randomSeed)
+        : implementation_(new Implementation(rules, atomsIndex, getAtomsVector, orderingSpec, randomSeed)) {}
+
+    void Matcher::addMatchesInvolvingExpressions(const std::vector<ExpressionID>& expressionIDs,
+                                                 const std::function<bool()>& shouldAbort) {
         implementation_->addMatchesInvolvingExpressions(expressionIDs, shouldAbort);
     }
-    
+
     void Matcher::removeMatchesInvolvingExpressions(const std::vector<ExpressionID>& expressionIDs) {
         implementation_->removeMatchesInvolvingExpressions(expressionIDs);
     }
-    
+
     bool Matcher::empty() const {
         return implementation_->empty();
     }
-    
+
     MatchPtr Matcher::nextMatch() const {
         return implementation_->nextMatch();
     }
-    
-    bool Matcher::substituteMissingAtomsIfPossible(const std::vector<AtomsVector> inputPatterns,
-                                                   const std::vector<AtomsVector> patternMatches,
+
+    bool Matcher::substituteMissingAtomsIfPossible(const std::vector<AtomsVector>& inputPatterns,
+                                                   const std::vector<AtomsVector>& patternMatches,
                                                    std::vector<AtomsVector>& atomsToReplace) {
         if (inputPatterns.size() != patternMatches.size()) return false;
-        
+
         std::unordered_map<Atom, Atom> match;
         for (size_t i = 0; i < inputPatterns.size(); ++i) {
             const auto& pattern = inputPatterns[i];
             const auto& patternMatch = patternMatches[i];
             if (pattern.size() != patternMatch.size()) return false;;
             for (size_t j = 0; j < pattern.size(); ++j) {
-                Atom inputAtom;
-                if (match.count(pattern[j])) {
-                    inputAtom = match.at(pattern[j]);
-                } else {
-                    inputAtom = pattern[j];
-                }
-                
+                const auto matchIterator = match.find(pattern[j]);
+                const Atom inputAtom = matchIterator != match.end() ? matchIterator->second : pattern[j];
                 if (inputAtom < 0) { // pattern
                     match[inputAtom] = patternMatch[j];
-                } else { // explicit atom ID
-                    if (inputAtom != patternMatch[j]) return false;
+                } else if (inputAtom != patternMatch[j]) { // explicit atom ID
+                    return false;
                 }
             }
         }
-        
-        for (size_t i = 0; i < atomsToReplace.size(); ++i) {
-            for (size_t j = 0; j < atomsToReplace[i].size(); ++j) {
-                if (match.count(atomsToReplace[i][j])) {
-                    atomsToReplace[i][j] = match[atomsToReplace[i][j]];
+
+        for (auto& av : atomsToReplace) {
+            for (auto& a : av) {
+                const auto matchIterator = match.find(a);
+                if (matchIterator != match.end()) {
+                    a = matchIterator->second;
                 }
             }
         }
         return true;
     }
 
-    const std::vector<MatchPtr> Matcher::allMatches() const {
+    std::vector<MatchPtr> Matcher::allMatches() const {
         return implementation_->allMatches();
     }
 }

--- a/libSetReplace/Match.cpp
+++ b/libSetReplace/Match.cpp
@@ -59,7 +59,7 @@ namespace SetReplace {
 
         static int compareVectors(const std::vector<ExpressionID>& first, const std::vector<ExpressionID>& second) {
             const auto mismatchingIterators = std::mismatch(first.begin(), first.end(), second.begin(), second.end());
-            if (mismatchingIterators.first != first.end())
+            if (mismatchingIterators.first != first.end() && mismatchingIterators.second != second.end())
                 return compare(*mismatchingIterators.first, *mismatchingIterators.second);
             else
                 return compare(first.size(), second.size());
@@ -108,10 +108,13 @@ namespace SetReplace {
     class MatchEquality {
      public:
         size_t operator()(const MatchPtr& a, const MatchPtr& b) const {
-            return (a->rule == b->rule) && (a->inputExpressions.size() == b->inputExpressions.size()) &&
-                (std::mismatch(a->inputExpressions.begin(), a->inputExpressions.end(),
-                               b->inputExpressions.begin(), b->inputExpressions.end())
-                    .first == a->inputExpressions.end());
+            if (a->rule != b->rule || a->inputExpressions.size() != b->inputExpressions.size())
+                return false;
+
+            const auto mismatchedIterators = std::mismatch(a->inputExpressions.begin(), a->inputExpressions.end(),
+                                                           b->inputExpressions.begin(), b->inputExpressions.end());
+            return mismatchedIterators.first == a->inputExpressions.end() &&
+                   mismatchedIterators.second == b->inputExpressions.end();
         }
     };
 

--- a/libSetReplace/Match.cpp
+++ b/libSetReplace/Match.cpp
@@ -13,7 +13,7 @@ namespace SetReplace {
 
         template<typename T>
         static int compare(T a, T b) {
-            return a < b ? -1 : static_cast<bool>(a > b);
+            return a < b ? -1 : static_cast<int>(a > b);
         }
 
      public:
@@ -59,10 +59,11 @@ namespace SetReplace {
 
         static int compareVectors(const std::vector<ExpressionID>& first, const std::vector<ExpressionID>& second) {
             const auto mismatchingIterators = std::mismatch(first.begin(), first.end(), second.begin(), second.end());
-            if (mismatchingIterators.first != first.end() && mismatchingIterators.second != second.end())
+            if (mismatchingIterators.first != first.end() && mismatchingIterators.second != second.end()) {
                 return compare(*mismatchingIterators.first, *mismatchingIterators.second);
-            else
+            } else {
                 return compare(first.size(), second.size());
+            }
         }
 
         static int compareSortedIDs(const MatchPtr& a, const MatchPtr& b, const bool reverseOrder) {
@@ -108,8 +109,9 @@ namespace SetReplace {
     class MatchEquality {
      public:
         size_t operator()(const MatchPtr& a, const MatchPtr& b) const {
-            if (a->rule != b->rule || a->inputExpressions.size() != b->inputExpressions.size())
+            if (a->rule != b->rule || a->inputExpressions.size() != b->inputExpressions.size()) {
                 return false;
+            }
 
             const auto mismatchedIterators = std::mismatch(a->inputExpressions.begin(), a->inputExpressions.end(),
                                                            b->inputExpressions.begin(), b->inputExpressions.end());
@@ -436,11 +438,11 @@ namespace SetReplace {
             }
         }
 
-        for (auto& av : atomsToReplace) {
-            for (auto& a : av) {
-                const auto matchIterator = match.find(a);
+        for (auto& atomsVectorToReplace : atomsToReplace) {
+            for (auto& atomToReplace : atomsVectorToReplace) {
+                const auto matchIterator = match.find(atomToReplace);
                 if (matchIterator != match.end()) {
-                    a = matchIterator->second;
+                    atomToReplace = matchIterator->second;
                 }
             }
         }

--- a/libSetReplace/Match.cpp
+++ b/libSetReplace/Match.cpp
@@ -200,10 +200,8 @@ namespace SetReplace {
         std::vector<MatchPtr> allMatches() const {
             std::vector<MatchPtr> result;
             for (const auto& exampleAndBucket : matchQueue_) {
-                result.reserve(result.size() + exampleAndBucket.second.second.size());
-                for (const auto& matchPtr : exampleAndBucket.second.second) {
-                    result.emplace_back(matchPtr);
-                }
+                result.insert(result.end(), exampleAndBucket.second.second.begin(),
+                              exampleAndBucket.second.second.end());
             }
             return result;
         }

--- a/libSetReplace/Match.cpp
+++ b/libSetReplace/Match.cpp
@@ -395,7 +395,8 @@ namespace SetReplace {
                      const std::function<AtomsVector(ExpressionID)>& getAtomsVector,
                      const OrderingSpec& orderingSpec,
                      const unsigned int randomSeed)
-        : implementation_(new Implementation(rules, atomsIndex, getAtomsVector, orderingSpec, randomSeed)) {}
+        : implementation_(std::make_shared<Implementation>(rules, atomsIndex, getAtomsVector, orderingSpec, randomSeed))
+        {}
 
     void Matcher::addMatchesInvolvingExpressions(const std::vector<ExpressionID>& expressionIDs,
                                                  const std::function<bool()>& shouldAbort) {

--- a/libSetReplace/Match.cpp
+++ b/libSetReplace/Match.cpp
@@ -179,9 +179,7 @@ namespace SetReplace {
 
             for (const auto& expression : expressionIDs) {
                 const auto& matches = expressionToMatches_[expression];
-                for (const auto& matchPtr : matches) {
-                    matchesToDelete.insert(matchPtr);
-                }
+                matchesToDelete.insert(matches.begin(), matches.end());
             }
 
             for (const auto& match : matchesToDelete) {
@@ -214,9 +212,10 @@ namespace SetReplace {
         void addMatchesForRule(const std::vector<ExpressionID>& expressionIDs,
                                const RuleID& ruleID,
                                const std::function<bool()>& shouldAbort) {
-            for (size_t i = 0; i < rules_[ruleID].inputs.size(); ++i) {
-                const Match emptyMatch{ruleID, std::vector<ExpressionID>(rules_[ruleID].inputs.size(), -1)};
-                completeMatchesStartingWithInput(emptyMatch, rules_[ruleID].inputs, i, expressionIDs, shouldAbort);
+            const auto& ruleInputExpressions = rules_[ruleID].inputs;
+            for (size_t i = 0; i < ruleInputExpressions.size(); ++i) {
+                const Match emptyMatch{ruleID, std::vector<ExpressionID>(ruleInputExpressions.size(), -1)};
+                completeMatchesStartingWithInput(emptyMatch, ruleInputExpressions, i, expressionIDs, shouldAbort);
             }
         }
 

--- a/libSetReplace/Match.hpp
+++ b/libSetReplace/Match.hpp
@@ -53,15 +53,16 @@ namespace SetReplace {
          */
         Matcher(const std::vector<Rule>& rules,
                 AtomsIndex& atomsIndex,
-                const std::function<AtomsVector(ExpressionID)> getAtomsVector,
-                const OrderingSpec orderingSpec,
-                const unsigned int randomSeed = 0);
-        
+                const std::function<AtomsVector(ExpressionID)>& getAtomsVector,
+                const OrderingSpec& orderingSpec,
+                unsigned int randomSeed = 0);
+
         /** @brief Finds and adds to the index all matches involving specified expressions.
          * @details Calls shouldAbort() frequently, and throws Error::Aborted if that returns true. Otherwise might take significant time to evaluate depending on the system.
          */
-        void addMatchesInvolvingExpressions(const std::vector<ExpressionID>& expressionIDs, const std::function<bool()> shouldAbort);
-        
+        void addMatchesInvolvingExpressions(const std::vector<ExpressionID>& expressionIDs,
+                                            const std::function<bool()>& shouldAbort);
+
         /** @brief Removes matches containing specified expression IDs from the index.
          */
         void removeMatchesInvolvingExpressions(const std::vector<ExpressionID>& expressionIDs);
@@ -80,14 +81,14 @@ namespace SetReplace {
          * @param patternMatches explicit atoms corresponding to patterns in inputPatterns.
          * @param atomsToReplace patterns, which would be replaced the same way as inputPatterns are matched to patternMatches.
          */
-        static bool substituteMissingAtomsIfPossible(const std::vector<AtomsVector> inputPatterns,
-                                                     const std::vector<AtomsVector> patternMatches,
+        static bool substituteMissingAtomsIfPossible(const std::vector<AtomsVector>& inputPatterns,
+                                                     const std::vector<AtomsVector>& patternMatches,
                                                      std::vector<AtomsVector>& atomsToReplace);
         
         /** @brief Returns the set of expression IDs matched in any match. */
-        const std::vector<MatchPtr> allMatches() const;
-        
-    private:
+        std::vector<MatchPtr> allMatches() const;
+
+     private:
         class Implementation;
         std::shared_ptr<Implementation> implementation_;
     };

--- a/libSetReplace/Set.cpp
+++ b/libSetReplace/Set.cpp
@@ -299,7 +299,6 @@ namespace SetReplace {
                                                       const Generation generation) {
             std::vector<ExpressionID> ids;
             ids.reserve(expressions.size());
-            expressions_.reserve(expressions_.size() + expressions.size());
             for (const auto& expression : expressions) {
                 ids.push_back(nextExpressionID_);
                 expressions_.insert(std::make_pair(nextExpressionID_++,

--- a/libSetReplace/Set.cpp
+++ b/libSetReplace/Set.cpp
@@ -346,7 +346,7 @@ namespace SetReplace {
              const std::vector<AtomsVector>& initialExpressions,
              const Matcher::OrderingSpec& orderingSpec,
              unsigned int randomSeed) :
-             implementation_(new Implementation(rules, initialExpressions, orderingSpec, randomSeed)) {}
+             implementation_(std::make_shared<Implementation>(rules, initialExpressions, orderingSpec, randomSeed)) {}
 
     int64_t Set::replaceOnce(const std::function<bool()>& shouldAbort) {
         return implementation_->replaceOnce(shouldAbort);

--- a/libSetReplace/Set.cpp
+++ b/libSetReplace/Set.cpp
@@ -43,7 +43,7 @@ namespace SetReplace {
     public:
         Implementation(const std::vector<Rule>& rules,
                        const std::vector<AtomsVector>& initialExpressions,
-                       const Matcher::OrderingSpec orderingSpec,
+                       const Matcher::OrderingSpec& orderingSpec,
                        const unsigned int randomSeed) :
             Implementation(rules, initialExpressions, orderingSpec, randomSeed, [this](const int64_t expressionID) {
                 return expressions_.at(expressionID).atoms;
@@ -347,24 +347,24 @@ namespace SetReplace {
     
     Set::Set(const std::vector<Rule>& rules,
              const std::vector<AtomsVector>& initialExpressions,
-             const Matcher::OrderingSpec orderingSpec,
-             const unsigned int randomSeed) {
+             const Matcher::OrderingSpec& orderingSpec,
+             unsigned int randomSeed) {
         implementation_ = std::make_shared<Implementation>(rules, initialExpressions, orderingSpec, randomSeed);
     }
-    
-    int64_t Set::replaceOnce(const std::function<bool()> shouldAbort) {
+
+    int64_t Set::replaceOnce(const std::function<bool()>& shouldAbort) {
         return implementation_->replaceOnce(shouldAbort);
     }
-    
-    int64_t Set::replace(const StepSpecification stepSpec, const std::function<bool()> shouldAbort) {
+
+    int64_t Set::replace(const StepSpecification& stepSpec, const std::function<bool()>& shouldAbort) {
         return implementation_->replace(stepSpec, shouldAbort);
     }
     
     std::vector<SetExpression> Set::expressions() const {
         return implementation_->expressions();
     }
-    
-    Generation Set::maxCompleteGeneration(const std::function<bool()> shouldAbort) {
+
+    Generation Set::maxCompleteGeneration(const std::function<bool()>& shouldAbort) {
         return implementation_->maxCompleteGeneration(shouldAbort);
     }
 

--- a/libSetReplace/Set.hpp
+++ b/libSetReplace/Set.hpp
@@ -54,21 +54,21 @@ namespace SetReplace {
          */
         Set(const std::vector<Rule>& rules,
             const std::vector<AtomsVector>& initialExpressions,
-            const Matcher::OrderingSpec orderingSpec,
-            const unsigned int randomSeed = 0);
-        
+            const Matcher::OrderingSpec& orderingSpec,
+            unsigned int randomSeed = 0);
+
         /** @brief Perform a single substitution, create the corresponding event, and output expressions.
          * @param shouldAbort function that should return true if Wolfram Language abort is in progress.
          * @return 1 if substitution was made, 0 if no matches were found.
          */
-        int64_t replaceOnce(const std::function<bool()> shouldAbort);
-        
+        int64_t replaceOnce(const std::function<bool()>& shouldAbort);
+
         /** @brief Run replaceOnce() stepSpec.maxEvents times, or until the next expression violates constraints imposed by stepSpec.
          * @param shouldAbort function that should return true if Wolfram Language abort is in progress.
          * @return The number of subtitutions made, could be between 0 and stepSpec.maxEvents.
          */
-        int64_t replace(const StepSpecification stepSpec, const std::function<bool()> shouldAbort);
-        
+        int64_t replace(const StepSpecification& stepSpec, const std::function<bool()>& shouldAbort);
+
         /** @brief List of all expressions in the set, past and present.
          */
         std::vector<SetExpression> expressions() const;
@@ -76,8 +76,8 @@ namespace SetReplace {
         /** @brief Returns the largest generation that has both been reached, and has no matches that would produce expressions with that or lower generation.
          * @details Takes O(matches count) + as long as it would take to do the next step (because new expressions need to be indexed).
          */
-        Generation maxCompleteGeneration(const std::function<bool()> shouldAbort);
-        
+        Generation maxCompleteGeneration(const std::function<bool()>& shouldAbort);
+
         /** @brief Yields termination reason for the previous evaluation, or TerminationReason::NotTerminated if no evaluation was done yet.
          */
         TerminationReason terminationReason() const;

--- a/libSetReplace/SetReplace.cpp
+++ b/libSetReplace/SetReplace.cpp
@@ -7,7 +7,7 @@
 
 #include "Set.hpp"
 
-mint getData(const mint* data, mint length, mint index) {
+mint getData(const mint* data, const mint& length, const mint& index) {
     if (index >= length || index < 0) {
         throw LIBRARY_FUNCTION_ERROR;
     } else {
@@ -21,7 +21,7 @@ namespace SetReplace {
     using SetID = int64_t;
     std::unordered_map<SetID, Set> sets_;
 
-    std::vector<AtomsVector> getNextSet(mint tensorLength, const mint* tensorData, mint& startReadIndex) {
+    std::vector<AtomsVector> getNextSet(const mint& tensorLength, const mint* tensorData, mint& startReadIndex) {
         const auto getDataFunc = [&tensorData, &tensorLength, &startReadIndex]() -> mint {
             return getData(tensorData, tensorLength, startReadIndex++);
         };
@@ -43,7 +43,7 @@ namespace SetReplace {
         const mint tensorLength = libData->MTensor_getFlattenedLength(rulesTensor);
         const mint* tensorData = libData->MTensor_getIntegerData(rulesTensor);
         mint readIndex = 0;
-        const auto getRulesData = [tensorData, tensorLength, &readIndex]() -> mint {
+        const auto getRulesData = [&tensorData, &tensorLength, &readIndex]() -> mint {
             return getData(tensorData, tensorLength, readIndex++);
         };
         
@@ -138,11 +138,10 @@ namespace SetReplace {
         // Put fake event at the end so that the length of final expression can be determined on WL side.
         constexpr EventID fakeEvent = -3;
         constexpr Generation fakeGeneration = -1;
-        appendToTensor({
-                           static_cast<mint>(fakeEvent),
-                           static_cast<mint>(fakeEvent),
-                           static_cast<mint>(fakeGeneration),
-                           static_cast<mint>(atomsPointer)});
+        appendToTensor({static_cast<mint>(fakeEvent),
+                        static_cast<mint>(fakeEvent),
+                        static_cast<mint>(fakeGeneration),
+                        static_cast<mint>(atomsPointer)});
 
         for (const auto& expression : expressions) {
             appendToTensor(expression.atoms);


### PR DESCRIPTION
## Changes
* Increased usage of STL functions for efficiency.
* Reduced instances of pass-by-value to reduce amount of copying, particularly vectors. 
* Reduced amount of hash lookups (sets/maps). Although complexity is constant, lookups are quite expensive.
* Increased usage of foreach loops
* Some other misc. optimizations

Overall performance is increased by up to 37% in one test I ran of WolframModel.

## Comments
* No functionality changes.
* As a bonus, these commits include auto code formatting. This partially addresses #319. You may see a lot of erasures on blank lines. Many IDEs including mine erase white space to reduce file size.

## Examples
Testing setup functions:
```wl
Attributes[meanAroundTiming] = {HoldAll};
meanAroundTiming[expr_, measurementsCount_ : 5] := 
 MeanAround@Table[First@AbsoluteTiming[expr], measurementsCount]
```
```wl
speedupDelta[old_, new_] := UnitConvert[(old - new)/old, "Percent"]
```
```wl
run := meanAroundTiming[WolframModel[#1, Automatic, #2]] & @@@ {
   {{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, 10},
   {{{1, 2, 3}, {4, 3, 5}, {3, 6}} -> {{6, 7, 8}, {6, 9, 10}, {11, 8, 
       10}, {5, 2, 9}, {9, 9}, {1, 9}, {7, 5}, {8, 5}}, 13},
   {{{1, 2, 2}, {3, 2, 4}} -> {{5, 4, 4}, {4, 3, 5}, {3, 5, 1}}, 
    10000},
   {{{1, 2}, {2, 1}, {1, 3}, {2, 3}, {3, 1}, {3, 2}} -> {{1, 2}, {2, 
       1}, {1, 3}, {2, 3}, {3, 1}, {3, 2}, {1, 4}, {2, 4}, {3, 4}, {4,
        1}, {4, 2}, {4, 3}}, 4},
   {{{1}, {1}, {1}} -> {{1}, {1}, {1}, {1}}, 10}
   }
```
Running from master, 
```wl
master = run
```
yields
![2020-04-22-203022_1920x1080_scrot](https://user-images.githubusercontent.com/26678747/80046285-2d895a00-84d8-11ea-80f2-950faea38b3d.png)
Running from this branch,
```wl
this = run
```
yields
![2020-04-22-203908_1920x1080_scrot](https://user-images.githubusercontent.com/26678747/80046741-75f54780-84d9-11ea-9cab-8e6da80de31d.png)
To compare the two, running
```wl
speedupDelta[master, this]
```
yields
![2020-04-22-180159_1920x1080_scrot](https://user-images.githubusercontent.com/26678747/80038553-e1341f00-84c3-11ea-9291-17d394e20139.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/328)
<!-- Reviewable:end -->
