### PR TITLE
Verify test completion in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,4 +24,4 @@ jobs:
 
       - run:
           name: Test
-          command: ./test.wls
+          command: ./.circleci/test.sh

--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+rm -f exit_status.txt
+STATUS_FILE=1 ./test.wls
+if [[ -f exit_status.txt && $(< exit_status.txt) == "0" ]]; then
+  true
+else
+  false
+fi

--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -2,8 +2,4 @@
 
 rm -f exit_status.txt
 STATUS_FILE=1 ./test.wls
-if [[ -f exit_status.txt && $(< exit_status.txt) == "0" ]]; then
-  true
-else
-  false
-fi
+[[ -f exit_status.txt && $(< exit_status.txt) == "0" ]]

--- a/test.wls
+++ b/test.wls
@@ -140,6 +140,10 @@ Print["Report file: ", $reportFile];
 
 If[$MessageList =!= {}, $successQ = False];
 
+If[Environment["STATUS_FILE"] === "1",
+  Export["exit_status.txt", If[$successQ, 0, 1]];
+];
+
 If[$successQ,
   Print["Tests passed."];
   Exit[0],


### PR DESCRIPTION
## Changes
* Resolves #327.
* Makes `./test.wls` write its expected exit status to a file, which is then read by CI. This prevents CI from succeeding if Wolfram Kernel crashes with exit status 0.

## Comments
* It appears that Wolfram Kernel sometimes crashes with exit status 0, as happened in [this build](https://app.circleci.com/pipelines/github/maxitg/SetReplace/583/workflows/e90468f6-cfc3-4a84-9f67-f5dbee24830b/jobs/622/steps).
* This PR makes the CI run a bash script instead, which makes `./test.wls` write its status to a text file at the end of execution, and then checks that text file to determine the CI status.
* This way, if `./test.wls` finishes running, its exit status would be the same as CIs, but if it crashes, the file would not exist, and CI will fail anyway.

## Examples
* Cherry-pick these commits on top of kernel-crashing a280118d2941c111d59f22eb7e9d100632439883, and run on CI. CI [fails](https://app.circleci.com/pipelines/github/maxitg/SetReplace/613/workflows/4e279d29-b5df-484c-b9b6-dca71af0e52a/jobs/653/steps) as expected.
* CI [also fails](https://app.circleci.com/pipelines/github/maxitg/SetReplace/614/workflows/194b6211-a915-4bd4-9f5c-3f90e95e90f3/jobs/654/steps) if some of the tests fail.
* Finally, CI passes if tests pass as in [this PR](https://app.circleci.com/pipelines/github/maxitg/SetReplace/612/workflows/47e945d6-ee43-48d0-85dc-ba23b6d6070e/jobs/655).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/331)
<!-- Reviewable:end -->
