### PR TITLE
Fix Windows compilation errors.

### DIFF
--- a/libSetReplace/SetReplace.cpp
+++ b/libSetReplace/SetReplace.cpp
@@ -144,7 +144,8 @@ namespace SetReplace {
                         static_cast<mint>(atomsPointer)});
 
         for (const auto& expression : expressions) {
-            appendToTensor(expression.atoms);
+            // Cannot do static_cast due to 32-bit Windows support
+            appendToTensor(std::vector<mint>(expression.atoms.begin(), expression.atoms.end()));
         }
         
         return output;

--- a/scripts/buildInit.wl
+++ b/scripts/buildInit.wl
@@ -82,8 +82,11 @@ updateVersion[] /; Names["GitLink`*"] =!= {} := Module[{
   Check[
     versionInformation = Import[FileNameJoin[{$repoRoot, "scripts", "version.wl"}]];
     gitRepo = GitOpen[$repoRoot];
+    If[$internalBuildQ, GitFetch[gitRepo, "origin"]];
     minorVersionNumber = Max[0, Length[GitRange[
-      gitRepo, Except[versionInformation["Checkpoint"]], GitMergeBase[gitRepo, "HEAD", "master"]]] - 1];
+      gitRepo,
+      Except[versionInformation["Checkpoint"]],
+      GitMergeBase[gitRepo, "HEAD", If[$internalBuildQ, "origin/master", "master"]]]] - 1];
     pacletInfoFilename = FileNameJoin[{$buildDirectory, "PacletInfo.m"}];
     pacletInfo = Association @@ Import[pacletInfoFilename];
     versionString = pacletInfo[Version] <> "." <> ToString[minorVersionNumber];,


### PR DESCRIPTION
## Changes
* Resolves #359.
* Resolves compilations errors on Windows-32.

## Comments
* `mint` on 32-bit Windows is 32-bit, however, `Atom` is `int64_t`. Because of that, conversion from `AtomList` to `std::vector<mint>` was failing on line 147.
* This is now replaced with an `std::vector<mint>` range constructor.
* We don't expect anyone with a 32-bit Windows to generate over 2 billion vertices in a single simulation, so this change should not cause any issues.
* Also, internal builds did not fetch master if building non-master, which is now fixed (without breaking normal offline builds).

## Examples
* Internal builds are now succeeding: [Windows_Build_132.log](https://github.com/maxitg/SetReplace/files/4645336/Windows_Build_132.log)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/360)
<!-- Reviewable:end -->
