### PR TITLE
performanceTest.wls checkout original SHA

### DIFF
--- a/performanceTest.wls
+++ b/performanceTest.wls
@@ -102,6 +102,8 @@ $newSHA = If[Length @ $ScriptCommandLine >= 3, $ScriptCommandLine[[3]], $current
 
 {$oldResults, $newResults} = runTests[$gitRepo, #, tests] & /@ {$oldSHA, $newSHA};
 
+GitCheckoutReference[$gitRepo, $currentSHA];
+
 $speedup = speedupDelta[$oldResults, $newResults];
 
 $redColor = "\033[0;31m";

--- a/performanceTest.wls
+++ b/performanceTest.wls
@@ -100,7 +100,7 @@ $oldSHA = If[Length @ $ScriptCommandLine >= 2, $ScriptCommandLine[[2]], "master"
 $newSHA = If[Length @ $ScriptCommandLine >= 3, $ScriptCommandLine[[3]], $currentSHA];
 
 $symbolicRef = RunProcess[{"git", "symbolic-ref", "--short", "HEAD"}];
-$originalRef = If[$symbolicRef["ExitCode"] == 0, StringExtract[$symbolicRef["StandardOutput"], 1], $currentSHA];
+$originalRef = If[$symbolicRef["ExitCode"] === 0, StringExtract[$symbolicRef["StandardOutput"], 1], $currentSHA];
 
 {$oldResults, $newResults} = runTests[$gitRepo, #, tests] & /@ {$oldSHA, $newSHA};
 

--- a/performanceTest.wls
+++ b/performanceTest.wls
@@ -81,7 +81,6 @@ runTests[repo_, sha_, tests_] := Module[{result, kernel},
     << SetReplace`; meanAroundTiming @@@ KeyMap[ReleaseHold, ReleaseHold @ Map[Hold, tests, {3}]],
     kernel
   ];
-  Run["git checkout -q -"];
   Print[""];
   result
 ]
@@ -100,9 +99,12 @@ If[!$cleanQ,
 $oldSHA = If[Length @ $ScriptCommandLine >= 2, $ScriptCommandLine[[2]], "master"];
 $newSHA = If[Length @ $ScriptCommandLine >= 3, $ScriptCommandLine[[3]], $currentSHA];
 
+$symbolicRef = RunProcess[{"git", "symbolic-ref", "--short", "HEAD"}];
+$originalRef = If[$symbolicRef["ExitCode"] == 0, StringExtract[$symbolicRef["StandardOutput"], 1], $currentSHA];
+
 {$oldResults, $newResults} = runTests[$gitRepo, #, tests] & /@ {$oldSHA, $newSHA};
 
-GitCheckoutReference[$gitRepo, $currentSHA];
+RunProcess[{"git", "checkout", "-q", $originalRef}];
 
 $speedup = speedupDelta[$oldResults, $newResults];
 


### PR DESCRIPTION
## Changes
* After completing tests on both input SHAs, performs `git checkout` on original git SHA.

## Examples
Originally, if running from `SHA_1`:
```bash
./performanceTest.wls SHA_2 SHA_3
```
would leave you on `SHA_3`.

With this change, running the same command would leave you on SHA_1.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/356)
<!-- Reviewable:end -->
