### PR TITLE
Lint script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,10 @@ jobs:
       - checkout
 
       - run:
+          name: Lint
+          command: ./lint.sh
+
+      - run:
           name: Build
           command: ./build.wls
 

--- a/.clang-format
+++ b/.clang-format
@@ -6,19 +6,5 @@ BinPackArguments: false
 BinPackParameters: false
 ColumnLimit: 120
 DerivePointerAlignment: false
-IncludeCategories:
-  - Regex:         '^<ext/.*\.h>'
-    Priority:      2
-    SortPriority:  0
-  - Regex:         '^<.*\.h>'
-    Priority:      2
-    SortPriority:  0
-  - Regex:         '^<.*'
-    Priority:      1
-    SortPriority:  0
-  - Regex:         '.*'
-    Priority:      3
-    SortPriority:  0
-IncludeIsMainRegex: '(Test)?$'
 Standard: c++17
 ...

--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,24 @@
+---
+Language: Cpp
+BasedOnStyle: Google
+AllowShortIfStatementsOnASingleLine: Always
+BinPackArguments: false
+BinPackParameters: false
+ColumnLimit: 120
+DerivePointerAlignment: false
+IncludeCategories:
+  - Regex:         '^<ext/.*\.h>'
+    Priority:      2
+    SortPriority:  0
+  - Regex:         '^<.*\.h>'
+    Priority:      2
+    SortPriority:  0
+  - Regex:         '^<.*'
+    Priority:      1
+    SortPriority:  0
+  - Regex:         '.*'
+    Priority:      3
+    SortPriority:  0
+IncludeIsMainRegex: '(Test)?$'
+Standard: c++17
+...

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -360,8 +360,8 @@ following exceptions:
 We use [`clang-format`](https://clang.llvm.org/docs/ClangFormat.html) for formatting and
 [`cpplint`](https://raw.githubusercontent.com/google/styleguide/gh-pages/cpplint/cpplint.py) for linting.
 
-To run these automatically, call `./lint.sh`. This will print error messages from both tools. To format the code in
-place use `./lint.sh -i`.
+To run these automatically, call `./lint.sh`. This will print a formatting diff and error messages from `cpplint`.
+To edit the code in place with the fixed formatting use `./lint.sh -i`.
 
 If `cpplint` flags a portion of your code, please make sure it is adhering to the proper code style. If it is a false
 positive or if there is no reasonable way to avoid the flag, you may put `// NOLINT` at the end of the line if there is

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -347,33 +347,29 @@ In addition to that, here are some more-or-less established rules:
 * Start global constants with `$`, whether internal or public, and tags (such as used in [`Throw`](https://reference.wolfram.com/language/ref/Throw.html) or [`Sow`](https://reference.wolfram.com/language/ref/Sow.html), or as generic enum labels) with `$$`.
 
 #### C++
-New code should follow [Google C++ Style](https://google.github.io/styleguide/cppguide.html) guidelines, save for
-the exceptions laid out in the list below. The code in this repository is currently undergoing refactoring to
-conform to this specification. You can track the progress of this refactoring
-[here](https://github.com/maxitg/SetReplace/projects/2).
-
-The following are exceptions to Google C++ Style:
+The code should follow [Google C++ Style](https://google.github.io/styleguide/cppguide.html) guidelines, save for the
+following exceptions:
 * Maximum line length is 120 characters.
 * Function and variable names, including const and constexpr variables, use lower camel case.
 * Namespace and class names use upper camel case.
 * C++ exceptions may be thrown.
-* All indentation uses four spaces, except for access specifiers which uses one.
-* White space in pointer and reference declarations goes after the `*` or `&` character. For example:
-    * `int* foo;`
-    * `const std::string& string;`
 * License, authors, and file descriptions should not be put at the top of files.
 * Doxygen is used for documentation.
+* We use `.cpp` and `.hpp` extensions for source files.
 
-A useful tool for confirming your code's adherence to the above code style is to use
-[cpplint](https://raw.githubusercontent.com/google/styleguide/gh-pages/cpplint/cpplint.py). You can lint a C++ source
-or header file like this:
-```bash
-cpplint.py --linelength=120 --filter=-legal/copyright file_name
-```
-If cpplint flags a portion of your code, please make sure it is adhering to the proper code style. If it is a false
+We use [`clang-format`](https://clang.llvm.org/docs/ClangFormat.html) for formatting and
+[`cpplint`](https://raw.githubusercontent.com/google/styleguide/gh-pages/cpplint/cpplint.py) for linting.
+
+To run these automatically, call `./lint.sh`. This will print error messages from both tools. To format the code in
+place use `./lint.sh -i`.
+
+If `cpplint` flags a portion of your code, please make sure it is adhering to the proper code style. If it is a false
 positive or if there is no reasonable way to avoid the flag, you may put `// NOLINT` at the end of the line if there is
 space, or `// NOLINTNEXTLINE` on a new line above if there is no space. For any usages of `// NOLINT` or
 `// NOLINTNEXTLINE`, please describe the reason for its inclusion both in a code comment and in your pull request's
 comments section.
+
+If you want to disable formatting, use `// clang-format off` and `// clang-format on` around the manually formatted
+code.
 
 That's all for our guidelines, now let's go figure out the fundamental theory of physics! :rocket:

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -353,6 +353,7 @@ following exceptions:
 * Function and variable names, including const and constexpr variables, use lower camel case.
 * Namespace and class names use upper camel case.
 * C++ exceptions may be thrown.
+* If splitting function arguments into multiple lines, each argument should go on a separate line.
 * License, authors, and file descriptions should not be put at the top of files.
 * Doxygen is used for documentation.
 * We use `.cpp` and `.hpp` extensions for source files.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -365,6 +365,7 @@ We use [`clang-format`](https://clang.llvm.org/docs/ClangFormat.html) for format
 [`cpplint`](https://raw.githubusercontent.com/google/styleguide/gh-pages/cpplint/cpplint.py) for linting.
 
 To run these automatically, call `./lint.sh`. This will print a formatting diff and error messages from `cpplint`.
+If there are no errors found, it will exit with no output.
 To edit the code in place with the fixed formatting use `./lint.sh -i`.
 
 If `cpplint` flags a portion of your code, please make sure it is adhering to the proper code style. If it is a false

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -353,6 +353,9 @@ following exceptions:
 * Function and variable names, including const and constexpr variables, use lower camel case.
 * Namespace and class names use upper camel case.
 * C++ exceptions may be thrown.
+* White space in pointer and reference declarations goes after the `*` or `&` character. For example:
+    * `int* foo;`
+    * `const std::string& string;`
 * If splitting function arguments into multiple lines, each argument should go on a separate line.
 * License, authors, and file descriptions should not be put at the top of files.
 * Doxygen is used for documentation.

--- a/SetReplace.xcodeproj/project.pbxproj
+++ b/SetReplace.xcodeproj/project.pbxproj
@@ -22,6 +22,8 @@
 /* Begin PBXFileReference section */
 		6909EBA922258611001458D2 /* Match.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = Match.cpp; sourceTree = "<group>"; };
 		6909EBAA22258611001458D2 /* Match.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = Match.hpp; sourceTree = "<group>"; };
+		691E077A2471CED500D2BDD5 /* CMakeLists.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = CMakeLists.txt; sourceTree = "<group>"; };
+		691E077C2471D1DD00D2BDD5 /* Set_test.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = Set_test.cpp; sourceTree = "<group>"; };
 		695F486E222443F20058E057 /* Set.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = Set.cpp; sourceTree = "<group>"; };
 		695F486F222443F20058E057 /* Set.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = Set.hpp; sourceTree = "<group>"; };
 		6961A1D523184ABC009461C8 /* Expression.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = Expression.cpp; sourceTree = "<group>"; };
@@ -44,6 +46,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		691E07792471CED500D2BDD5 /* test */ = {
+			isa = PBXGroup;
+			children = (
+				691E077A2471CED500D2BDD5 /* CMakeLists.txt */,
+				691E077C2471D1DD00D2BDD5 /* Set_test.cpp */,
+			);
+			path = test;
+			sourceTree = "<group>";
+		};
 		695F485A222440B90058E057 = {
 			isa = PBXGroup;
 			children = (
@@ -63,16 +74,17 @@
 		695F4865222440B90058E057 /* libSetReplace */ = {
 			isa = PBXGroup;
 			children = (
-				69ED0F4023170D5D0014A48E /* IDTypes.hpp */,
 				69B2D41122244AFC008778A3 /* Expression.hpp */,
 				6961A1D523184ABC009461C8 /* Expression.cpp */,
-				69B2D41422244D1F008778A3 /* Rule.hpp */,
+				69ED0F4023170D5D0014A48E /* IDTypes.hpp */,
 				6909EBAA22258611001458D2 /* Match.hpp */,
 				6909EBA922258611001458D2 /* Match.cpp */,
+				69B2D41422244D1F008778A3 /* Rule.hpp */,
 				695F486F222443F20058E057 /* Set.hpp */,
 				695F486E222443F20058E057 /* Set.cpp */,
-				69CAF8732257B23B006F9C60 /* SetReplace.cpp */,
 				69CAF8742257B23B006F9C60 /* SetReplace.hpp */,
+				69CAF8732257B23B006F9C60 /* SetReplace.cpp */,
+				691E07792471CED500D2BDD5 /* test */,
 			);
 			path = libSetReplace;
 			sourceTree = "<group>";

--- a/libSetReplace/Expression.cpp
+++ b/libSetReplace/Expression.cpp
@@ -5,67 +5,67 @@
 #include <utility>
 
 namespace SetReplace {
-    class AtomsIndex::Implementation {
-     private:
-        const std::function<AtomsVector(ExpressionID)> getAtomsVector_;
-        std::unordered_map<Atom, std::unordered_set<ExpressionID>> index_;
+class AtomsIndex::Implementation {
+ private:
+  const std::function<AtomsVector(ExpressionID)> getAtomsVector_;
+  std::unordered_map<Atom, std::unordered_set<ExpressionID>> index_;
 
-     public:
-        explicit Implementation(std::function<AtomsVector(ExpressionID)> getAtomsVector)
-            : getAtomsVector_(std::move(getAtomsVector)) {}
+ public:
+  explicit Implementation(std::function<AtomsVector(ExpressionID)> getAtomsVector)
+      : getAtomsVector_(std::move(getAtomsVector)) {}
 
-        void removeExpressions(const std::vector<ExpressionID>& expressionIDs) {
-            const std::unordered_set<ExpressionID> expressionsToDelete(expressionIDs.begin(), expressionIDs.end());
+  void removeExpressions(const std::vector<ExpressionID>& expressionIDs) {
+    const std::unordered_set<ExpressionID> expressionsToDelete(expressionIDs.begin(), expressionIDs.end());
 
-            std::unordered_set<Atom> involvedAtoms;
-            for (const auto& expression : expressionIDs) {
-                const auto& atomsVector = getAtomsVector_(expression);
-                involvedAtoms.insert(atomsVector.begin(), atomsVector.end());
-            }
-
-            for (const auto& atom : involvedAtoms) {
-                auto& atomExpressionSet = index_[atom];
-                auto atomExpressionIterator = atomExpressionSet.begin();
-                const auto atomExpressionSetEnd = atomExpressionSet.cend();
-                while (atomExpressionIterator != atomExpressionSetEnd) {
-                    if (expressionsToDelete.count(*atomExpressionIterator)) {
-                        atomExpressionIterator = atomExpressionSet.erase(atomExpressionIterator);
-                    } else {
-                        ++atomExpressionIterator;
-                    }
-                }
-                if (atomExpressionSet.empty()) {
-                    index_.erase(atom);
-                }
-            }
-        }
-
-        void addExpressions(const std::vector<ExpressionID>& expressionIDs) {
-            for (const auto& expressionID : expressionIDs) {
-                for (const auto& atom : getAtomsVector_(expressionID)) {
-                    index_[atom].insert(expressionID);
-                }
-            }
-        }
-
-        std::unordered_set<ExpressionID> expressionsContainingAtom(const Atom atom) const {
-            const auto resultIterator = index_.find(atom);
-            return resultIterator != index_.end() ? resultIterator->second : std::unordered_set<ExpressionID>();
-        }
-    };
-
-    AtomsIndex::AtomsIndex(const std::function<AtomsVector(ExpressionID)>& getAtomsVector)
-        : implementation_(std::make_shared<Implementation>(getAtomsVector)) {}
-
-    void AtomsIndex::removeExpressions(const std::vector<ExpressionID>& expressionIDs) {
-        implementation_->removeExpressions(expressionIDs);
+    std::unordered_set<Atom> involvedAtoms;
+    for (const auto& expression : expressionIDs) {
+      const auto& atomsVector = getAtomsVector_(expression);
+      involvedAtoms.insert(atomsVector.begin(), atomsVector.end());
     }
 
-    void AtomsIndex::addExpressions(const std::vector<ExpressionID>& expressionIDs) {
-        implementation_->addExpressions(expressionIDs);
+    for (const auto& atom : involvedAtoms) {
+      auto& atomExpressionSet = index_[atom];
+      auto atomExpressionIterator = atomExpressionSet.begin();
+      const auto atomExpressionSetEnd = atomExpressionSet.cend();
+      while (atomExpressionIterator != atomExpressionSetEnd) {
+        if (expressionsToDelete.count(*atomExpressionIterator)) {
+          atomExpressionIterator = atomExpressionSet.erase(atomExpressionIterator);
+        } else {
+          ++atomExpressionIterator;
+        }
+      }
+      if (atomExpressionSet.empty()) {
+        index_.erase(atom);
+      }
     }
+  }
 
-    std::unordered_set<ExpressionID> AtomsIndex::expressionsContainingAtom(const Atom atom) const {
-        return implementation_->expressionsContainingAtom(atom);
+  void addExpressions(const std::vector<ExpressionID>& expressionIDs) {
+    for (const auto& expressionID : expressionIDs) {
+      for (const auto& atom : getAtomsVector_(expressionID)) {
+        index_[atom].insert(expressionID);
+      }
     }
+  }
+
+  std::unordered_set<ExpressionID> expressionsContainingAtom(const Atom atom) const {
+    const auto resultIterator = index_.find(atom);
+    return resultIterator != index_.end() ? resultIterator->second : std::unordered_set<ExpressionID>();
+  }
+};
+
+AtomsIndex::AtomsIndex(const std::function<AtomsVector(ExpressionID)>& getAtomsVector)
+    : implementation_(std::make_shared<Implementation>(getAtomsVector)) {}
+
+void AtomsIndex::removeExpressions(const std::vector<ExpressionID>& expressionIDs) {
+  implementation_->removeExpressions(expressionIDs);
 }
+
+void AtomsIndex::addExpressions(const std::vector<ExpressionID>& expressionIDs) {
+  implementation_->addExpressions(expressionIDs);
+}
+
+std::unordered_set<ExpressionID> AtomsIndex::expressionsContainingAtom(const Atom atom) const {
+  return implementation_->expressionsContainingAtom(atom);
+}
+}  // namespace SetReplace

--- a/libSetReplace/Expression.hpp
+++ b/libSetReplace/Expression.hpp
@@ -3,61 +3,61 @@
 
 #include <functional>
 #include <memory>
-#include <vector>
 #include <unordered_set>
+#include <vector>
 
 #include "IDTypes.hpp"
 
 namespace SetReplace {
-    /** @brief List of atoms without references to events, as can be used in, i.e., rule specification.
-     */
-    using AtomsVector = std::vector<Atom>;
+/** @brief List of atoms without references to events, as can be used in, i.e., rule specification.
+ */
+using AtomsVector = std::vector<Atom>;
 
-    /** @brief Expression, as a part of the set, i.e., (hyper)edges in the graph.
-     */
-    struct SetExpression {
-        /** @brief Ordered list of atoms the expression contains.
-         */
-        AtomsVector atoms;
+/** @brief Expression, as a part of the set, i.e., (hyper)edges in the graph.
+ */
+struct SetExpression {
+  /** @brief Ordered list of atoms the expression contains.
+   */
+  AtomsVector atoms;
 
-        /** @brief Substitution event that has this expression as part of its output.
-         */
-        EventID creatorEvent;
+  /** @brief Substitution event that has this expression as part of its output.
+   */
+  EventID creatorEvent;
 
-        /** @brief Substitution event that has this expression as part of its input.
-         */
-        EventID destroyerEvent = finalStateEvent;
+  /** @brief Substitution event that has this expression as part of its input.
+   */
+  EventID destroyerEvent = finalStateEvent;
 
-        /** @brief Layer of the causal network this expression belongs to.
-         */
-        Generation generation;
-    };
+  /** @brief Layer of the causal network this expression belongs to.
+   */
+  Generation generation;
+};
 
-    /** @brief AtomsIndex keeps references to set expressions accessible by atoms, which is useful for matching.
-     */
-    class AtomsIndex {
-    public:
-        /** @brief Creates an empty index.
-         * @param getAtomsVector datasource function that returns the list of atoms for a requested expression.
-         */
-        explicit AtomsIndex(const std::function<AtomsVector(ExpressionID)>& getAtomsVector);
+/** @brief AtomsIndex keeps references to set expressions accessible by atoms, which is useful for matching.
+ */
+class AtomsIndex {
+ public:
+  /** @brief Creates an empty index.
+   * @param getAtomsVector datasource function that returns the list of atoms for a requested expression.
+   */
+  explicit AtomsIndex(const std::function<AtomsVector(ExpressionID)>& getAtomsVector);
 
-        /** @brief Removes expressions with specified IDs from the index.
-         */
-        void removeExpressions(const std::vector<ExpressionID>& expressionIDs);
+  /** @brief Removes expressions with specified IDs from the index.
+   */
+  void removeExpressions(const std::vector<ExpressionID>& expressionIDs);
 
-        /** @brief Adds expressions with specified IDs to the index.
-         */
-        void addExpressions(const std::vector<ExpressionID>& expressionIDs);
+  /** @brief Adds expressions with specified IDs to the index.
+   */
+  void addExpressions(const std::vector<ExpressionID>& expressionIDs);
 
-        /** @brief Returns the list of expressions containing a specified atom.
-         */
-        std::unordered_set<ExpressionID> expressionsContainingAtom(Atom atom) const;
+  /** @brief Returns the list of expressions containing a specified atom.
+   */
+  std::unordered_set<ExpressionID> expressionsContainingAtom(Atom atom) const;
 
-     private:
-        class Implementation;
-        std::shared_ptr<Implementation> implementation_;
-    };
-}
+ private:
+  class Implementation;
+  std::shared_ptr<Implementation> implementation_;
+};
+}  // namespace SetReplace
 
 #endif /* Expression_hpp */

--- a/libSetReplace/Expression.hpp
+++ b/libSetReplace/Expression.hpp
@@ -1,5 +1,5 @@
-#ifndef Expression_hpp
-#define Expression_hpp
+#ifndef LIBSETREPLACE_EXPRESSION_HPP_
+#define LIBSETREPLACE_EXPRESSION_HPP_
 
 #include <functional>
 #include <memory>
@@ -60,4 +60,4 @@ class AtomsIndex {
 };
 }  // namespace SetReplace
 
-#endif /* Expression_hpp */
+#endif  // LIBSETREPLACE_EXPRESSION_HPP_

--- a/libSetReplace/IDTypes.hpp
+++ b/libSetReplace/IDTypes.hpp
@@ -1,5 +1,5 @@
-#ifndef IDTypes_h
-#define IDTypes_h
+#ifndef LIBSETREPLACE_IDTYPES_HPP_
+#define LIBSETREPLACE_IDTYPES_HPP_
 
 #include <cstdint>
 
@@ -33,4 +33,4 @@ using Generation = int64_t;
 constexpr Generation initialGeneration = 0;
 }  // namespace SetReplace
 
-#endif /* IDTypes_h */
+#endif  // LIBSETREPLACE_IDTYPES_HPP_

--- a/libSetReplace/IDTypes.hpp
+++ b/libSetReplace/IDTypes.hpp
@@ -4,30 +4,33 @@
 #include <cstdint>
 
 namespace SetReplace {
-    /** @brief Identifiers for atoms, which are the elements of expressions, i.e., vertices in the graph.
-     * @details Positive IDs refer to specific atoms, negative IDs refer to patterns (as, for instance, can be used in the rules).
-     */
-    using Atom = int64_t;
-    
-    /** @brief Identifiers for rules, which stay the same for the entire evolution of the system.
-     */
-    using RuleID = int;
-    
-    /** @brief Identifiers for expressions, which are the elements of the set, and contain ordered sequences of atoms, i.e., (hyper)edges in the graph.
-     */
-    using ExpressionID = int64_t;
-    
-    /** @brief Identifiers for substitution events, later events have larger IDs.
-     */
-    using EventID = int64_t;
-    constexpr EventID initialConditionEvent = 0;
-    constexpr EventID finalStateEvent = -1;
-    
-    /** @brief Layer this expression belongs to in the causal network.
-     * @details Specifically, if the largest generation of expressions in the event inputs is n, the generation of its outputs will be n + 1.
-     */
-    using Generation = int64_t;
-    constexpr Generation initialGeneration = 0;
-}
+/** @brief Identifiers for atoms, which are the elements of expressions, i.e., vertices in the graph.
+ * @details Positive IDs refer to specific atoms, negative IDs refer to patterns (as, for instance, can be used in the
+ * rules).
+ */
+using Atom = int64_t;
+
+/** @brief Identifiers for rules, which stay the same for the entire evolution of the system.
+ */
+using RuleID = int;
+
+/** @brief Identifiers for expressions, which are the elements of the set, and contain ordered sequences of atoms, i.e.,
+ * (hyper)edges in the graph.
+ */
+using ExpressionID = int64_t;
+
+/** @brief Identifiers for substitution events, later events have larger IDs.
+ */
+using EventID = int64_t;
+constexpr EventID initialConditionEvent = 0;
+constexpr EventID finalStateEvent = -1;
+
+/** @brief Layer this expression belongs to in the causal network.
+ * @details Specifically, if the largest generation of expressions in the event inputs is n, the generation of its
+ * outputs will be n + 1.
+ */
+using Generation = int64_t;
+constexpr Generation initialGeneration = 0;
+}  // namespace SetReplace
 
 #endif /* IDTypes_h */

--- a/libSetReplace/Match.cpp
+++ b/libSetReplace/Match.cpp
@@ -7,447 +7,430 @@
 #include <utility>
 
 namespace SetReplace {
-    class MatchComparator {
-     private:
-        const Matcher::OrderingSpec orderingSpec_;
+class MatchComparator {
+ private:
+  const Matcher::OrderingSpec orderingSpec_;
 
-        template<typename T>
-        static int compare(T a, T b) {
-            return a < b ? -1 : static_cast<int>(a > b);
+  template <typename T>
+  static int compare(T a, T b) {
+    return a < b ? -1 : static_cast<int>(a > b);
+  }
+
+ public:
+  MatchComparator(Matcher::OrderingSpec orderingSpec) : orderingSpec_(std::move(orderingSpec)) {}
+
+  bool operator()(const MatchPtr& a, const MatchPtr& b) const {
+    for (const auto& ordering : orderingSpec_) {
+      int comparison = compare(a, b, ordering.first);
+      if (comparison != 0) {
+        switch (ordering.second) {
+          case Matcher::OrderingDirection::Normal:
+            break;
+          case Matcher::OrderingDirection::Reverse:
+            comparison = -comparison;
+            break;
+          default:
+            throw Matcher::Error::InvalidOrderingDirection;
         }
+        return comparison < 0;
+      }
+    }
+    return false;
+  }
 
-     public:
-        MatchComparator(Matcher::OrderingSpec orderingSpec) : orderingSpec_(std::move(orderingSpec)) {}
+  static int compare(const MatchPtr& a, const MatchPtr& b, const Matcher::OrderingFunction& ordering) {
+    switch (ordering) {
+      case Matcher::OrderingFunction::SortedExpressionIDs:
+        return compareSortedIDs(a, b, false);
 
-        bool operator()(const MatchPtr& a, const MatchPtr& b) const {
-            for (const auto& ordering : orderingSpec_) {
-                int comparison = compare(a, b, ordering.first);
-                if (comparison != 0) {
-                    switch (ordering.second) {
-                        case Matcher::OrderingDirection::Normal:
-                            break;
-                        case Matcher::OrderingDirection::Reverse:
-                            comparison = -comparison;
-                            break;
-                        default:
-                            throw Matcher::Error::InvalidOrderingDirection;
-                    }
-                    return comparison < 0;
-                }
-            }
-            return false;
-        }
+      case Matcher::OrderingFunction::ReverseSortedExpressionIDs:
+        return compareSortedIDs(a, b, true);
 
-        static int compare(const MatchPtr& a, const MatchPtr& b, const Matcher::OrderingFunction& ordering) {
-            switch (ordering) {
-                case Matcher::OrderingFunction::SortedExpressionIDs:
-                    return compareSortedIDs(a, b, false);
+      case Matcher::OrderingFunction::ExpressionIDs:
+        return compareUnsortedIDs(a, b);
 
-                case Matcher::OrderingFunction::ReverseSortedExpressionIDs:
-                    return compareSortedIDs(a, b, true);
+      case Matcher::OrderingFunction::RuleIndex:
+        return compare(a->rule, b->rule);
 
-                case Matcher::OrderingFunction::ExpressionIDs:
-                    return compareUnsortedIDs(a, b);
+      default:
+        throw Matcher::Error::InvalidOrderingFunction;
+    }
+  }
 
-                case Matcher::OrderingFunction::RuleIndex:
-                    return compare(a->rule, b->rule);
+  static int compareVectors(const std::vector<ExpressionID>& first, const std::vector<ExpressionID>& second) {
+    const auto mismatchingIterators = std::mismatch(first.begin(), first.end(), second.begin(), second.end());
+    if (mismatchingIterators.first != first.end() && mismatchingIterators.second != second.end()) {
+      return compare(*mismatchingIterators.first, *mismatchingIterators.second);
+    } else {
+      return compare(first.size(), second.size());
+    }
+  }
 
-                default:
-                    throw Matcher::Error::InvalidOrderingFunction;
-            }
-        }
+  static int compareSortedIDs(const MatchPtr& a, const MatchPtr& b, const bool reverseOrder) {
+    std::vector<ExpressionID> aExpressions(a->inputExpressions.begin(), a->inputExpressions.end());
+    std::vector<ExpressionID> bExpressions(b->inputExpressions.begin(), b->inputExpressions.end());
 
-        static int compareVectors(const std::vector<ExpressionID>& first, const std::vector<ExpressionID>& second) {
-            const auto mismatchingIterators = std::mismatch(first.begin(), first.end(), second.begin(), second.end());
-            if (mismatchingIterators.first != first.end() && mismatchingIterators.second != second.end()) {
-                return compare(*mismatchingIterators.first, *mismatchingIterators.second);
-            } else {
-                return compare(first.size(), second.size());
-            }
-        }
+    if (!reverseOrder) {
+      std::sort(aExpressions.begin(), aExpressions.end(), std::less<>());
+      std::sort(bExpressions.begin(), bExpressions.end(), std::less<>());
+    } else {
+      std::sort(aExpressions.begin(), aExpressions.end(), std::greater<>());
+      std::sort(bExpressions.begin(), bExpressions.end(), std::greater<>());
+    }
+    return compareVectors(aExpressions, bExpressions);
+  }
 
-        static int compareSortedIDs(const MatchPtr& a, const MatchPtr& b, const bool reverseOrder) {
-            std::vector<ExpressionID> aExpressions(a->inputExpressions.begin(), a->inputExpressions.end());
-            std::vector<ExpressionID> bExpressions(b->inputExpressions.begin(), b->inputExpressions.end());
+  static int compareUnsortedIDs(const MatchPtr& a, const MatchPtr& b) {
+    return compareVectors(a->inputExpressions, b->inputExpressions);
+  }
+};
 
-            if (!reverseOrder) {
-                std::sort(aExpressions.begin(), aExpressions.end(), std::less<>());
-                std::sort(bExpressions.begin(), bExpressions.end(), std::less<>());
-            } else {
-                std::sort(aExpressions.begin(), aExpressions.end(), std::greater<>());
-                std::sort(bExpressions.begin(), bExpressions.end(), std::greater<>());
-            }
-            return compareVectors(aExpressions, bExpressions);
-        }
+// Hashes the values of the matches, not the pointer itself.
+class MatchHasher {
+ public:
+  size_t operator()(const MatchPtr& ptr) const {
+    std::size_t result = 0;
+    hash_combine(result, ptr->rule);
+    for (const auto expression : ptr->inputExpressions) {
+      hash_combine(result, expression);
+    }
+    return result;
+  }
 
-        static int compareUnsortedIDs(const MatchPtr& a, const MatchPtr& b) {
-            return compareVectors(a->inputExpressions, b->inputExpressions);
-        }
-    };
+ private:
+  // https://stackoverflow.com/a/2595226
+  template <class T>
+  static void hash_combine(std::size_t& seed, const T& value) {
+    std::hash<T> hasher;
+    seed ^= hasher(value) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+  }
+};
 
-    // Hashes the values of the matches, not the pointer itself.
-    class MatchHasher {
-     public:
-        size_t operator()(const MatchPtr& ptr) const {
-            std::size_t result = 0;
-            hash_combine(result, ptr->rule);
-            for (const auto expression : ptr->inputExpressions) {
-                hash_combine(result, expression);
-            }
-            return result;
-        }
-
-     private:
-        // https://stackoverflow.com/a/2595226
-        template<class T>
-        static void hash_combine(std::size_t& seed, const T& value) {
-            std::hash<T> hasher;
-            seed ^= hasher(value) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
-        }
-    };
-
-    class MatchEquality {
-     public:
-        size_t operator()(const MatchPtr& a, const MatchPtr& b) const {
-            if (a->rule != b->rule || a->inputExpressions.size() != b->inputExpressions.size()) {
-                return false;
-            }
-
-            const auto mismatchedIterators = std::mismatch(a->inputExpressions.begin(), a->inputExpressions.end(),
-                                                           b->inputExpressions.begin(), b->inputExpressions.end());
-            return mismatchedIterators.first == a->inputExpressions.end() &&
-                   mismatchedIterators.second == b->inputExpressions.end();
-        }
-    };
-
-    class Matcher::Implementation {
-     private:
-        const std::vector<Rule>& rules_;
-        AtomsIndex& atomsIndex_;
-        const std::function<AtomsVector(ExpressionID)> getAtomsVector_;
-
-        // Matches are arranged in buckets. Each bucket contains matches that are equivalent in terms of the ordering
-        // function, however, buckets themselves are ordered according to that function.
-        // To select next match, we select a random element from the first bucket.
-        // That in particular means the random ordering function will automatically be used if ordering
-        // specification is incomplete.
-
-        // We use MatchPtr instead of Match to save memory, however, they are hashed and sorted according to their
-        // dereferenced values in the corresponding classes above.
-
-        // We cannot directly select a random element from an unordered_map, which is why we use a vector here.
-        using Bucket = std::pair<std::unordered_map<MatchPtr, size_t, MatchHasher, MatchEquality>,
-                                 std::vector<MatchPtr>>;
-        std::map<MatchPtr, Bucket, MatchComparator> matchQueue_;
-        std::unordered_map<ExpressionID, std::unordered_set<MatchPtr, MatchHasher, MatchEquality>> expressionToMatches_;
-
-        // A frequent operation here is detection of duplicate matches. Hashing is much faster than searching for
-        // duplicates in a std::map, so we separately keep a flat hash table of all matches to speed that up.
-        // That's purely an optimization.
-        std::unordered_set<MatchPtr, MatchHasher, MatchEquality> allMatches_;
-
-        std::mt19937 randomGenerator_;
-        MatchPtr nextMatch_;
-
-     public:
-        Implementation(const std::vector<Rule>& rules,
-                       AtomsIndex& atomsIndex,
-                       std::function<AtomsVector(ExpressionID)> getAtomsVector,
-                       const OrderingSpec& orderingSpec,
-                       const unsigned int randomSeed) :
-            rules_(rules),
-            atomsIndex_(atomsIndex),
-            getAtomsVector_(std::move(getAtomsVector)),
-            matchQueue_(orderingSpec),
-            randomGenerator_(randomSeed) {}
-
-        void addMatchesInvolvingExpressions(const std::vector<ExpressionID>& expressionIDs,
-                                            const std::function<bool()>& shouldAbort) {
-            for (size_t i = 0; i < rules_.size(); ++i) {
-                addMatchesForRule(expressionIDs, static_cast<RuleID>(i), shouldAbort);
-            }
-            chooseNextMatch();
-        }
-
-        // Note, deletion changes the ordering of allMatchIterators_, therefore
-        // deletion should be done in deterministic order, otherwise, the random replacements will not be deterministic
-        void removeMatchesInvolvingExpressions(const std::vector<ExpressionID>& expressionIDs) {
-            // do not use unordered_set, as it make order undeterministic
-            // any ordering spec works here, as long as it's complete.
-            OrderingSpec fullOrderingSpec = {
-                {OrderingFunction::ExpressionIDs, OrderingDirection::Normal},
-                {OrderingFunction::RuleIndex, OrderingDirection::Normal}};
-            std::set<MatchPtr, MatchComparator> matchesToDelete(fullOrderingSpec);
-
-            for (const auto& expression : expressionIDs) {
-                const auto& matches = expressionToMatches_[expression];
-                matchesToDelete.insert(matches.begin(), matches.end());
-            }
-
-            for (const auto& match : matchesToDelete) {
-                deleteMatch(match);
-            }
-
-            chooseNextMatch();
-        }
-
-        bool empty() const {
-            return matchQueue_.empty();
-        }
-
-        MatchPtr nextMatch() const {
-            return nextMatch_;
-        }
-
-        std::vector<MatchPtr> allMatches() const {
-            std::vector<MatchPtr> result;
-            for (const auto& exampleAndBucket : matchQueue_) {
-                result.insert(result.end(), exampleAndBucket.second.second.begin(),
-                              exampleAndBucket.second.second.end());
-            }
-            return result;
-        }
-
-     private:
-        void addMatchesForRule(const std::vector<ExpressionID>& expressionIDs,
-                               const RuleID& ruleID,
-                               const std::function<bool()>& shouldAbort) {
-            const auto& ruleInputExpressions = rules_[ruleID].inputs;
-            for (size_t i = 0; i < ruleInputExpressions.size(); ++i) {
-                const Match emptyMatch{ruleID, std::vector<ExpressionID>(ruleInputExpressions.size(), -1)};
-                completeMatchesStartingWithInput(emptyMatch, ruleInputExpressions, i, expressionIDs, shouldAbort);
-            }
-        }
-
-        void completeMatchesStartingWithInput(const Match& incompleteMatch,
-                                              const std::vector<AtomsVector>& partiallyMatchedInputs,
-                                              const size_t nextInputIdx,
-                                              const std::vector<ExpressionID>& potentialExpressionIDs,
-                                              const std::function<bool()>& shouldAbort) {
-            for (const auto expressionID : potentialExpressionIDs) {
-                if (isExpressionUnused(incompleteMatch, expressionID)) {
-                    attemptMatchExpressionToInput(incompleteMatch,
-                                                  partiallyMatchedInputs,
-                                                  nextInputIdx,
-                                                  expressionID,
-                                                  shouldAbort);
-                }
-            }
-        }
-
-        static bool isExpressionUnused(const Match& match, const ExpressionID expressionID) {
-            return std::find(match.inputExpressions.begin(),
-                             match.inputExpressions.end(), expressionID) == match.inputExpressions.end();
-        }
-
-        void attemptMatchExpressionToInput(const Match& incompleteMatch,
-                                           const std::vector<AtomsVector>& partiallyMatchedInputs,
-                                           const size_t nextInputIdx,
-                                           const ExpressionID potentialExpressionID,
-                                           const std::function<bool()>& shouldAbort) {
-            // If WL wants to abort, abort
-            if (shouldAbort()) {
-                throw Error::Aborted;
-            }
-
-            const auto& input = partiallyMatchedInputs[nextInputIdx];
-            const auto& expressionAtoms = getAtomsVector_(potentialExpressionID);
-
-            // edges (expressions) of different sizes, cannot match
-            if (input.size() != expressionAtoms.size()) return;
-
-            Match newMatch = incompleteMatch;
-            newMatch.inputExpressions[nextInputIdx] = potentialExpressionID;
-
-            auto newInputs = partiallyMatchedInputs;
-            if (!Matcher::substituteMissingAtomsIfPossible({input}, {expressionAtoms}, newInputs)) return;
-
-            if (isMatchComplete(newMatch)) {
-                insertMatch(newMatch);
-                return;
-            }
-
-            const auto nextInputIdxAndCandidateExpressions = nextBestInputAndExpressionsToTry(newMatch, newInputs);
-            completeMatchesStartingWithInput(newMatch,
-                                             newInputs,
-                                             nextInputIdxAndCandidateExpressions.first,
-                                             nextInputIdxAndCandidateExpressions.second,
-                                             shouldAbort);
-        }
-
-        void insertMatch(const Match& newMatch) {
-            // careful, don't create different pointers to the same match!
-            const auto matchPtr = std::make_shared<Match>(newMatch);
-
-            if (!allMatches_.insert(matchPtr).second)
-                return;
-
-            auto bucketIt = matchQueue_.find(matchPtr); // works because comparison is smart
-            if (bucketIt == matchQueue_.end()) {
-                bucketIt = matchQueue_.insert({matchPtr, {{}, {}}}).first;
-            }
-            auto& bucket = bucketIt->second;
-            if (!bucket.first.count(matchPtr)) { // works because hashing is smart
-                bucket.second.push_back(matchPtr);
-                bucket.first[matchPtr] = bucket.second.size() - 1;
-
-                const auto& expressions = matchPtr->inputExpressions;
-                for (const auto expression : expressions) {
-                    expressionToMatches_[expression].insert(matchPtr);
-                }
-            }
-        }
-
-        void deleteMatch(const MatchPtr& matchPtr) {
-            allMatches_.erase(matchPtr);
-
-            const auto& expressions = matchPtr->inputExpressions;
-            for (const auto expression : expressions) {
-                expressionToMatches_[expression].erase(matchPtr);
-                if (expressionToMatches_[expression].empty()) expressionToMatches_.erase(expression);
-            }
-
-            auto& bucket = matchQueue_[matchPtr];
-            const auto bucketIndex = bucket.first.at(matchPtr);
-            // O(1) order-non-preserving deletion from a vector
-            std::swap(bucket.second[bucketIndex], bucket.second[bucket.second.size() - 1]);
-            bucket.first[bucket.second[bucketIndex]] = bucketIndex;
-            bucket.first.erase(bucket.second[bucket.second.size() - 1]);
-            bucket.second.pop_back();
-            if (bucket.first.empty()) matchQueue_.erase(matchPtr);
-        }
-
-        static bool isMatchComplete(const Match& match) {
-            return std::find_if(match.inputExpressions.begin(), match.inputExpressions.end(),
-                                [](const auto& ex) -> bool { return ex < 0; }) == match.inputExpressions.end();
-        }
-
-        std::pair<size_t, std::vector<ExpressionID>> nextBestInputAndExpressionsToTry(const Match& incompleteMatch,
-                                                                                      const std::vector<AtomsVector>& partiallyMatchedInputs) const {
-            int64_t nextInputIdx = -1;
-            std::vector<ExpressionID> nextExpressionsToTry;
-
-            // For each input, we will see how many expressions in the set contain atoms appearing in this input.
-            // The fewer there are, the less branching we will have to do.
-            for (size_t i = 0; i < partiallyMatchedInputs.size(); ++i) {
-                if (incompleteMatch.inputExpressions[i] != -1) continue;
-
-                std::unordered_set<Atom> appearingAtoms;
-                bool allAtomsArePatterns = true;
-                for (const auto atom : partiallyMatchedInputs[i]) {
-                    if (atom >= 0) {
-                        appearingAtoms.insert(atom);
-                        allAtomsArePatterns = false;
-                    }
-                }
-
-                // this input does not have any specific atom references,
-                // there is nothing we can do unless we want to enumerate the entire set
-                if (allAtomsArePatterns) continue;
-
-                // For each expression, we will count how many of the input atoms appear in it.
-                // We will then only use expressions that have all the required atoms.
-                std::unordered_map<ExpressionID, uint64_t> inputAtomsCountByExpression;
-                for (const auto atom : appearingAtoms) {
-                    for (const auto expression : atomsIndex_.expressionsContainingAtom(atom)) {
-                        inputAtomsCountByExpression[expression]++;
-                    }
-                }
-
-                // Here we will collect all expressions that contain all the required atoms.
-                std::vector<ExpressionID> potentialExpressions;
-                for (const auto& expressionAndCount : inputAtomsCountByExpression) {
-                    if (expressionAndCount.second == appearingAtoms.size()) {
-                        potentialExpressions.push_back(expressionAndCount.first);
-                    }
-                }
-
-                // If there are fewer expressions, that is what we'll want to try first.
-                // Note, if there are zero matching expressions, it means the match is not possible, because none of the expressions contain all the atoms needed.
-                if (nextInputIdx == -1 || potentialExpressions.size() < nextExpressionsToTry.size()) {
-                    nextExpressionsToTry = potentialExpressions;
-                    nextInputIdx = static_cast<int64_t>(i);
-                }
-            }
-
-            if (nextInputIdx == -1) {
-                // We could not find any potential inputs, which means, all inputs not already matched are fully patterns,
-                // and don't have any specific atom references.
-                // That implies rule inputs are not a connected graph, which is not supported at the moment,
-                // and would require custom logic to implement efficiently.
-                throw Error::DisconnectedInputs;
-            } else {
-                return {nextInputIdx, nextExpressionsToTry};
-            }
-        }
-
-        // This should be called every time matches are updated.
-        void chooseNextMatch() {
-            if (empty()) return;
-            const auto& allPossibleMatches = matchQueue_.begin()->second.second;
-            auto distribution = std::uniform_int_distribution<size_t>(0, allPossibleMatches.size() - 1);
-            nextMatch_ = allPossibleMatches[distribution(randomGenerator_)];
-        }
-    };
-
-    Matcher::Matcher(const std::vector<Rule>& rules,
-                     AtomsIndex& atomsIndex,
-                     const std::function<AtomsVector(ExpressionID)>& getAtomsVector,
-                     const OrderingSpec& orderingSpec,
-                     const unsigned int randomSeed)
-        : implementation_(std::make_shared<Implementation>(rules, atomsIndex, getAtomsVector, orderingSpec, randomSeed))
-        {}
-
-    void Matcher::addMatchesInvolvingExpressions(const std::vector<ExpressionID>& expressionIDs,
-                                                 const std::function<bool()>& shouldAbort) {
-        implementation_->addMatchesInvolvingExpressions(expressionIDs, shouldAbort);
+class MatchEquality {
+ public:
+  size_t operator()(const MatchPtr& a, const MatchPtr& b) const {
+    if (a->rule != b->rule || a->inputExpressions.size() != b->inputExpressions.size()) {
+      return false;
     }
 
-    void Matcher::removeMatchesInvolvingExpressions(const std::vector<ExpressionID>& expressionIDs) {
-        implementation_->removeMatchesInvolvingExpressions(expressionIDs);
+    const auto mismatchedIterators = std::mismatch(
+        a->inputExpressions.begin(), a->inputExpressions.end(), b->inputExpressions.begin(), b->inputExpressions.end());
+    return mismatchedIterators.first == a->inputExpressions.end() &&
+           mismatchedIterators.second == b->inputExpressions.end();
+  }
+};
+
+class Matcher::Implementation {
+ private:
+  const std::vector<Rule>& rules_;
+  AtomsIndex& atomsIndex_;
+  const std::function<AtomsVector(ExpressionID)> getAtomsVector_;
+
+  // Matches are arranged in buckets. Each bucket contains matches that are equivalent in terms of the ordering
+  // function, however, buckets themselves are ordered according to that function.
+  // To select next match, we select a random element from the first bucket.
+  // That in particular means the random ordering function will automatically be used if ordering
+  // specification is incomplete.
+
+  // We use MatchPtr instead of Match to save memory, however, they are hashed and sorted according to their
+  // dereferenced values in the corresponding classes above.
+
+  // We cannot directly select a random element from an unordered_map, which is why we use a vector here.
+  using Bucket = std::pair<std::unordered_map<MatchPtr, size_t, MatchHasher, MatchEquality>, std::vector<MatchPtr>>;
+  std::map<MatchPtr, Bucket, MatchComparator> matchQueue_;
+  std::unordered_map<ExpressionID, std::unordered_set<MatchPtr, MatchHasher, MatchEquality>> expressionToMatches_;
+
+  // A frequent operation here is detection of duplicate matches. Hashing is much faster than searching for
+  // duplicates in a std::map, so we separately keep a flat hash table of all matches to speed that up.
+  // That's purely an optimization.
+  std::unordered_set<MatchPtr, MatchHasher, MatchEquality> allMatches_;
+
+  std::mt19937 randomGenerator_;
+  MatchPtr nextMatch_;
+
+ public:
+  Implementation(const std::vector<Rule>& rules,
+                 AtomsIndex& atomsIndex,
+                 std::function<AtomsVector(ExpressionID)> getAtomsVector,
+                 const OrderingSpec& orderingSpec,
+                 const unsigned int randomSeed)
+      : rules_(rules),
+        atomsIndex_(atomsIndex),
+        getAtomsVector_(std::move(getAtomsVector)),
+        matchQueue_(orderingSpec),
+        randomGenerator_(randomSeed) {}
+
+  void addMatchesInvolvingExpressions(const std::vector<ExpressionID>& expressionIDs,
+                                      const std::function<bool()>& shouldAbort) {
+    for (size_t i = 0; i < rules_.size(); ++i) {
+      addMatchesForRule(expressionIDs, static_cast<RuleID>(i), shouldAbort);
+    }
+    chooseNextMatch();
+  }
+
+  // Note, deletion changes the ordering of allMatchIterators_, therefore
+  // deletion should be done in deterministic order, otherwise, the random replacements will not be deterministic
+  void removeMatchesInvolvingExpressions(const std::vector<ExpressionID>& expressionIDs) {
+    // do not use unordered_set, as it make order undeterministic
+    // any ordering spec works here, as long as it's complete.
+    OrderingSpec fullOrderingSpec = {{OrderingFunction::ExpressionIDs, OrderingDirection::Normal},
+                                     {OrderingFunction::RuleIndex, OrderingDirection::Normal}};
+    std::set<MatchPtr, MatchComparator> matchesToDelete(fullOrderingSpec);
+
+    for (const auto& expression : expressionIDs) {
+      const auto& matches = expressionToMatches_[expression];
+      matchesToDelete.insert(matches.begin(), matches.end());
     }
 
-    bool Matcher::empty() const {
-        return implementation_->empty();
+    for (const auto& match : matchesToDelete) {
+      deleteMatch(match);
     }
 
-    MatchPtr Matcher::nextMatch() const {
-        return implementation_->nextMatch();
+    chooseNextMatch();
+  }
+
+  bool empty() const { return matchQueue_.empty(); }
+
+  MatchPtr nextMatch() const { return nextMatch_; }
+
+  std::vector<MatchPtr> allMatches() const {
+    std::vector<MatchPtr> result;
+    for (const auto& exampleAndBucket : matchQueue_) {
+      result.insert(result.end(), exampleAndBucket.second.second.begin(), exampleAndBucket.second.second.end());
+    }
+    return result;
+  }
+
+ private:
+  void addMatchesForRule(const std::vector<ExpressionID>& expressionIDs,
+                         const RuleID& ruleID,
+                         const std::function<bool()>& shouldAbort) {
+    const auto& ruleInputExpressions = rules_[ruleID].inputs;
+    for (size_t i = 0; i < ruleInputExpressions.size(); ++i) {
+      const Match emptyMatch{ruleID, std::vector<ExpressionID>(ruleInputExpressions.size(), -1)};
+      completeMatchesStartingWithInput(emptyMatch, ruleInputExpressions, i, expressionIDs, shouldAbort);
+    }
+  }
+
+  void completeMatchesStartingWithInput(const Match& incompleteMatch,
+                                        const std::vector<AtomsVector>& partiallyMatchedInputs,
+                                        const size_t nextInputIdx,
+                                        const std::vector<ExpressionID>& potentialExpressionIDs,
+                                        const std::function<bool()>& shouldAbort) {
+    for (const auto expressionID : potentialExpressionIDs) {
+      if (isExpressionUnused(incompleteMatch, expressionID)) {
+        attemptMatchExpressionToInput(incompleteMatch, partiallyMatchedInputs, nextInputIdx, expressionID, shouldAbort);
+      }
+    }
+  }
+
+  static bool isExpressionUnused(const Match& match, const ExpressionID expressionID) {
+    return std::find(match.inputExpressions.begin(), match.inputExpressions.end(), expressionID) ==
+           match.inputExpressions.end();
+  }
+
+  void attemptMatchExpressionToInput(const Match& incompleteMatch,
+                                     const std::vector<AtomsVector>& partiallyMatchedInputs,
+                                     const size_t nextInputIdx,
+                                     const ExpressionID potentialExpressionID,
+                                     const std::function<bool()>& shouldAbort) {
+    // If WL wants to abort, abort
+    if (shouldAbort()) {
+      throw Error::Aborted;
     }
 
-    bool Matcher::substituteMissingAtomsIfPossible(const std::vector<AtomsVector>& inputPatterns,
-                                                   const std::vector<AtomsVector>& patternMatches,
-                                                   std::vector<AtomsVector>& atomsToReplace) {
-        if (inputPatterns.size() != patternMatches.size()) return false;
+    const auto& input = partiallyMatchedInputs[nextInputIdx];
+    const auto& expressionAtoms = getAtomsVector_(potentialExpressionID);
 
-        std::unordered_map<Atom, Atom> match;
-        for (size_t i = 0; i < inputPatterns.size(); ++i) {
-            const auto& pattern = inputPatterns[i];
-            const auto& patternMatch = patternMatches[i];
-            if (pattern.size() != patternMatch.size()) return false;
-            for (size_t j = 0; j < pattern.size(); ++j) {
-                const auto matchIterator = match.find(pattern[j]);
-                const Atom inputAtom = matchIterator != match.end() ? matchIterator->second : pattern[j];
-                if (inputAtom < 0) { // pattern
-                    match[inputAtom] = patternMatch[j];
-                } else if (inputAtom != patternMatch[j]) { // explicit atom ID
-                    return false;
-                }
-            }
+    // edges (expressions) of different sizes, cannot match
+    if (input.size() != expressionAtoms.size()) return;
+
+    Match newMatch = incompleteMatch;
+    newMatch.inputExpressions[nextInputIdx] = potentialExpressionID;
+
+    auto newInputs = partiallyMatchedInputs;
+    if (!Matcher::substituteMissingAtomsIfPossible({input}, {expressionAtoms}, newInputs)) return;
+
+    if (isMatchComplete(newMatch)) {
+      insertMatch(newMatch);
+      return;
+    }
+
+    const auto nextInputIdxAndCandidateExpressions = nextBestInputAndExpressionsToTry(newMatch, newInputs);
+    completeMatchesStartingWithInput(newMatch,
+                                     newInputs,
+                                     nextInputIdxAndCandidateExpressions.first,
+                                     nextInputIdxAndCandidateExpressions.second,
+                                     shouldAbort);
+  }
+
+  void insertMatch(const Match& newMatch) {
+    // careful, don't create different pointers to the same match!
+    const auto matchPtr = std::make_shared<Match>(newMatch);
+
+    if (!allMatches_.insert(matchPtr).second) return;
+
+    auto bucketIt = matchQueue_.find(matchPtr);  // works because comparison is smart
+    if (bucketIt == matchQueue_.end()) {
+      bucketIt = matchQueue_.insert({matchPtr, {{}, {}}}).first;
+    }
+    auto& bucket = bucketIt->second;
+    if (!bucket.first.count(matchPtr)) {  // works because hashing is smart
+      bucket.second.push_back(matchPtr);
+      bucket.first[matchPtr] = bucket.second.size() - 1;
+
+      const auto& expressions = matchPtr->inputExpressions;
+      for (const auto expression : expressions) {
+        expressionToMatches_[expression].insert(matchPtr);
+      }
+    }
+  }
+
+  void deleteMatch(const MatchPtr& matchPtr) {
+    allMatches_.erase(matchPtr);
+
+    const auto& expressions = matchPtr->inputExpressions;
+    for (const auto expression : expressions) {
+      expressionToMatches_[expression].erase(matchPtr);
+      if (expressionToMatches_[expression].empty()) expressionToMatches_.erase(expression);
+    }
+
+    auto& bucket = matchQueue_[matchPtr];
+    const auto bucketIndex = bucket.first.at(matchPtr);
+    // O(1) order-non-preserving deletion from a vector
+    std::swap(bucket.second[bucketIndex], bucket.second[bucket.second.size() - 1]);
+    bucket.first[bucket.second[bucketIndex]] = bucketIndex;
+    bucket.first.erase(bucket.second[bucket.second.size() - 1]);
+    bucket.second.pop_back();
+    if (bucket.first.empty()) matchQueue_.erase(matchPtr);
+  }
+
+  static bool isMatchComplete(const Match& match) {
+    return std::find_if(match.inputExpressions.begin(), match.inputExpressions.end(), [](const auto& ex) -> bool {
+             return ex < 0;
+           }) == match.inputExpressions.end();
+  }
+
+  std::pair<size_t, std::vector<ExpressionID>> nextBestInputAndExpressionsToTry(
+      const Match& incompleteMatch, const std::vector<AtomsVector>& partiallyMatchedInputs) const {
+    int64_t nextInputIdx = -1;
+    std::vector<ExpressionID> nextExpressionsToTry;
+
+    // For each input, we will see how many expressions in the set contain atoms appearing in this input.
+    // The fewer there are, the less branching we will have to do.
+    for (size_t i = 0; i < partiallyMatchedInputs.size(); ++i) {
+      if (incompleteMatch.inputExpressions[i] != -1) continue;
+
+      std::unordered_set<Atom> appearingAtoms;
+      bool allAtomsArePatterns = true;
+      for (const auto atom : partiallyMatchedInputs[i]) {
+        if (atom >= 0) {
+          appearingAtoms.insert(atom);
+          allAtomsArePatterns = false;
         }
+      }
 
-        for (auto& atomsVectorToReplace : atomsToReplace) {
-            for (auto& atomToReplace : atomsVectorToReplace) {
-                const auto matchIterator = match.find(atomToReplace);
-                if (matchIterator != match.end()) {
-                    atomToReplace = matchIterator->second;
-                }
-            }
+      // this input does not have any specific atom references,
+      // there is nothing we can do unless we want to enumerate the entire set
+      if (allAtomsArePatterns) continue;
+
+      // For each expression, we will count how many of the input atoms appear in it.
+      // We will then only use expressions that have all the required atoms.
+      std::unordered_map<ExpressionID, uint64_t> inputAtomsCountByExpression;
+      for (const auto atom : appearingAtoms) {
+        for (const auto expression : atomsIndex_.expressionsContainingAtom(atom)) {
+          inputAtomsCountByExpression[expression]++;
         }
-        return true;
+      }
+
+      // Here we will collect all expressions that contain all the required atoms.
+      std::vector<ExpressionID> potentialExpressions;
+      for (const auto& expressionAndCount : inputAtomsCountByExpression) {
+        if (expressionAndCount.second == appearingAtoms.size()) {
+          potentialExpressions.push_back(expressionAndCount.first);
+        }
+      }
+
+      // If there are fewer expressions, that is what we'll want to try first.
+      // Note, if there are zero matching expressions, it means the match is not possible, because none of the
+      // expressions contain all the atoms needed.
+      if (nextInputIdx == -1 || potentialExpressions.size() < nextExpressionsToTry.size()) {
+        nextExpressionsToTry = potentialExpressions;
+        nextInputIdx = static_cast<int64_t>(i);
+      }
     }
 
-    std::vector<MatchPtr> Matcher::allMatches() const {
-        return implementation_->allMatches();
+    if (nextInputIdx == -1) {
+      // We could not find any potential inputs, which means, all inputs not already matched are fully patterns,
+      // and don't have any specific atom references.
+      // That implies rule inputs are not a connected graph, which is not supported at the moment,
+      // and would require custom logic to implement efficiently.
+      throw Error::DisconnectedInputs;
+    } else {
+      return {nextInputIdx, nextExpressionsToTry};
     }
+  }
+
+  // This should be called every time matches are updated.
+  void chooseNextMatch() {
+    if (empty()) return;
+    const auto& allPossibleMatches = matchQueue_.begin()->second.second;
+    auto distribution = std::uniform_int_distribution<size_t>(0, allPossibleMatches.size() - 1);
+    nextMatch_ = allPossibleMatches[distribution(randomGenerator_)];
+  }
+};
+
+Matcher::Matcher(const std::vector<Rule>& rules,
+                 AtomsIndex& atomsIndex,
+                 const std::function<AtomsVector(ExpressionID)>& getAtomsVector,
+                 const OrderingSpec& orderingSpec,
+                 const unsigned int randomSeed)
+    : implementation_(std::make_shared<Implementation>(rules, atomsIndex, getAtomsVector, orderingSpec, randomSeed)) {}
+
+void Matcher::addMatchesInvolvingExpressions(const std::vector<ExpressionID>& expressionIDs,
+                                             const std::function<bool()>& shouldAbort) {
+  implementation_->addMatchesInvolvingExpressions(expressionIDs, shouldAbort);
 }
+
+void Matcher::removeMatchesInvolvingExpressions(const std::vector<ExpressionID>& expressionIDs) {
+  implementation_->removeMatchesInvolvingExpressions(expressionIDs);
+}
+
+bool Matcher::empty() const { return implementation_->empty(); }
+
+MatchPtr Matcher::nextMatch() const { return implementation_->nextMatch(); }
+
+bool Matcher::substituteMissingAtomsIfPossible(const std::vector<AtomsVector>& inputPatterns,
+                                               const std::vector<AtomsVector>& patternMatches,
+                                               std::vector<AtomsVector>& atomsToReplace) {
+  if (inputPatterns.size() != patternMatches.size()) return false;
+
+  std::unordered_map<Atom, Atom> match;
+  for (size_t i = 0; i < inputPatterns.size(); ++i) {
+    const auto& pattern = inputPatterns[i];
+    const auto& patternMatch = patternMatches[i];
+    if (pattern.size() != patternMatch.size()) return false;
+    for (size_t j = 0; j < pattern.size(); ++j) {
+      const auto matchIterator = match.find(pattern[j]);
+      const Atom inputAtom = matchIterator != match.end() ? matchIterator->second : pattern[j];
+      if (inputAtom < 0) {  // pattern
+        match[inputAtom] = patternMatch[j];
+      } else if (inputAtom != patternMatch[j]) {  // explicit atom ID
+        return false;
+      }
+    }
+  }
+
+  for (auto& atomsVectorToReplace : atomsToReplace) {
+    for (auto& atomToReplace : atomsVectorToReplace) {
+      const auto matchIterator = match.find(atomToReplace);
+      if (matchIterator != match.end()) {
+        atomToReplace = matchIterator->second;
+      }
+    }
+  }
+  return true;
+}
+
+std::vector<MatchPtr> Matcher::allMatches() const { return implementation_->allMatches(); }
+}  // namespace SetReplace

--- a/libSetReplace/Match.cpp
+++ b/libSetReplace/Match.cpp
@@ -424,7 +424,7 @@ namespace SetReplace {
         for (size_t i = 0; i < inputPatterns.size(); ++i) {
             const auto& pattern = inputPatterns[i];
             const auto& patternMatch = patternMatches[i];
-            if (pattern.size() != patternMatch.size()) return false;;
+            if (pattern.size() != patternMatch.size()) return false;
             for (size_t j = 0; j < pattern.size(); ++j) {
                 const auto matchIterator = match.find(pattern[j]);
                 const Atom inputAtom = matchIterator != match.end() ? matchIterator->second : pattern[j];

--- a/libSetReplace/Match.hpp
+++ b/libSetReplace/Match.hpp
@@ -1,97 +1,101 @@
 #ifndef Match_hpp
 #define Match_hpp
 
-#include <vector>
 #include <set>
+#include <vector>
 
-#include "IDTypes.hpp"
 #include "Expression.hpp"
+#include "IDTypes.hpp"
 #include "Rule.hpp"
 
 namespace SetReplace {
-    /** @brief Match is a potential event that has not actualized yet.
-     */
-    struct Match {
-        /** @brief ID for the rule this match corresponds to.
-         */
-        RuleID rule;
-        
-        /** @brief Expression matching the rule inputs.
-         */
-        std::vector<ExpressionID> inputExpressions;
-    };
+/** @brief Match is a potential event that has not actualized yet.
+ */
+struct Match {
+  /** @brief ID for the rule this match corresponds to.
+   */
+  RuleID rule;
 
-    using MatchPtr = std::shared_ptr<const Match>;
-    
-    /** @brief Matcher takes rules, atoms index, and a list of expressions, and returns all possible matches.
-     * @details This contains the lowest-level code, and the main functionality of the library. Uses atomsIndex to discover expressions, thus if an expression is absent from the atomsIndex, it would not appear in any matches.
-     */
-    class Matcher {
-    public:
-        /** @brief Type of the error occurred during evaluation.
-         */
-        enum Error {Aborted, DisconnectedInputs, NoMatches, InvalidOrderingFunction, InvalidOrderingDirection};
-        
-        /** @brief All possible functions available to sort matches. Random is the default that is always applied last.
-         */
-        enum class OrderingFunction {
-            SortedExpressionIDs = 0,
-            ReverseSortedExpressionIDs = 1,
-            ExpressionIDs = 2,
-            RuleIndex = 3};
-        
-        /** @brief Whether to sort in normal or reverse order.
-         */
-        enum class OrderingDirection {Normal = 0, Reverse = 1};
-        
-        /** @brief Full specification for the sequence of ordering functions.
-         */
-        using OrderingSpec = std::vector<std::pair<OrderingFunction, OrderingDirection>>;
-                
-        /** @brief Creates a new matcher object.
-         * @details This is an O(1) operation, does not do any matching yet.
-         */
-        Matcher(const std::vector<Rule>& rules,
-                AtomsIndex& atomsIndex,
-                const std::function<AtomsVector(ExpressionID)>& getAtomsVector,
-                const OrderingSpec& orderingSpec,
-                unsigned int randomSeed = 0);
+  /** @brief Expression matching the rule inputs.
+   */
+  std::vector<ExpressionID> inputExpressions;
+};
 
-        /** @brief Finds and adds to the index all matches involving specified expressions.
-         * @details Calls shouldAbort() frequently, and throws Error::Aborted if that returns true. Otherwise might take significant time to evaluate depending on the system.
-         */
-        void addMatchesInvolvingExpressions(const std::vector<ExpressionID>& expressionIDs,
-                                            const std::function<bool()>& shouldAbort);
+using MatchPtr = std::shared_ptr<const Match>;
 
-        /** @brief Removes matches containing specified expression IDs from the index.
-         */
-        void removeMatchesInvolvingExpressions(const std::vector<ExpressionID>& expressionIDs);
-        
-        /** @brief Yields true if there are no matches left.
-         */
-        bool empty() const;
-        
-        /** @brief Returns the match that should be substituted next.
-         * @details Throws Error::NoMatches if there are no matches.
-         */
-        MatchPtr nextMatch() const;
-        
-        /** @brief Replaces patterns in atomsToReplace with explicit atoms.
-         * @param inputPatterns patterns corresponding to patternMatches.
-         * @param patternMatches explicit atoms corresponding to patterns in inputPatterns.
-         * @param atomsToReplace patterns, which would be replaced the same way as inputPatterns are matched to patternMatches.
-         */
-        static bool substituteMissingAtomsIfPossible(const std::vector<AtomsVector>& inputPatterns,
-                                                     const std::vector<AtomsVector>& patternMatches,
-                                                     std::vector<AtomsVector>& atomsToReplace);
-        
-        /** @brief Returns the set of expression IDs matched in any match. */
-        std::vector<MatchPtr> allMatches() const;
+/** @brief Matcher takes rules, atoms index, and a list of expressions, and returns all possible matches.
+ * @details This contains the lowest-level code, and the main functionality of the library. Uses atomsIndex to discover
+ * expressions, thus if an expression is absent from the atomsIndex, it would not appear in any matches.
+ */
+class Matcher {
+ public:
+  /** @brief Type of the error occurred during evaluation.
+   */
+  enum Error { Aborted, DisconnectedInputs, NoMatches, InvalidOrderingFunction, InvalidOrderingDirection };
 
-     private:
-        class Implementation;
-        std::shared_ptr<Implementation> implementation_;
-    };
-}
+  /** @brief All possible functions available to sort matches. Random is the default that is always applied last.
+   */
+  enum class OrderingFunction {
+    SortedExpressionIDs = 0,
+    ReverseSortedExpressionIDs = 1,
+    ExpressionIDs = 2,
+    RuleIndex = 3
+  };
+
+  /** @brief Whether to sort in normal or reverse order.
+   */
+  enum class OrderingDirection { Normal = 0, Reverse = 1 };
+
+  /** @brief Full specification for the sequence of ordering functions.
+   */
+  using OrderingSpec = std::vector<std::pair<OrderingFunction, OrderingDirection>>;
+
+  /** @brief Creates a new matcher object.
+   * @details This is an O(1) operation, does not do any matching yet.
+   */
+  Matcher(const std::vector<Rule>& rules,
+          AtomsIndex& atomsIndex,
+          const std::function<AtomsVector(ExpressionID)>& getAtomsVector,
+          const OrderingSpec& orderingSpec,
+          unsigned int randomSeed = 0);
+
+  /** @brief Finds and adds to the index all matches involving specified expressions.
+   * @details Calls shouldAbort() frequently, and throws Error::Aborted if that returns true. Otherwise might take
+   * significant time to evaluate depending on the system.
+   */
+  void addMatchesInvolvingExpressions(const std::vector<ExpressionID>& expressionIDs,
+                                      const std::function<bool()>& shouldAbort);
+
+  /** @brief Removes matches containing specified expression IDs from the index.
+   */
+  void removeMatchesInvolvingExpressions(const std::vector<ExpressionID>& expressionIDs);
+
+  /** @brief Yields true if there are no matches left.
+   */
+  bool empty() const;
+
+  /** @brief Returns the match that should be substituted next.
+   * @details Throws Error::NoMatches if there are no matches.
+   */
+  MatchPtr nextMatch() const;
+
+  /** @brief Replaces patterns in atomsToReplace with explicit atoms.
+   * @param inputPatterns patterns corresponding to patternMatches.
+   * @param patternMatches explicit atoms corresponding to patterns in inputPatterns.
+   * @param atomsToReplace patterns, which would be replaced the same way as inputPatterns are matched to
+   * patternMatches.
+   */
+  static bool substituteMissingAtomsIfPossible(const std::vector<AtomsVector>& inputPatterns,
+                                               const std::vector<AtomsVector>& patternMatches,
+                                               std::vector<AtomsVector>& atomsToReplace);
+
+  /** @brief Returns the set of expression IDs matched in any match. */
+  std::vector<MatchPtr> allMatches() const;
+
+ private:
+  class Implementation;
+  std::shared_ptr<Implementation> implementation_;
+};
+}  // namespace SetReplace
 
 #endif /* Match_hpp */

--- a/libSetReplace/Match.hpp
+++ b/libSetReplace/Match.hpp
@@ -1,7 +1,9 @@
-#ifndef Match_hpp
-#define Match_hpp
+#ifndef LIBSETREPLACE_MATCH_HPP_
+#define LIBSETREPLACE_MATCH_HPP_
 
+#include <memory>
 #include <set>
+#include <utility>
 #include <vector>
 
 #include "Expression.hpp"
@@ -54,7 +56,7 @@ class Matcher {
    * @details This is an O(1) operation, does not do any matching yet.
    */
   Matcher(const std::vector<Rule>& rules,
-          AtomsIndex& atomsIndex,
+          AtomsIndex* atomsIndex,
           const std::function<AtomsVector(ExpressionID)>& getAtomsVector,
           const OrderingSpec& orderingSpec,
           unsigned int randomSeed = 0);
@@ -87,7 +89,7 @@ class Matcher {
    */
   static bool substituteMissingAtomsIfPossible(const std::vector<AtomsVector>& inputPatterns,
                                                const std::vector<AtomsVector>& patternMatches,
-                                               std::vector<AtomsVector>& atomsToReplace);
+                                               std::vector<AtomsVector>* atomsToReplace);
 
   /** @brief Returns the set of expression IDs matched in any match. */
   std::vector<MatchPtr> allMatches() const;
@@ -98,4 +100,4 @@ class Matcher {
 };
 }  // namespace SetReplace
 
-#endif /* Match_hpp */
+#endif  // LIBSETREPLACE_MATCH_HPP_

--- a/libSetReplace/Rule.hpp
+++ b/libSetReplace/Rule.hpp
@@ -6,12 +6,12 @@
 #include "Expression.hpp"
 
 namespace SetReplace {
-    /** @brief Substitution rule used in the evolution.
-     */
-    struct Rule {
-        const std::vector<AtomsVector> inputs;
-        const std::vector<AtomsVector> outputs;
-    };
-}
+/** @brief Substitution rule used in the evolution.
+ */
+struct Rule {
+  const std::vector<AtomsVector> inputs;
+  const std::vector<AtomsVector> outputs;
+};
+}  // namespace SetReplace
 
 #endif /* Rule_hpp */

--- a/libSetReplace/Rule.hpp
+++ b/libSetReplace/Rule.hpp
@@ -1,5 +1,5 @@
-#ifndef Rule_hpp
-#define Rule_hpp
+#ifndef LIBSETREPLACE_RULE_HPP_
+#define LIBSETREPLACE_RULE_HPP_
 
 #include <vector>
 
@@ -14,4 +14,4 @@ struct Rule {
 };
 }  // namespace SetReplace
 
-#endif /* Rule_hpp */
+#endif  // LIBSETREPLACE_RULE_HPP_

--- a/libSetReplace/Set.cpp
+++ b/libSetReplace/Set.cpp
@@ -8,366 +8,351 @@
 #include <utility>
 
 namespace SetReplace {
-    class Set::Implementation {
-    private:
-        // Rules fundamentally cannot be changed during evaluation, don't try to remove const.
-        // If rules do need to be changed, create another instance of Set and copy the expressions over.
-        const std::vector<Rule> rules_;
-        
-        // Determines the limiting conditions for the evaluation.
-        StepSpecification stepSpec_;
-        TerminationReason terminationReason_ = TerminationReason::NotTerminated;
-        
-        std::unordered_map<ExpressionID, SetExpression> expressions_;
-        std::vector<RuleID> eventRuleIDs_ = {-1};
-        
-        Atom nextAtom_ = 1;
-        ExpressionID nextExpressionID_ = 0;
-        
-        int64_t destroyedExpressionsCount_ = 0;
-        
-        // In another words, expressions counts by atom.
-        // Note, we cannot use atomsIndex_, because it does not keep last generation expressions.
-        std::unordered_map<Atom, int64_t> atomDegrees_;
-        
-        // Largest generation produced so far.
-        // Note, this is not the same as max of generations of all expressions,
-        // because there might exist an event that deletes expressions, but does not create any new ones.
-        Generation largestGeneration_ = 0;
-        
-        AtomsIndex atomsIndex_;
-        
-        Matcher matcher_;
-        
-        std::vector<ExpressionID> unindexedExpressions_;
-        
-    public:
-        Implementation(const std::vector<Rule>& rules,
-                       const std::vector<AtomsVector>& initialExpressions,
-                       const Matcher::OrderingSpec& orderingSpec,
-                       const unsigned int randomSeed) :
-            Implementation(rules, initialExpressions, orderingSpec, randomSeed, [this](const int64_t expressionID) {
-                return expressions_.at(expressionID).atoms;
-            }) {}
-        
-        int64_t replaceOnce(const std::function<bool()> shouldAbort) {
-            terminationReason_ = TerminationReason::NotTerminated;
+class Set::Implementation {
+ private:
+  // Rules fundamentally cannot be changed during evaluation, don't try to remove const.
+  // If rules do need to be changed, create another instance of Set and copy the expressions over.
+  const std::vector<Rule> rules_;
 
-            if (eventRuleIDs_.size() > static_cast<size_t>(stepSpec_.maxEvents)) {
-                terminationReason_ = TerminationReason::MaxEvents;
-                return 0;
-            }
-            
-            indexNewExpressions([this, &shouldAbort](){
-                const bool isAborted = shouldAbort();
-                if (isAborted) terminationReason_ = TerminationReason::Aborted;
-                return isAborted;
-            });
-            if (matcher_.empty()) {
-                if (largestGeneration_ == stepSpec_.maxGenerationsLocal) {
-                    terminationReason_ = TerminationReason::MaxGenerationsLocal;
-                } else {
-                    terminationReason_ = TerminationReason::FixedPoint;
-                }
-                return 0;
-            }
-            const MatchPtr match = matcher_.nextMatch();
-            
-            const auto& ruleInputs = rules_[match->rule].inputs;
-            std::vector<AtomsVector> inputExpressions;
-            inputExpressions.reserve(match->inputExpressions.size());
-            for (const auto& expressionID : match->inputExpressions) {
-                inputExpressions.emplace_back(expressions_.at(expressionID).atoms);
-            }
-            
-            auto explicitRuleInputs = ruleInputs;
-            Matcher::substituteMissingAtomsIfPossible(ruleInputs, inputExpressions, explicitRuleInputs);
-            
-            // Identify output atoms that appear in the input, that still leaves newly created atoms as patterns.
-            auto explicitRuleOutputs = rules_[match->rule].outputs;
-            Matcher::substituteMissingAtomsIfPossible(ruleInputs, inputExpressions, explicitRuleOutputs);
-            
-            for (const auto function : {&Implementation::willExceedAtomLimits,
-                                        &Implementation::willExceedExpressionsLimit}) {
-                const auto willExceedAtomLimitsStatus = (this->*function)(explicitRuleInputs, explicitRuleOutputs);
-                if (willExceedAtomLimitsStatus != TerminationReason::NotTerminated) {
-                    terminationReason_ = willExceedAtomLimitsStatus;
-                    return 0;
-                }
-            }
-            
-            // At this point, we are committed to modifying the set.
-            
-            // Name newly created atoms as well, now all atoms in the output are explicitly named.
-            const auto namedRuleOutputs = nameAnonymousAtoms(explicitRuleOutputs);
-            
-            matcher_.removeMatchesInvolvingExpressions(match->inputExpressions);
-            atomsIndex_.removeExpressions(match->inputExpressions);
-            
-            Generation outputGeneration = 0;
-            for (const auto& inputExpression : match->inputExpressions) {
-                outputGeneration = std::max(outputGeneration, expressions_[inputExpression].generation + 1);
-            }
-            largestGeneration_ = std::max(largestGeneration_, outputGeneration);
-            
-            const EventID eventID = static_cast<EventID>(eventRuleIDs_.size());
-            addExpressions(namedRuleOutputs, eventID, outputGeneration);
-            assignDestroyerEvent(match->inputExpressions, eventID);
-            eventRuleIDs_.push_back(match->rule);
-            
-            return 1;
-        }
-        
-        int64_t replace(const StepSpecification stepSpec, const std::function<bool()>& shouldAbort) {
-            updateStepSpec(stepSpec);
-            int64_t count = 0;
-            while (true) {
-                if (replaceOnce(shouldAbort)) {
-                    ++count;
-                } else {
-                    return count;
-                }
-            }
-        }
-        
-        std::vector<SetExpression> expressions() const {
-            std::vector<std::pair<ExpressionID, SetExpression>> idsAndExpressions(expressions_.begin(),
-                                                                                  expressions_.end());
-            std::sort(idsAndExpressions.begin(), idsAndExpressions.end(), [](const auto& a, const auto& b) {
-                return a.first < b.first;
-            });
-            std::vector<SetExpression> result;
-            result.reserve(idsAndExpressions.size());
-            for (const auto& idAndExpression : idsAndExpressions) {
-                result.emplace_back(idAndExpression.second);
-            }
-            return result;
-        }
-        
-        Generation maxCompleteGeneration(const std::function<bool()>& shouldAbort) {
-            indexNewExpressions(shouldAbort);
-            return std::min(smallestGeneration(matcher_.allMatches()), largestGeneration_);
-        }
-        
-        TerminationReason terminationReason() const {
-            return terminationReason_;
-        }
-        
-        const std::vector<RuleID>& eventRuleIDs() const {
-            return eventRuleIDs_;
-        }
+  // Determines the limiting conditions for the evaluation.
+  StepSpecification stepSpec_;
+  TerminationReason terminationReason_ = TerminationReason::NotTerminated;
 
-    private:
-        Implementation(std::vector<Rule>  rules,
-                       const std::vector<AtomsVector>& initialExpressions,
-                       const Matcher::OrderingSpec& orderingSpec,
-                       const unsigned int randomSeed,
-                       const std::function<AtomsVector(ExpressionID)>& getAtomsVector) :
-        rules_(std::move(rules)),
+  std::unordered_map<ExpressionID, SetExpression> expressions_;
+  std::vector<RuleID> eventRuleIDs_ = {-1};
+
+  Atom nextAtom_ = 1;
+  ExpressionID nextExpressionID_ = 0;
+
+  int64_t destroyedExpressionsCount_ = 0;
+
+  // In another words, expressions counts by atom.
+  // Note, we cannot use atomsIndex_, because it does not keep last generation expressions.
+  std::unordered_map<Atom, int64_t> atomDegrees_;
+
+  // Largest generation produced so far.
+  // Note, this is not the same as max of generations of all expressions,
+  // because there might exist an event that deletes expressions, but does not create any new ones.
+  Generation largestGeneration_ = 0;
+
+  AtomsIndex atomsIndex_;
+
+  Matcher matcher_;
+
+  std::vector<ExpressionID> unindexedExpressions_;
+
+ public:
+  Implementation(const std::vector<Rule>& rules,
+                 const std::vector<AtomsVector>& initialExpressions,
+                 const Matcher::OrderingSpec& orderingSpec,
+                 const unsigned int randomSeed)
+      : Implementation(rules, initialExpressions, orderingSpec, randomSeed, [this](const int64_t expressionID) {
+          return expressions_.at(expressionID).atoms;
+        }) {}
+
+  int64_t replaceOnce(const std::function<bool()> shouldAbort) {
+    terminationReason_ = TerminationReason::NotTerminated;
+
+    if (eventRuleIDs_.size() > static_cast<size_t>(stepSpec_.maxEvents)) {
+      terminationReason_ = TerminationReason::MaxEvents;
+      return 0;
+    }
+
+    indexNewExpressions([this, &shouldAbort]() {
+      const bool isAborted = shouldAbort();
+      if (isAborted) terminationReason_ = TerminationReason::Aborted;
+      return isAborted;
+    });
+    if (matcher_.empty()) {
+      if (largestGeneration_ == stepSpec_.maxGenerationsLocal) {
+        terminationReason_ = TerminationReason::MaxGenerationsLocal;
+      } else {
+        terminationReason_ = TerminationReason::FixedPoint;
+      }
+      return 0;
+    }
+    const MatchPtr match = matcher_.nextMatch();
+
+    const auto& ruleInputs = rules_[match->rule].inputs;
+    std::vector<AtomsVector> inputExpressions;
+    inputExpressions.reserve(match->inputExpressions.size());
+    for (const auto& expressionID : match->inputExpressions) {
+      inputExpressions.emplace_back(expressions_.at(expressionID).atoms);
+    }
+
+    auto explicitRuleInputs = ruleInputs;
+    Matcher::substituteMissingAtomsIfPossible(ruleInputs, inputExpressions, explicitRuleInputs);
+
+    // Identify output atoms that appear in the input, that still leaves newly created atoms as patterns.
+    auto explicitRuleOutputs = rules_[match->rule].outputs;
+    Matcher::substituteMissingAtomsIfPossible(ruleInputs, inputExpressions, explicitRuleOutputs);
+
+    for (const auto function : {&Implementation::willExceedAtomLimits, &Implementation::willExceedExpressionsLimit}) {
+      const auto willExceedAtomLimitsStatus = (this->*function)(explicitRuleInputs, explicitRuleOutputs);
+      if (willExceedAtomLimitsStatus != TerminationReason::NotTerminated) {
+        terminationReason_ = willExceedAtomLimitsStatus;
+        return 0;
+      }
+    }
+
+    // At this point, we are committed to modifying the set.
+
+    // Name newly created atoms as well, now all atoms in the output are explicitly named.
+    const auto namedRuleOutputs = nameAnonymousAtoms(explicitRuleOutputs);
+
+    matcher_.removeMatchesInvolvingExpressions(match->inputExpressions);
+    atomsIndex_.removeExpressions(match->inputExpressions);
+
+    Generation outputGeneration = 0;
+    for (const auto& inputExpression : match->inputExpressions) {
+      outputGeneration = std::max(outputGeneration, expressions_[inputExpression].generation + 1);
+    }
+    largestGeneration_ = std::max(largestGeneration_, outputGeneration);
+
+    const EventID eventID = static_cast<EventID>(eventRuleIDs_.size());
+    addExpressions(namedRuleOutputs, eventID, outputGeneration);
+    assignDestroyerEvent(match->inputExpressions, eventID);
+    eventRuleIDs_.push_back(match->rule);
+
+    return 1;
+  }
+
+  int64_t replace(const StepSpecification stepSpec, const std::function<bool()>& shouldAbort) {
+    updateStepSpec(stepSpec);
+    int64_t count = 0;
+    while (true) {
+      if (replaceOnce(shouldAbort)) {
+        ++count;
+      } else {
+        return count;
+      }
+    }
+  }
+
+  std::vector<SetExpression> expressions() const {
+    std::vector<std::pair<ExpressionID, SetExpression>> idsAndExpressions(expressions_.begin(), expressions_.end());
+    std::sort(idsAndExpressions.begin(), idsAndExpressions.end(), [](const auto& a, const auto& b) {
+      return a.first < b.first;
+    });
+    std::vector<SetExpression> result;
+    result.reserve(idsAndExpressions.size());
+    for (const auto& idAndExpression : idsAndExpressions) {
+      result.emplace_back(idAndExpression.second);
+    }
+    return result;
+  }
+
+  Generation maxCompleteGeneration(const std::function<bool()>& shouldAbort) {
+    indexNewExpressions(shouldAbort);
+    return std::min(smallestGeneration(matcher_.allMatches()), largestGeneration_);
+  }
+
+  TerminationReason terminationReason() const { return terminationReason_; }
+
+  const std::vector<RuleID>& eventRuleIDs() const { return eventRuleIDs_; }
+
+ private:
+  Implementation(std::vector<Rule> rules,
+                 const std::vector<AtomsVector>& initialExpressions,
+                 const Matcher::OrderingSpec& orderingSpec,
+                 const unsigned int randomSeed,
+                 const std::function<AtomsVector(ExpressionID)>& getAtomsVector)
+      : rules_(std::move(rules)),
         atomsIndex_(getAtomsVector),
         matcher_(rules_, atomsIndex_, getAtomsVector, orderingSpec, randomSeed) {
-            for (const auto& expression : initialExpressions) {
-                for (const auto& atom : expression) {
-                    if (atom <= 0) throw Error::NonPositiveAtoms;
-                    nextAtom_ = std::max(nextAtom_ - 1, atom);
-                    incrementNextAtom();
-                }
-            }
-            addExpressions(initialExpressions, initialConditionEvent, initialGeneration);
-        }
+    for (const auto& expression : initialExpressions) {
+      for (const auto& atom : expression) {
+        if (atom <= 0) throw Error::NonPositiveAtoms;
+        nextAtom_ = std::max(nextAtom_ - 1, atom);
+        incrementNextAtom();
+      }
+    }
+    addExpressions(initialExpressions, initialConditionEvent, initialGeneration);
+  }
 
-        Atom incrementNextAtom() {
-            if (nextAtom_ == std::numeric_limits<Atom>::max()) {
-                throw Error::AtomCountOverflow;
-            }
-            return ++nextAtom_;
+  Atom incrementNextAtom() {
+    if (nextAtom_ == std::numeric_limits<Atom>::max()) {
+      throw Error::AtomCountOverflow;
+    }
+    return ++nextAtom_;
+  }
+
+  void updateStepSpec(const StepSpecification newStepSpec) {
+    const auto previousMaxGeneration = stepSpec_.maxGenerationsLocal;
+    stepSpec_ = newStepSpec;
+    if (newStepSpec.maxGenerationsLocal > previousMaxGeneration) {
+      for (const auto& idAndExpression : expressions_) {
+        if (idAndExpression.second.generation == previousMaxGeneration) {
+          unindexedExpressions_.push_back(idAndExpression.first);
         }
-        
-        void updateStepSpec(const StepSpecification newStepSpec) {
-            const auto previousMaxGeneration = stepSpec_.maxGenerationsLocal;
-            stepSpec_ = newStepSpec;
-            if (newStepSpec.maxGenerationsLocal > previousMaxGeneration) {
-                for (const auto& idAndExpression : expressions_) {
-                    if (idAndExpression.second.generation == previousMaxGeneration) {
-                        unindexedExpressions_.push_back(idAndExpression.first);
-                    }
-                }
-            }
+      }
+    }
+  }
+
+  void indexNewExpressions(const std::function<bool()>& shouldAbort) {
+    // Atoms index must be updated first, because the matcher uses it to discover expressions.
+    atomsIndex_.addExpressions(unindexedExpressions_);
+    matcher_.addMatchesInvolvingExpressions(unindexedExpressions_, shouldAbort);
+    unindexedExpressions_.clear();
+  }
+
+  TerminationReason willExceedAtomLimits(const std::vector<AtomsVector>& explicitRuleInputs,
+                                         const std::vector<AtomsVector>& explicitRuleOutputs) const {
+    const int64_t currentAtomsCount = static_cast<int64_t>(atomDegrees_.size());
+
+    std::unordered_map<Atom, int64_t> atomDegreeDeltas;
+    updateAtomDegrees(atomDegreeDeltas, explicitRuleInputs, -1, false);
+    updateAtomDegrees(atomDegreeDeltas, explicitRuleOutputs, +1, false);
+
+    int64_t newAtomsCount = currentAtomsCount;
+    for (const auto& atomAndDegreeDelta : atomDegreeDeltas) {
+      const Atom atom = atomAndDegreeDelta.first;
+      const int64_t degreeDelta = atomAndDegreeDelta.second;
+      const int64_t currentDegree = static_cast<int64_t>(atomDegrees_.count(atom)) ? atomDegrees_.at(atom) : 0;
+      if (currentDegree == 0 && degreeDelta > 0) {
+        ++newAtomsCount;
+      } else if (currentDegree > 0 && currentDegree + degreeDelta == 0) {
+        --newAtomsCount;
+      }
+
+      // Check atom degree.
+      if (currentDegree + degreeDelta > stepSpec_.maxFinalAtomDegree) {
+        return TerminationReason::MaxFinalAtomDegree;
+      }
+    }
+
+    if (newAtomsCount > stepSpec_.maxFinalAtoms) {
+      return TerminationReason::MaxFinalAtoms;
+    } else {
+      return TerminationReason::NotTerminated;
+    }
+  }
+
+  static void updateAtomDegrees(std::unordered_map<Atom, int64_t>& atomDegrees,
+                                const std::vector<AtomsVector>& deltaExpressions,
+                                const int64_t deltaCount,
+                                bool deleteIfZero = true) {
+    for (const auto& expression : deltaExpressions) {
+      const std::unordered_set<Atom> expressionAtoms(expression.begin(), expression.end());
+      for (const auto& atom : expressionAtoms) {
+        atomDegrees[atom] += deltaCount;
+        if (deleteIfZero && atomDegrees[atom] == 0) {
+          atomDegrees.erase(atom);
         }
-        
-        void indexNewExpressions(const std::function<bool()>& shouldAbort) {
-            // Atoms index must be updated first, because the matcher uses it to discover expressions.
-            atomsIndex_.addExpressions(unindexedExpressions_);
-            matcher_.addMatchesInvolvingExpressions(unindexedExpressions_, shouldAbort);
-            unindexedExpressions_.clear();
-        }
-        
-        TerminationReason willExceedAtomLimits(const std::vector<AtomsVector>& explicitRuleInputs,
+      }
+    }
+  }
+
+  TerminationReason willExceedExpressionsLimit(const std::vector<AtomsVector>& explicitRuleInputs,
                                                const std::vector<AtomsVector>& explicitRuleOutputs) const {
-            const int64_t currentAtomsCount = static_cast<int64_t>(atomDegrees_.size());
-            
-            std::unordered_map<Atom, int64_t> atomDegreeDeltas;
-            updateAtomDegrees(atomDegreeDeltas, explicitRuleInputs, -1, false);
-            updateAtomDegrees(atomDegreeDeltas, explicitRuleOutputs, +1, false);
-            
-            int64_t newAtomsCount = currentAtomsCount;
-            for (const auto& atomAndDegreeDelta : atomDegreeDeltas) {
-                const Atom atom = atomAndDegreeDelta.first;
-                const int64_t degreeDelta = atomAndDegreeDelta.second;
-                const int64_t currentDegree = static_cast<int64_t>(atomDegrees_.count(atom)) ? atomDegrees_.at(atom) : 0;
-                if (currentDegree == 0 && degreeDelta > 0) {
-                    ++newAtomsCount;
-                }
-                else if (currentDegree > 0 && currentDegree + degreeDelta == 0) {
-                    --newAtomsCount;
-                }
-                
-                // Check atom degree.
-                if (currentDegree + degreeDelta > stepSpec_.maxFinalAtomDegree) {
-                    return TerminationReason::MaxFinalAtomDegree;
-                }
-            }
-            
-            if (newAtomsCount > stepSpec_.maxFinalAtoms) {
-                return TerminationReason::MaxFinalAtoms;
-            } else {
-                return TerminationReason::NotTerminated;
-            }
-        }
-        
-        static void updateAtomDegrees(std::unordered_map<Atom, int64_t>& atomDegrees,
-                                      const std::vector<AtomsVector>& deltaExpressions,
-                                      const int64_t deltaCount,
-                                      bool deleteIfZero = true) {
-            for (const auto& expression : deltaExpressions) {
-                const std::unordered_set<Atom> expressionAtoms(expression.begin(), expression.end());
-                for (const auto& atom : expressionAtoms) {
-                    atomDegrees[atom] += deltaCount;
-                    if (deleteIfZero && atomDegrees[atom] == 0) {
-                        atomDegrees.erase(atom);
-                    }
-                }
-            }
-        }
-        
-        TerminationReason willExceedExpressionsLimit(const std::vector<AtomsVector>& explicitRuleInputs,
-                                                     const std::vector<AtomsVector>& explicitRuleOutputs) const {
-            const int64_t currentExpressionsCount = nextExpressionID_ - destroyedExpressionsCount_;
-            const int64_t newExpressionsCount = currentExpressionsCount
-                                                - static_cast<int64_t>(explicitRuleInputs.size())
-                                                + static_cast<int64_t>(explicitRuleOutputs.size());
-            if (newExpressionsCount > stepSpec_.maxFinalExpressions) {
-                return TerminationReason::MaxFinalExpressions;
-            } else {
-                return TerminationReason::NotTerminated;
-            }
-        }
-        
-        std::vector<AtomsVector> nameAnonymousAtoms(const std::vector<AtomsVector>& atomVectors) {
-            std::unordered_map<Atom, Atom> names;
-            std::vector<AtomsVector> result = atomVectors;
-            for (auto& expression : result) {
-                for (auto& atom : expression) {
-                    if (atom < 0 && names.count(atom) == 0) {
-                        names[atom] = incrementNextAtom();
-                    }
-                    if (atom < 0) {
-                        atom = names[atom];
-                    }
-                }
-            }
-            
-            return result;
-        }
-        
-        std::vector<ExpressionID> addExpressions(const std::vector<AtomsVector>& expressions,
-                                                 const EventID creatorEvent,
-                                                 const Generation generation) {
-            auto ids = assignExpressionIDs(expressions, creatorEvent, generation);
-            
-            // If generation is at least maxGeneration_, we will never use these expressions as inputs, so no need adding them to the index.
-            if (generation < stepSpec_.maxGenerationsLocal) {
-                unindexedExpressions_.insert(unindexedExpressions_.end(), ids.begin(), ids.end());
-            }
-            
-            updateAtomDegrees(atomDegrees_, expressions, +1);
-            return ids;
-        }
-        
-        std::vector<ExpressionID> assignExpressionIDs(const std::vector<AtomsVector>& expressions,
-                                                      const EventID creatorEvent,
-                                                      const Generation generation) {
-            std::vector<ExpressionID> ids;
-            ids.reserve(expressions.size());
-            for (const auto& expression : expressions) {
-                ids.push_back(nextExpressionID_);
-                expressions_.insert(std::make_pair(nextExpressionID_++,
-                                                   SetExpression{expression,creatorEvent, finalStateEvent, generation}));
-            }
-            return ids;
-        }
-        
-        void assignDestroyerEvent(const std::vector<ExpressionID>& expressions, const EventID destroyerEvent) {
-            for (const auto id : expressions) {
-                if (expressions_.at(id).destroyerEvent == finalStateEvent) {
-                    ++destroyedExpressionsCount_;
-                }
-                expressions_.at(id).destroyerEvent = destroyerEvent;
-            }
-            updateAtomDegrees(atomDegrees_, expressions, -1);
-        }
-        
-        void updateAtomDegrees(std::unordered_map<Atom, int64_t>& atomDegrees,
-                               const std::vector<ExpressionID>& deltaExpressionIDs,
-                               const int64_t deltaCount) const {
-            std::vector<AtomsVector> expressions;
-            expressions.reserve(deltaExpressionIDs.size());
-            for (const auto id : deltaExpressionIDs) {
-                expressions.emplace_back(expressions_.at(id).atoms);
-            }
-            updateAtomDegrees(atomDegrees, expressions, deltaCount);
-        }
-        
-        Generation smallestGeneration(const std::vector<MatchPtr>& matches) const {
-            Generation smallestSoFar = std::numeric_limits<Generation>::max();
-            for (const auto& match : matches) {
-                Generation largestForTheMatch = 0;
-                for (const ExpressionID id : match->inputExpressions) {
-                    largestForTheMatch = std::max(largestForTheMatch, expressions_.at(id).generation);
-                }
-                smallestSoFar = std::min(smallestSoFar, largestForTheMatch);
-            }
-            return smallestSoFar;
-        }
-    };
-    
-    Set::Set(const std::vector<Rule>& rules,
-             const std::vector<AtomsVector>& initialExpressions,
-             const Matcher::OrderingSpec& orderingSpec,
-             unsigned int randomSeed) :
-             implementation_(std::make_shared<Implementation>(rules, initialExpressions, orderingSpec, randomSeed)) {}
+    const int64_t currentExpressionsCount = nextExpressionID_ - destroyedExpressionsCount_;
+    const int64_t newExpressionsCount = currentExpressionsCount - static_cast<int64_t>(explicitRuleInputs.size()) +
+                                        static_cast<int64_t>(explicitRuleOutputs.size());
+    if (newExpressionsCount > stepSpec_.maxFinalExpressions) {
+      return TerminationReason::MaxFinalExpressions;
+    } else {
+      return TerminationReason::NotTerminated;
+    }
+  }
 
-    int64_t Set::replaceOnce(const std::function<bool()>& shouldAbort) {
-        return implementation_->replaceOnce(shouldAbort);
+  std::vector<AtomsVector> nameAnonymousAtoms(const std::vector<AtomsVector>& atomVectors) {
+    std::unordered_map<Atom, Atom> names;
+    std::vector<AtomsVector> result = atomVectors;
+    for (auto& expression : result) {
+      for (auto& atom : expression) {
+        if (atom < 0 && names.count(atom) == 0) {
+          names[atom] = incrementNextAtom();
+        }
+        if (atom < 0) {
+          atom = names[atom];
+        }
+      }
     }
 
-    int64_t Set::replace(const StepSpecification& stepSpec, const std::function<bool()>& shouldAbort) {
-        return implementation_->replace(stepSpec, shouldAbort);
-    }
-    
-    std::vector<SetExpression> Set::expressions() const {
-        return implementation_->expressions();
+    return result;
+  }
+
+  std::vector<ExpressionID> addExpressions(const std::vector<AtomsVector>& expressions,
+                                           const EventID creatorEvent,
+                                           const Generation generation) {
+    auto ids = assignExpressionIDs(expressions, creatorEvent, generation);
+
+    // If generation is at least maxGeneration_, we will never use these expressions as inputs, so no need adding them
+    // to the index.
+    if (generation < stepSpec_.maxGenerationsLocal) {
+      unindexedExpressions_.insert(unindexedExpressions_.end(), ids.begin(), ids.end());
     }
 
-    Generation Set::maxCompleteGeneration(const std::function<bool()>& shouldAbort) {
-        return implementation_->maxCompleteGeneration(shouldAbort);
-    }
+    updateAtomDegrees(atomDegrees_, expressions, +1);
+    return ids;
+  }
 
-    Set::TerminationReason Set::terminationReason() const {
-        return implementation_->terminationReason();
+  std::vector<ExpressionID> assignExpressionIDs(const std::vector<AtomsVector>& expressions,
+                                                const EventID creatorEvent,
+                                                const Generation generation) {
+    std::vector<ExpressionID> ids;
+    ids.reserve(expressions.size());
+    for (const auto& expression : expressions) {
+      ids.push_back(nextExpressionID_);
+      expressions_.insert(
+          std::make_pair(nextExpressionID_++, SetExpression{expression, creatorEvent, finalStateEvent, generation}));
     }
+    return ids;
+  }
 
-    const std::vector<RuleID>& Set::eventRuleIDs() const {
-        return implementation_->eventRuleIDs();
+  void assignDestroyerEvent(const std::vector<ExpressionID>& expressions, const EventID destroyerEvent) {
+    for (const auto id : expressions) {
+      if (expressions_.at(id).destroyerEvent == finalStateEvent) {
+        ++destroyedExpressionsCount_;
+      }
+      expressions_.at(id).destroyerEvent = destroyerEvent;
     }
+    updateAtomDegrees(atomDegrees_, expressions, -1);
+  }
+
+  void updateAtomDegrees(std::unordered_map<Atom, int64_t>& atomDegrees,
+                         const std::vector<ExpressionID>& deltaExpressionIDs,
+                         const int64_t deltaCount) const {
+    std::vector<AtomsVector> expressions;
+    expressions.reserve(deltaExpressionIDs.size());
+    for (const auto id : deltaExpressionIDs) {
+      expressions.emplace_back(expressions_.at(id).atoms);
+    }
+    updateAtomDegrees(atomDegrees, expressions, deltaCount);
+  }
+
+  Generation smallestGeneration(const std::vector<MatchPtr>& matches) const {
+    Generation smallestSoFar = std::numeric_limits<Generation>::max();
+    for (const auto& match : matches) {
+      Generation largestForTheMatch = 0;
+      for (const ExpressionID id : match->inputExpressions) {
+        largestForTheMatch = std::max(largestForTheMatch, expressions_.at(id).generation);
+      }
+      smallestSoFar = std::min(smallestSoFar, largestForTheMatch);
+    }
+    return smallestSoFar;
+  }
+};
+
+Set::Set(const std::vector<Rule>& rules,
+         const std::vector<AtomsVector>& initialExpressions,
+         const Matcher::OrderingSpec& orderingSpec,
+         unsigned int randomSeed)
+    : implementation_(std::make_shared<Implementation>(rules, initialExpressions, orderingSpec, randomSeed)) {}
+
+int64_t Set::replaceOnce(const std::function<bool()>& shouldAbort) { return implementation_->replaceOnce(shouldAbort); }
+
+int64_t Set::replace(const StepSpecification& stepSpec, const std::function<bool()>& shouldAbort) {
+  return implementation_->replace(stepSpec, shouldAbort);
 }
+
+std::vector<SetExpression> Set::expressions() const { return implementation_->expressions(); }
+
+Generation Set::maxCompleteGeneration(const std::function<bool()>& shouldAbort) {
+  return implementation_->maxCompleteGeneration(shouldAbort);
+}
+
+Set::TerminationReason Set::terminationReason() const { return implementation_->terminationReason(); }
+
+const std::vector<RuleID>& Set::eventRuleIDs() const { return implementation_->eventRuleIDs(); }
+}  // namespace SetReplace

--- a/libSetReplace/Set.hpp
+++ b/libSetReplace/Set.hpp
@@ -1,5 +1,5 @@
-#ifndef Set_hpp
-#define Set_hpp
+#ifndef LIBSETREPLACE_SET_HPP_
+#define LIBSETREPLACE_SET_HPP_
 
 #include <functional>
 #include <memory>
@@ -101,4 +101,4 @@ class Set {
 };
 }  // namespace SetReplace
 
-#endif /* Set_hpp */
+#endif  // LIBSETREPLACE_SET_HPP_

--- a/libSetReplace/Set.hpp
+++ b/libSetReplace/Set.hpp
@@ -10,86 +10,95 @@
 #include "Rule.hpp"
 
 namespace SetReplace {
-    /** @brief Set is the set of expressions (i.e., the graph, the Universe) that is being evolved.
-     */
-    class Set {
-    public:
-        /** @brief Type of the error occurred during evaluation.
-         */
-        enum class Error {Aborted, DisconnectedInputs, NonPositiveAtoms, AtomCountOverflow};
-        
-        /** @brief Specification of conditions upon which to stop evaluation.
-         * @details Each of these is UpTo, i.e., the evolution is terminated when the first of these, fixed point, or an abort is reached.
-         * @var maxEvents Total number of events to produce.
-         * @var maxGenerationsLocal Total number of generations. Local means the expressions of max generation will never even be matched, which means the evaluation order might be different than if the equivalent number of events is specified, and non-default evaluation order is used.
-         * @var maxFinalAtoms The evaluation will be aborted at the first attempt to apply an event, which will cause the number of atoms in the final state to go over the limit.
-         * @var maxFinalAtomDegree Same as above, but for the maximum number of expressions a single atom is involved in.
-         * @var maxFinalExpressions Same as for the atoms above, but for expressions.
-         */
-        struct StepSpecification {
-            int64_t maxEvents = 0;
-            int64_t maxGenerationsLocal = 0;
-            int64_t maxFinalAtoms = 0;
-            int64_t maxFinalAtomDegree = 0;
-            int64_t maxFinalExpressions = 0;
-        };
-        
-        /** @brief Status of evaluation / termination reason if evaluation is finished.
-         */
-        enum class TerminationReason {
-            NotTerminated = 0,
-            MaxEvents = 1,
-            MaxGenerationsLocal = 2,
-            MaxFinalAtoms = 3,
-            MaxFinalAtomDegree = 4,
-            MaxFinalExpressions = 5,
-            FixedPoint = 6,
-            Aborted = 7};
+/** @brief Set is the set of expressions (i.e., the graph, the Universe) that is being evolved.
+ */
+class Set {
+ public:
+  /** @brief Type of the error occurred during evaluation.
+   */
+  enum class Error { Aborted, DisconnectedInputs, NonPositiveAtoms, AtomCountOverflow };
 
-        /** @brief Creates a new set with a given set of evolution rules, and initial condition.
-         * @param rules substittion rules used for evolution. Note, these rules cannot be changed.
-         * @param initialExpressions initial condition. It will be lazily indexed before the first replacement.
-         * @param orderingSpec in which order to apply events.
-         * @param randomSeed the seed to use for selecting matches in random evaluation case.
-         */
-        Set(const std::vector<Rule>& rules,
-            const std::vector<AtomsVector>& initialExpressions,
-            const Matcher::OrderingSpec& orderingSpec,
-            unsigned int randomSeed = 0);
+  /** @brief Specification of conditions upon which to stop evaluation.
+   * @details Each of these is UpTo, i.e., the evolution is terminated when the first of these, fixed point, or an abort
+   * is reached.
+   * @var maxEvents Total number of events to produce.
+   * @var maxGenerationsLocal Total number of generations. Local means the expressions of max generation will never even
+   * be matched, which means the evaluation order might be different than if the equivalent number of events is
+   * specified, and non-default evaluation order is used.
+   * @var maxFinalAtoms The evaluation will be aborted at the first attempt to apply an event, which will cause the
+   * number of atoms in the final state to go over the limit.
+   * @var maxFinalAtomDegree Same as above, but for the maximum number of expressions a single atom is involved in.
+   * @var maxFinalExpressions Same as for the atoms above, but for expressions.
+   */
+  struct StepSpecification {
+    int64_t maxEvents = 0;
+    int64_t maxGenerationsLocal = 0;
+    int64_t maxFinalAtoms = 0;
+    int64_t maxFinalAtomDegree = 0;
+    int64_t maxFinalExpressions = 0;
+  };
 
-        /** @brief Perform a single substitution, create the corresponding event, and output expressions.
-         * @param shouldAbort function that should return true if Wolfram Language abort is in progress.
-         * @return 1 if substitution was made, 0 if no matches were found.
-         */
-        int64_t replaceOnce(const std::function<bool()>& shouldAbort);
+  /** @brief Status of evaluation / termination reason if evaluation is finished.
+   */
+  enum class TerminationReason {
+    NotTerminated = 0,
+    MaxEvents = 1,
+    MaxGenerationsLocal = 2,
+    MaxFinalAtoms = 3,
+    MaxFinalAtomDegree = 4,
+    MaxFinalExpressions = 5,
+    FixedPoint = 6,
+    Aborted = 7
+  };
 
-        /** @brief Run replaceOnce() stepSpec.maxEvents times, or until the next expression violates constraints imposed by stepSpec.
-         * @param shouldAbort function that should return true if Wolfram Language abort is in progress.
-         * @return The number of subtitutions made, could be between 0 and stepSpec.maxEvents.
-         */
-        int64_t replace(const StepSpecification& stepSpec, const std::function<bool()>& shouldAbort);
+  /** @brief Creates a new set with a given set of evolution rules, and initial condition.
+   * @param rules substittion rules used for evolution. Note, these rules cannot be changed.
+   * @param initialExpressions initial condition. It will be lazily indexed before the first replacement.
+   * @param orderingSpec in which order to apply events.
+   * @param randomSeed the seed to use for selecting matches in random evaluation case.
+   */
+  Set(const std::vector<Rule>& rules,
+      const std::vector<AtomsVector>& initialExpressions,
+      const Matcher::OrderingSpec& orderingSpec,
+      unsigned int randomSeed = 0);
 
-        /** @brief List of all expressions in the set, past and present.
-         */
-        std::vector<SetExpression> expressions() const;
-        
-        /** @brief Returns the largest generation that has both been reached, and has no matches that would produce expressions with that or lower generation.
-         * @details Takes O(matches count) + as long as it would take to do the next step (because new expressions need to be indexed).
-         */
-        Generation maxCompleteGeneration(const std::function<bool()>& shouldAbort);
+  /** @brief Perform a single substitution, create the corresponding event, and output expressions.
+   * @param shouldAbort function that should return true if Wolfram Language abort is in progress.
+   * @return 1 if substitution was made, 0 if no matches were found.
+   */
+  int64_t replaceOnce(const std::function<bool()>& shouldAbort);
 
-        /** @brief Yields termination reason for the previous evaluation, or TerminationReason::NotTerminated if no evaluation was done yet.
-         */
-        TerminationReason terminationReason() const;
-        
-        /** @brief Yields rule IDs corresponding to each event.
-         */
-        const std::vector<RuleID>& eventRuleIDs() const;
+  /** @brief Run replaceOnce() stepSpec.maxEvents times, or until the next expression violates constraints imposed by
+   * stepSpec.
+   * @param shouldAbort function that should return true if Wolfram Language abort is in progress.
+   * @return The number of subtitutions made, could be between 0 and stepSpec.maxEvents.
+   */
+  int64_t replace(const StepSpecification& stepSpec, const std::function<bool()>& shouldAbort);
 
-    private:
-        class Implementation;
-        std::shared_ptr<Implementation> implementation_;
-    };
-}
+  /** @brief List of all expressions in the set, past and present.
+   */
+  std::vector<SetExpression> expressions() const;
+
+  /** @brief Returns the largest generation that has both been reached, and has no matches that would produce
+   * expressions with that or lower generation.
+   * @details Takes O(matches count) + as long as it would take to do the next step (because new expressions need to be
+   * indexed).
+   */
+  Generation maxCompleteGeneration(const std::function<bool()>& shouldAbort);
+
+  /** @brief Yields termination reason for the previous evaluation, or TerminationReason::NotTerminated if no evaluation
+   * was done yet.
+   */
+  TerminationReason terminationReason() const;
+
+  /** @brief Yields rule IDs corresponding to each event.
+   */
+  const std::vector<RuleID>& eventRuleIDs() const;
+
+ private:
+  class Implementation;
+  std::shared_ptr<Implementation> implementation_;
+};
+}  // namespace SetReplace
 
 #endif /* Set_hpp */

--- a/libSetReplace/SetReplace.cpp
+++ b/libSetReplace/SetReplace.cpp
@@ -96,7 +96,7 @@ namespace SetReplace {
 
             return Set::StepSpecification{stepSpecElements[0], stepSpecElements[1],
                                           stepSpecElements[2], stepSpecElements[3],
-                                          stepSpecElements[4]};;
+                                          stepSpecElements[4]};
         }
     }
     
@@ -244,7 +244,7 @@ namespace SetReplace {
             return LIBRARY_FUNCTION_ERROR;
         }
         
-        const SetID setID = MArgument_getInteger(argv[0]);;
+        const SetID setID = MArgument_getInteger(argv[0]);
         
         std::vector<SetExpression> expressions;
         try {
@@ -263,7 +263,7 @@ namespace SetReplace {
             return LIBRARY_FUNCTION_ERROR;
         }
         
-        const SetID setID = MArgument_getInteger(argv[0]);;
+        const SetID setID = MArgument_getInteger(argv[0]);
         
         Generation maxCompleteGeneration;
         try {

--- a/libSetReplace/SetReplace.cpp
+++ b/libSetReplace/SetReplace.cpp
@@ -1,366 +1,356 @@
+#include "SetReplace.hpp"
+
 #include <chrono>
 #include <random>
 #include <string>
 #include <unordered_map>
 
-#include "SetReplace.hpp"
-
 #include "Set.hpp"
 
 mint getData(const mint* data, const mint& length, const mint& index) {
-    if (index >= length || index < 0) {
-        throw LIBRARY_FUNCTION_ERROR;
-    } else {
-        return data[index];
-    }
+  if (index >= length || index < 0) {
+    throw LIBRARY_FUNCTION_ERROR;
+  } else {
+    return data[index];
+  }
 }
 
 namespace SetReplace {
-    // These are global variables that keep all sets returned to Wolfram Language until they are destroyed.
-    // Pointers are not returned directly for security reasons.
-    using SetID = int64_t;
-    std::unordered_map<SetID, Set> sets_;
+// These are global variables that keep all sets returned to Wolfram Language until they are destroyed.
+// Pointers are not returned directly for security reasons.
+using SetID = int64_t;
+std::unordered_map<SetID, Set> sets_;
 
-    std::vector<AtomsVector> getNextSet(const mint& tensorLength, const mint* tensorData, mint& startReadIndex) {
-        const auto getDataFunc = [&tensorData, &tensorLength, &startReadIndex]() -> mint {
-            return getData(tensorData, tensorLength, startReadIndex++);
-        };
+std::vector<AtomsVector> getNextSet(const mint& tensorLength, const mint* tensorData, mint& startReadIndex) {
+  const auto getDataFunc = [&tensorData, &tensorLength, &startReadIndex]() -> mint {
+    return getData(tensorData, tensorLength, startReadIndex++);
+  };
 
-        const mint setLength = getDataFunc();
-        std::vector<AtomsVector> set(setLength);
-        for (mint expressionIndex = 0; expressionIndex < setLength; ++expressionIndex) {
-            const mint expressionLength = getDataFunc();
-            auto& currentSet = set[expressionIndex];
-            currentSet.reserve(expressionLength);
-            for (mint atomIndex = 0; atomIndex < expressionLength; ++atomIndex) {
-                currentSet.emplace_back(static_cast<Atom>(getDataFunc()));
-            }
-        }
-        return set;
+  const mint setLength = getDataFunc();
+  std::vector<AtomsVector> set(setLength);
+  for (mint expressionIndex = 0; expressionIndex < setLength; ++expressionIndex) {
+    const mint expressionLength = getDataFunc();
+    auto& currentSet = set[expressionIndex];
+    currentSet.reserve(expressionLength);
+    for (mint atomIndex = 0; atomIndex < expressionLength; ++atomIndex) {
+      currentSet.emplace_back(static_cast<Atom>(getDataFunc()));
     }
-
-    std::vector<Rule> getRules(WolframLibraryData libData, MTensor& rulesTensor) {
-        const mint tensorLength = libData->MTensor_getFlattenedLength(rulesTensor);
-        const mint* tensorData = libData->MTensor_getIntegerData(rulesTensor);
-        mint readIndex = 0;
-        const auto getRulesData = [&tensorData, &tensorLength, &readIndex]() -> mint {
-            return getData(tensorData, tensorLength, readIndex++);
-        };
-        
-        const mint rulesCount = getRulesData();
-        std::vector<Rule> rules;
-        rules.reserve(rulesCount);
-        for (mint ruleIndex = 0; ruleIndex < rulesCount; ++ruleIndex) {
-            if (getRulesData() != 2) {
-                throw LIBRARY_FUNCTION_ERROR;
-            } else {
-                rules.emplace_back(Rule{getNextSet(tensorLength, tensorData, readIndex),
-                                        getNextSet(tensorLength, tensorData, readIndex)});
-            }
-        }
-        return rules;
-    }
-    
-    std::vector<AtomsVector> getSet(WolframLibraryData libData, MTensor& setTensor) {
-        mint readIndex = 0;
-        return getNextSet(libData->MTensor_getFlattenedLength(setTensor),
-                          libData->MTensor_getIntegerData(setTensor),
-                          readIndex);
-    }
-
-    Matcher::OrderingSpec getOrderingSpec(WolframLibraryData libData, MTensor& orderingSpecTensor) {
-        mint tensorLength = libData->MTensor_getFlattenedLength(orderingSpecTensor);
-        mint* tensorData = libData->MTensor_getIntegerData(orderingSpecTensor);
-        Matcher::OrderingSpec result;
-        result.reserve(tensorLength);
-        for (mint i = 0; i < tensorLength; i += 2) {
-            result.emplace_back(std::make_pair<Matcher::OrderingFunction, Matcher::OrderingDirection>(
-                static_cast<Matcher::OrderingFunction>(getData(tensorData, tensorLength, i)),
-                static_cast<Matcher::OrderingDirection>(getData(tensorData, tensorLength, i + 1))));
-        }
-        return result;
-    }
-    
-    Set::StepSpecification getStepSpec(WolframLibraryData libData, MTensor& stepsTensor) {
-        mint tensorLength = libData->MTensor_getFlattenedLength(stepsTensor);
-        constexpr mint specLength = 5;
-        if (tensorLength != specLength) {
-            throw LIBRARY_FUNCTION_ERROR;
-        } else {
-            mint* tensorData = libData->MTensor_getIntegerData(stepsTensor);
-            std::vector<int64_t> stepSpecElements(specLength);
-            for (mint k = 0; k < specLength; ++k) {
-                stepSpecElements[k] = static_cast<int64_t>(getData(tensorData, specLength, k));
-                if (stepSpecElements[k] < 0) throw LIBRARY_FUNCTION_ERROR;
-            }
-
-            return Set::StepSpecification{stepSpecElements[0], stepSpecElements[1],
-                                          stepSpecElements[2], stepSpecElements[3],
-                                          stepSpecElements[4]};
-        }
-    }
-    
-    MTensor putSet(const std::vector<SetExpression>& expressions, WolframLibraryData libData) {
-        // creator + destroyer events + generation + atoms count
-        // add fake event at the end to specify the length of the last expression
-        size_t tensorLength = 1 + 4 * (expressions.size() + 1);
-        
-        // The rest of the result are the atoms, positions to which are referenced in each expression spec.
-        // This is where the first atom will be located.
-        size_t atomsPointer = tensorLength + 1;
-
-        for (const auto& expression : expressions) {
-            tensorLength += expression.atoms.size();
-        }
-
-        const mint dimensions[1] = {static_cast<mint>(tensorLength)};
-        MTensor output;
-        libData->MTensor_new(MType_Integer, 1, dimensions, &output);
-        
-        mint writeIndex = 0;
-        mint position[1];
-        const auto appendToTensor = [libData, &writeIndex, &position, &output](const std::vector<mint>& numbers) {
-            for (const auto number : numbers) {
-                position[0] = ++writeIndex;
-                libData->MTensor_setInteger(output, position, number);
-            }
-        };
-        
-        appendToTensor({static_cast<mint>(expressions.size())});
-        for (const auto& expression : expressions) {
-            appendToTensor({static_cast<mint>(expression.creatorEvent),
-                            static_cast<mint>(expression.destroyerEvent),
-                            static_cast<mint>(expression.generation),
-                            static_cast<mint>(atomsPointer)});
-            atomsPointer += expression.atoms.size();
-        }
-        
-        // Put fake event at the end so that the length of final expression can be determined on WL side.
-        constexpr EventID fakeEvent = -3;
-        constexpr Generation fakeGeneration = -1;
-        appendToTensor({static_cast<mint>(fakeEvent),
-                        static_cast<mint>(fakeEvent),
-                        static_cast<mint>(fakeGeneration),
-                        static_cast<mint>(atomsPointer)});
-
-        for (const auto& expression : expressions) {
-            appendToTensor(expression.atoms);
-        }
-        
-        return output;
-    }
-
-    int setCreate(WolframLibraryData libData, mint argc, const MArgument* argv, MArgument result) {
-        if (argc != 4) {
-            return LIBRARY_FUNCTION_ERROR;
-        }
-        
-        std::vector<Rule> rules;
-        std::vector<AtomsVector> initialExpressions;
-        Matcher::OrderingSpec orderingSpec;
-        unsigned int randomSeed;
-        try {
-            rules = getRules(libData, MArgument_getMTensor(argv[0]));
-            initialExpressions = getSet(libData, MArgument_getMTensor(argv[1]));
-            orderingSpec = getOrderingSpec(libData, MArgument_getMTensor(argv[2]));
-            randomSeed = static_cast<unsigned int>(MArgument_getInteger(argv[3]));
-        } catch (...) {
-            return LIBRARY_FUNCTION_ERROR;
-        }
-        
-        SetID thisSetID;
-        do {
-            std::mt19937_64 randomGenerator(std::chrono::system_clock::now().time_since_epoch().count());
-            std::uniform_int_distribution<SetID> distribution(0, std::numeric_limits<SetID>::max());
-            thisSetID = distribution(randomGenerator);
-        } while (sets_.count(thisSetID) > 0);
-        try {
-            sets_.insert({thisSetID, Set(rules, initialExpressions, orderingSpec, randomSeed)});
-        } catch (...) {
-            return LIBRARY_FUNCTION_ERROR;
-        }
-        
-        MArgument_setInteger(result, thisSetID);
-        return LIBRARY_NO_ERROR;
-    }
-
-    int setDelete([[maybe_unused]] WolframLibraryData libData,
-                  mint argc,
-                  MArgument* argv,
-                  [[maybe_unused]] MArgument result) {
-        if (argc != 1) {
-            return LIBRARY_FUNCTION_ERROR;
-        }
-        const SetID setToDelete = MArgument_getInteger(argv[0]);
-
-        const auto setToDeleteIterator = sets_.find(setToDelete);
-        if (setToDeleteIterator != sets_.end()) {
-            sets_.erase(setToDeleteIterator);
-        } else {
-            return LIBRARY_FUNCTION_ERROR;
-        }
-        return LIBRARY_NO_ERROR;
-    }
-
-    std::function<bool()> shouldAbort(WolframLibraryData& libData) {
-        return [&libData]() {
-            return static_cast<bool>(libData->AbortQ());
-        };
-    }
-
-    Set& setFromID(const SetID id) {
-        const auto setIDIterator = sets_.find(id);
-        if (setIDIterator != sets_.end()) {
-            return setIDIterator->second;
-        } else {
-            throw LIBRARY_FUNCTION_ERROR;
-        }
-    }
-
-    int setReplace(WolframLibraryData libData, mint argc, MArgument *argv, [[maybe_unused]] MArgument result) {
-        if (argc != 2) {
-            return LIBRARY_FUNCTION_ERROR;
-        }
-        
-        const SetID setID = MArgument_getInteger(argv[0]);
-        Set::StepSpecification stepSpec;
-        try {
-            stepSpec = getStepSpec(libData, MArgument_getMTensor(argv[1]));
-        } catch (...) {
-            return LIBRARY_FUNCTION_ERROR;
-        }
-        
-        try {
-            setFromID(setID).replace(stepSpec, shouldAbort(libData));
-        } catch (...) {
-            return LIBRARY_FUNCTION_ERROR;
-        }
-        
-        return LIBRARY_NO_ERROR;
-    }
-
-    int setExpressions(WolframLibraryData libData, mint argc, MArgument *argv, MArgument result) {
-        if (argc != 1) {
-            return LIBRARY_FUNCTION_ERROR;
-        }
-        
-        const SetID setID = MArgument_getInteger(argv[0]);
-        
-        std::vector<SetExpression> expressions;
-        try {
-            expressions = setFromID(setID).expressions();
-        } catch (...) {
-            return LIBRARY_FUNCTION_ERROR;
-        }
-        
-        MArgument_setMTensor(result, putSet(expressions, libData));
-        
-        return LIBRARY_NO_ERROR;
-    }
-
-    int maxCompleteGeneration(WolframLibraryData libData, mint argc, MArgument *argv, MArgument result) {
-        if (argc != 1) {
-            return LIBRARY_FUNCTION_ERROR;
-        }
-        
-        const SetID setID = MArgument_getInteger(argv[0]);
-        
-        Generation maxCompleteGeneration;
-        try {
-            maxCompleteGeneration = setFromID(setID).maxCompleteGeneration(shouldAbort(libData));
-        } catch (...) {
-            return LIBRARY_FUNCTION_ERROR;
-        }
-        
-        MArgument_setInteger(result, maxCompleteGeneration);
-        
-        return LIBRARY_NO_ERROR;
-    }
-
-    int terminationReason([[maybe_unused]] WolframLibraryData, mint argc, MArgument *argv, MArgument result) {
-        if (argc != 1) {
-            return LIBRARY_FUNCTION_ERROR;
-        }
-        
-        const SetID setID = MArgument_getInteger(argv[0]);
-        
-        Set::TerminationReason terminationReason;
-        try {
-            terminationReason = setFromID(setID).terminationReason();
-        } catch (...) {
-            return LIBRARY_FUNCTION_ERROR;
-        }
-        
-        MArgument_setInteger(result, static_cast<int>(terminationReason));
-
-        return LIBRARY_NO_ERROR;
-    }
-
-    int eventRuleIDs(WolframLibraryData libData, mint argc, MArgument *argv, MArgument result) {
-        if (argc != 1) {
-            return LIBRARY_FUNCTION_ERROR;
-        }
-        
-        const SetID setID = MArgument_getInteger(argv[0]);
-        
-        try {
-            const auto ruleIDs = setFromID(setID).eventRuleIDs();
-            const mint dimensions[1] = {static_cast<mint>(ruleIDs.size() - 1)};
-            MTensor output;
-            libData->MTensor_new(MType_Integer, 1, dimensions, &output);
-            
-            mint writeIndex = 0;
-            mint position[1];
-            for (size_t event = 1; event < ruleIDs.size(); ++event) {
-                position[0] = ++writeIndex;
-                libData->MTensor_setInteger(output, position, static_cast<mint>(ruleIDs[event]) + 1);
-            }
-            
-            MArgument_setMTensor(result, output);
-        } catch (...) {
-            return LIBRARY_FUNCTION_ERROR;
-        }
-        
-        return LIBRARY_NO_ERROR;
-    }
+  }
+  return set;
 }
 
-EXTERN_C mint WolframLibrary_getVersion() {
-    return WolframLibraryVersion;
+std::vector<Rule> getRules(WolframLibraryData libData, MTensor& rulesTensor) {
+  const mint tensorLength = libData->MTensor_getFlattenedLength(rulesTensor);
+  const mint* tensorData = libData->MTensor_getIntegerData(rulesTensor);
+  mint readIndex = 0;
+  const auto getRulesData = [&tensorData, &tensorLength, &readIndex]() -> mint {
+    return getData(tensorData, tensorLength, readIndex++);
+  };
+
+  const mint rulesCount = getRulesData();
+  std::vector<Rule> rules;
+  rules.reserve(rulesCount);
+  for (mint ruleIndex = 0; ruleIndex < rulesCount; ++ruleIndex) {
+    if (getRulesData() != 2) {
+      throw LIBRARY_FUNCTION_ERROR;
+    } else {
+      rules.emplace_back(
+          Rule{getNextSet(tensorLength, tensorData, readIndex), getNextSet(tensorLength, tensorData, readIndex)});
+    }
+  }
+  return rules;
 }
 
-EXTERN_C int WolframLibrary_initialize([[maybe_unused]] WolframLibraryData libData) {
-    return 0;
+std::vector<AtomsVector> getSet(WolframLibraryData libData, MTensor& setTensor) {
+  mint readIndex = 0;
+  return getNextSet(
+      libData->MTensor_getFlattenedLength(setTensor), libData->MTensor_getIntegerData(setTensor), readIndex);
 }
 
-EXTERN_C void WolframLibrary_uninitialize([[maybe_unused]] WolframLibraryData libData) {
-    return;
+Matcher::OrderingSpec getOrderingSpec(WolframLibraryData libData, MTensor& orderingSpecTensor) {
+  mint tensorLength = libData->MTensor_getFlattenedLength(orderingSpecTensor);
+  mint* tensorData = libData->MTensor_getIntegerData(orderingSpecTensor);
+  Matcher::OrderingSpec result;
+  result.reserve(tensorLength);
+  for (mint i = 0; i < tensorLength; i += 2) {
+    result.emplace_back(std::make_pair<Matcher::OrderingFunction, Matcher::OrderingDirection>(
+        static_cast<Matcher::OrderingFunction>(getData(tensorData, tensorLength, i)),
+        static_cast<Matcher::OrderingDirection>(getData(tensorData, tensorLength, i + 1))));
+  }
+  return result;
 }
 
-EXTERN_C int setCreate(WolframLibraryData libData, mint argc, MArgument *argv, MArgument result) {
-    return SetReplace::setCreate(libData, argc, argv, result);
+Set::StepSpecification getStepSpec(WolframLibraryData libData, MTensor& stepsTensor) {
+  mint tensorLength = libData->MTensor_getFlattenedLength(stepsTensor);
+  constexpr mint specLength = 5;
+  if (tensorLength != specLength) {
+    throw LIBRARY_FUNCTION_ERROR;
+  } else {
+    mint* tensorData = libData->MTensor_getIntegerData(stepsTensor);
+    std::vector<int64_t> stepSpecElements(specLength);
+    for (mint k = 0; k < specLength; ++k) {
+      stepSpecElements[k] = static_cast<int64_t>(getData(tensorData, specLength, k));
+      if (stepSpecElements[k] < 0) throw LIBRARY_FUNCTION_ERROR;
+    }
+
+    return Set::StepSpecification{
+        stepSpecElements[0], stepSpecElements[1], stepSpecElements[2], stepSpecElements[3], stepSpecElements[4]};
+  }
 }
 
-EXTERN_C int setDelete(WolframLibraryData libData, mint argc, MArgument *argv, MArgument result) {
-    return SetReplace::setDelete(libData, argc, argv, result);
+MTensor putSet(const std::vector<SetExpression>& expressions, WolframLibraryData libData) {
+  // creator + destroyer events + generation + atoms count
+  // add fake event at the end to specify the length of the last expression
+  size_t tensorLength = 1 + 4 * (expressions.size() + 1);
+
+  // The rest of the result are the atoms, positions to which are referenced in each expression spec.
+  // This is where the first atom will be located.
+  size_t atomsPointer = tensorLength + 1;
+
+  for (const auto& expression : expressions) {
+    tensorLength += expression.atoms.size();
+  }
+
+  const mint dimensions[1] = {static_cast<mint>(tensorLength)};
+  MTensor output;
+  libData->MTensor_new(MType_Integer, 1, dimensions, &output);
+
+  mint writeIndex = 0;
+  mint position[1];
+  const auto appendToTensor = [libData, &writeIndex, &position, &output](const std::vector<mint>& numbers) {
+    for (const auto number : numbers) {
+      position[0] = ++writeIndex;
+      libData->MTensor_setInteger(output, position, number);
+    }
+  };
+
+  appendToTensor({static_cast<mint>(expressions.size())});
+  for (const auto& expression : expressions) {
+    appendToTensor({static_cast<mint>(expression.creatorEvent),
+                    static_cast<mint>(expression.destroyerEvent),
+                    static_cast<mint>(expression.generation),
+                    static_cast<mint>(atomsPointer)});
+    atomsPointer += expression.atoms.size();
+  }
+
+  // Put fake event at the end so that the length of final expression can be determined on WL side.
+  constexpr EventID fakeEvent = -3;
+  constexpr Generation fakeGeneration = -1;
+  appendToTensor({static_cast<mint>(fakeEvent),
+                  static_cast<mint>(fakeEvent),
+                  static_cast<mint>(fakeGeneration),
+                  static_cast<mint>(atomsPointer)});
+
+  for (const auto& expression : expressions) {
+    appendToTensor(expression.atoms);
+  }
+
+  return output;
 }
 
-EXTERN_C int setReplace(WolframLibraryData libData, mint argc, MArgument *argv, MArgument result) {
-    return SetReplace::setReplace(libData, argc, argv, result);
+int setCreate(WolframLibraryData libData, mint argc, const MArgument* argv, MArgument result) {
+  if (argc != 4) {
+    return LIBRARY_FUNCTION_ERROR;
+  }
+
+  std::vector<Rule> rules;
+  std::vector<AtomsVector> initialExpressions;
+  Matcher::OrderingSpec orderingSpec;
+  unsigned int randomSeed;
+  try {
+    rules = getRules(libData, MArgument_getMTensor(argv[0]));
+    initialExpressions = getSet(libData, MArgument_getMTensor(argv[1]));
+    orderingSpec = getOrderingSpec(libData, MArgument_getMTensor(argv[2]));
+    randomSeed = static_cast<unsigned int>(MArgument_getInteger(argv[3]));
+  } catch (...) {
+    return LIBRARY_FUNCTION_ERROR;
+  }
+
+  SetID thisSetID;
+  do {
+    std::mt19937_64 randomGenerator(std::chrono::system_clock::now().time_since_epoch().count());
+    std::uniform_int_distribution<SetID> distribution(0, std::numeric_limits<SetID>::max());
+    thisSetID = distribution(randomGenerator);
+  } while (sets_.count(thisSetID) > 0);
+  try {
+    sets_.insert({thisSetID, Set(rules, initialExpressions, orderingSpec, randomSeed)});
+  } catch (...) {
+    return LIBRARY_FUNCTION_ERROR;
+  }
+
+  MArgument_setInteger(result, thisSetID);
+  return LIBRARY_NO_ERROR;
 }
 
-EXTERN_C int setExpressions(WolframLibraryData libData, mint argc, MArgument *argv, MArgument result) {
-    return SetReplace::setExpressions(libData, argc, argv, result);
+int setDelete([[maybe_unused]] WolframLibraryData libData,
+              mint argc,
+              MArgument* argv,
+              [[maybe_unused]] MArgument result) {
+  if (argc != 1) {
+    return LIBRARY_FUNCTION_ERROR;
+  }
+  const SetID setToDelete = MArgument_getInteger(argv[0]);
+
+  const auto setToDeleteIterator = sets_.find(setToDelete);
+  if (setToDeleteIterator != sets_.end()) {
+    sets_.erase(setToDeleteIterator);
+  } else {
+    return LIBRARY_FUNCTION_ERROR;
+  }
+  return LIBRARY_NO_ERROR;
 }
 
-EXTERN_C int maxCompleteGeneration(WolframLibraryData libData, mint argc, MArgument *argv, MArgument result) {
-    return SetReplace::maxCompleteGeneration(libData, argc, argv, result);
+std::function<bool()> shouldAbort(WolframLibraryData& libData) {
+  return [&libData]() { return static_cast<bool>(libData->AbortQ()); };
 }
 
-EXTERN_C int terminationReason(WolframLibraryData libData, mint argc, MArgument *argv, MArgument result) {
-    return SetReplace::terminationReason(libData, argc, argv, result);
+Set& setFromID(const SetID id) {
+  const auto setIDIterator = sets_.find(id);
+  if (setIDIterator != sets_.end()) {
+    return setIDIterator->second;
+  } else {
+    throw LIBRARY_FUNCTION_ERROR;
+  }
 }
 
-EXTERN_C int eventRuleIDs(WolframLibraryData libData, mint argc, MArgument *argv, MArgument result) {
-    return SetReplace::eventRuleIDs(libData, argc, argv, result);
+int setReplace(WolframLibraryData libData, mint argc, MArgument* argv, [[maybe_unused]] MArgument result) {
+  if (argc != 2) {
+    return LIBRARY_FUNCTION_ERROR;
+  }
+
+  const SetID setID = MArgument_getInteger(argv[0]);
+  Set::StepSpecification stepSpec;
+  try {
+    stepSpec = getStepSpec(libData, MArgument_getMTensor(argv[1]));
+  } catch (...) {
+    return LIBRARY_FUNCTION_ERROR;
+  }
+
+  try {
+    setFromID(setID).replace(stepSpec, shouldAbort(libData));
+  } catch (...) {
+    return LIBRARY_FUNCTION_ERROR;
+  }
+
+  return LIBRARY_NO_ERROR;
+}
+
+int setExpressions(WolframLibraryData libData, mint argc, MArgument* argv, MArgument result) {
+  if (argc != 1) {
+    return LIBRARY_FUNCTION_ERROR;
+  }
+
+  const SetID setID = MArgument_getInteger(argv[0]);
+
+  std::vector<SetExpression> expressions;
+  try {
+    expressions = setFromID(setID).expressions();
+  } catch (...) {
+    return LIBRARY_FUNCTION_ERROR;
+  }
+
+  MArgument_setMTensor(result, putSet(expressions, libData));
+
+  return LIBRARY_NO_ERROR;
+}
+
+int maxCompleteGeneration(WolframLibraryData libData, mint argc, MArgument* argv, MArgument result) {
+  if (argc != 1) {
+    return LIBRARY_FUNCTION_ERROR;
+  }
+
+  const SetID setID = MArgument_getInteger(argv[0]);
+
+  Generation maxCompleteGeneration;
+  try {
+    maxCompleteGeneration = setFromID(setID).maxCompleteGeneration(shouldAbort(libData));
+  } catch (...) {
+    return LIBRARY_FUNCTION_ERROR;
+  }
+
+  MArgument_setInteger(result, maxCompleteGeneration);
+
+  return LIBRARY_NO_ERROR;
+}
+
+int terminationReason([[maybe_unused]] WolframLibraryData, mint argc, MArgument* argv, MArgument result) {
+  if (argc != 1) {
+    return LIBRARY_FUNCTION_ERROR;
+  }
+
+  const SetID setID = MArgument_getInteger(argv[0]);
+
+  Set::TerminationReason terminationReason;
+  try {
+    terminationReason = setFromID(setID).terminationReason();
+  } catch (...) {
+    return LIBRARY_FUNCTION_ERROR;
+  }
+
+  MArgument_setInteger(result, static_cast<int>(terminationReason));
+
+  return LIBRARY_NO_ERROR;
+}
+
+int eventRuleIDs(WolframLibraryData libData, mint argc, MArgument* argv, MArgument result) {
+  if (argc != 1) {
+    return LIBRARY_FUNCTION_ERROR;
+  }
+
+  const SetID setID = MArgument_getInteger(argv[0]);
+
+  try {
+    const auto ruleIDs = setFromID(setID).eventRuleIDs();
+    const mint dimensions[1] = {static_cast<mint>(ruleIDs.size() - 1)};
+    MTensor output;
+    libData->MTensor_new(MType_Integer, 1, dimensions, &output);
+
+    mint writeIndex = 0;
+    mint position[1];
+    for (size_t event = 1; event < ruleIDs.size(); ++event) {
+      position[0] = ++writeIndex;
+      libData->MTensor_setInteger(output, position, static_cast<mint>(ruleIDs[event]) + 1);
+    }
+
+    MArgument_setMTensor(result, output);
+  } catch (...) {
+    return LIBRARY_FUNCTION_ERROR;
+  }
+
+  return LIBRARY_NO_ERROR;
+}
+}  // namespace SetReplace
+
+EXTERN_C mint WolframLibrary_getVersion() { return WolframLibraryVersion; }
+
+EXTERN_C int WolframLibrary_initialize([[maybe_unused]] WolframLibraryData libData) { return 0; }
+
+EXTERN_C void WolframLibrary_uninitialize([[maybe_unused]] WolframLibraryData libData) { return; }
+
+EXTERN_C int setCreate(WolframLibraryData libData, mint argc, MArgument* argv, MArgument result) {
+  return SetReplace::setCreate(libData, argc, argv, result);
+}
+
+EXTERN_C int setDelete(WolframLibraryData libData, mint argc, MArgument* argv, MArgument result) {
+  return SetReplace::setDelete(libData, argc, argv, result);
+}
+
+EXTERN_C int setReplace(WolframLibraryData libData, mint argc, MArgument* argv, MArgument result) {
+  return SetReplace::setReplace(libData, argc, argv, result);
+}
+
+EXTERN_C int setExpressions(WolframLibraryData libData, mint argc, MArgument* argv, MArgument result) {
+  return SetReplace::setExpressions(libData, argc, argv, result);
+}
+
+EXTERN_C int maxCompleteGeneration(WolframLibraryData libData, mint argc, MArgument* argv, MArgument result) {
+  return SetReplace::maxCompleteGeneration(libData, argc, argv, result);
+}
+
+EXTERN_C int terminationReason(WolframLibraryData libData, mint argc, MArgument* argv, MArgument result) {
+  return SetReplace::terminationReason(libData, argc, argv, result);
+}
+
+EXTERN_C int eventRuleIDs(WolframLibraryData libData, mint argc, MArgument* argv, MArgument result) {
+  return SetReplace::eventRuleIDs(libData, argc, argv, result);
 }

--- a/libSetReplace/SetReplace.cpp
+++ b/libSetReplace/SetReplace.cpp
@@ -4,6 +4,7 @@
 #include <random>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include "Set.hpp"
@@ -74,9 +75,9 @@ Matcher::OrderingSpec getOrderingSpec(WolframLibraryData libData, MTensor orderi
   Matcher::OrderingSpec result;
   result.reserve(tensorLength);
   for (mint i = 0; i < tensorLength; i += 2) {
-    result.emplace_back(std::make_pair(
-        static_cast<Matcher::OrderingFunction>(getData(tensorData, tensorLength, i)),
-        static_cast<Matcher::OrderingDirection>(getData(tensorData, tensorLength, i + 1))));
+    result.emplace_back(
+        std::make_pair(static_cast<Matcher::OrderingFunction>(getData(tensorData, tensorLength, i)),
+                       static_cast<Matcher::OrderingDirection>(getData(tensorData, tensorLength, i + 1))));
   }
   return result;
 }

--- a/libSetReplace/SetReplace.cpp
+++ b/libSetReplace/SetReplace.cpp
@@ -1,6 +1,7 @@
 #include "SetReplace.hpp"
 
-#include <chrono>
+// NOLINTNEXTLINE(build/c++11)
+#include <chrono>  // <chrono> is banned in Chromium, so cpplint flags it https://stackoverflow.com/a/33653404/905496
 #include <limits>
 #include <random>
 #include <string>

--- a/libSetReplace/SetReplace.cpp
+++ b/libSetReplace/SetReplace.cpp
@@ -1,5 +1,6 @@
 #include "SetReplace.hpp"
 
+#include <chrono>
 #include <limits>
 #include <random>
 #include <string>

--- a/libSetReplace/SetReplace.hpp
+++ b/libSetReplace/SetReplace.hpp
@@ -14,32 +14,33 @@ EXTERN_C DLLEXPORT void WolframLibrary_uninitialize(WolframLibraryData libData);
 /** @brief Creates a new set object.
  * @return Pointer to the newly created set in memory.
  * @note Memory is not managed, the set needs to be destroyed manually.
-*/
-EXTERN_C DLLEXPORT int setCreate(WolframLibraryData libData, mint argc, MArgument *argv, MArgument result);
+ */
+EXTERN_C DLLEXPORT int setCreate(WolframLibraryData libData, mint argc, MArgument* argv, MArgument result);
 
 /** @brief Destroys a set given a pointer.
  */
-EXTERN_C DLLEXPORT int setDelete(WolframLibraryData libData, mint argc, MArgument *argv, MArgument result);
+EXTERN_C DLLEXPORT int setDelete(WolframLibraryData libData, mint argc, MArgument* argv, MArgument result);
 
 /** @brief Performs a specified number of replacements, but does not return anything.
  */
-EXTERN_C DLLEXPORT int setReplace(WolframLibraryData libData, mint argc, MArgument *argv, MArgument result);
+EXTERN_C DLLEXPORT int setReplace(WolframLibraryData libData, mint argc, MArgument* argv, MArgument result);
 
 /** @brief Returns a list of expressions for a specified set pointer.
  */
-EXTERN_C DLLEXPORT int setExpressions(WolframLibraryData libData, mint argc, MArgument *argv, MArgument result);
+EXTERN_C DLLEXPORT int setExpressions(WolframLibraryData libData, mint argc, MArgument* argv, MArgument result);
 
-/** @brief Returns the largest generation that has both been reached, and has no matches that would produce expressions with that or lower generation.
+/** @brief Returns the largest generation that has both been reached, and has no matches that would produce expressions
+ * with that or lower generation.
  * @details Is abortable, in which case returns LIBRARY_FUNCTION_ERROR.
  */
-EXTERN_C DLLEXPORT int maxCompleteGeneration(WolframLibraryData libData, mint argc, MArgument *argv, MArgument result);
+EXTERN_C DLLEXPORT int maxCompleteGeneration(WolframLibraryData libData, mint argc, MArgument* argv, MArgument result);
 
 /** @brief Returns a number corresponding to the termination reason.
  */
-EXTERN_C DLLEXPORT int terminationReason(WolframLibraryData libData, mint argc, MArgument *argv, MArgument result);
+EXTERN_C DLLEXPORT int terminationReason(WolframLibraryData libData, mint argc, MArgument* argv, MArgument result);
 
 /** @brief Returns the list of indices of rules used for each event.
  */
-EXTERN_C DLLEXPORT int eventRuleIDs(WolframLibraryData libData, mint argc, MArgument *argv, MArgument result);
+EXTERN_C DLLEXPORT int eventRuleIDs(WolframLibraryData libData, mint argc, MArgument* argv, MArgument result);
 
 #endif /* SetReplace_hpp */

--- a/libSetReplace/SetReplace.hpp
+++ b/libSetReplace/SetReplace.hpp
@@ -1,7 +1,7 @@
 // Library definition for Wolfram LibraryLink
 
-#ifndef SetReplace_hpp
-#define SetReplace_hpp
+#ifndef LIBSETREPLACE_SETREPLACE_HPP_
+#define LIBSETREPLACE_SETREPLACE_HPP_
 
 #include "WolframLibrary.h"
 
@@ -43,4 +43,4 @@ EXTERN_C DLLEXPORT int terminationReason(WolframLibraryData libData, mint argc, 
  */
 EXTERN_C DLLEXPORT int eventRuleIDs(WolframLibraryData libData, mint argc, MArgument* argv, MArgument result);
 
-#endif /* SetReplace_hpp */
+#endif  // LIBSETREPLACE_SETREPLACE_HPP_

--- a/libSetReplace/test/Set_test.cpp
+++ b/libSetReplace/test/Set_test.cpp
@@ -1,15 +1,14 @@
 #include "Set.hpp"
 
-#include <iostream>
-
 #include <gtest/gtest.h>
+
+#include <iostream>
 
 #include "IDTypes.hpp"
 #include "Match.hpp"
 #include "Rule.hpp"
 
-using namespace SetReplace;
-
+namespace SetReplace {
 TEST(SetReplace, createSetAndReplace) {
   // Negative atoms refer to patterns (useful for rules)
   std::vector<Rule> rules;
@@ -35,3 +34,4 @@ TEST(SetReplace, createSetAndReplace) {
   stepSpec.maxFinalExpressions = 100000;
   EXPECT_TRUE(a_set.replace(stepSpec, shouldAbort));
 }
+}  // namespace SetReplace

--- a/lint.sh
+++ b/lint.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+sourceFiles="libSetReplace/*pp libSetReplace/test/*pp"
+
+red="\\\033[0;31m"
+green="\\\033[0;32m"
+endColor="\\\033[0m"
+
+formatInPlace=0
+
+for arg in "$@"
+do
+  case $arg in
+    -i)
+    formatInPlace=1
+    shift
+    ;;
+    *)
+    echo "Argument $arg is not recognized."
+    echo
+    echo "Usage: ./lint.sh [-i]"
+    echo "Analyze the C++ code with clang-format and cpplint."
+    echo
+    echo "Options:"
+    echo "  -i  Inplace edit files with clang-format."
+    shift
+    ;;
+  esac
+done
+
+exitStatus=0
+
+for file in $sourceFiles; do
+  diff=$(diff -U0 --label $file $file --label formatted <(clang-format $file))
+  if [ $formatInPlace -eq 1 ]; then
+    clang-format -i $file
+  fi
+  if [[ ! -z "$diff" ]]; then
+    printf -- "$(echo "$diff\n\n" | sed "s|^-|$red-|g" | sed "s|^+|$green+|g" | sed "s|$|$endColor|g")"
+    exitStatus=1
+  fi
+done
+
+if ! cpplint --quiet --linelength=120 --filter=-legal/copyright $sourceFiles; then
+  exitStatus=1
+fi
+
+exit $exitStatus

--- a/lint.sh
+++ b/lint.sh
@@ -23,7 +23,7 @@ do
     echo
     echo "Options:"
     echo "  -i  Inplace edit files with clang-format."
-    shift
+    exit 1
     ;;
   esac
 done


### PR DESCRIPTION
## Changes
* This closes the C++ Style Refactor project.
* Resolves #316.
* Resolves #317.
* Resolves #319.
* Closes #357.
* Reformats all C++ code according to [Google C++ Style Guide].
* Adds `.clang-format` file specifying the exceptions to the Google style guide.
* Adds lint.sh script which prints a diff generated by `clang-format` (if any) and the errors generated by `cpplint`, and allows one to apply formatting in place with `./lint.sh -i`.
* Adds Lint step to CI before Build.
* Updates .gitbub/CONTRIBUTING.md with instructions on how to use lint.sh.
* Adds the missing test file to the Xcode project.

## Comments
* Linting in CI is not parallelized and is using the same Docker image because it will eventually include linting of the Wolfram Language code as well as described in #247.
* Bin packing is now disallowed in addition to the existing style exceptions.
* All `cpplint` errors are fixed as well, not just the formatting.
* `#include <chrono>` is not allowed by `cpplint` for Chromium-specific reasons, so added `// NOLINT` there.
* Renamed `SetTest.cpp` -> `Set_test.cpp` because the suffix appears to be hard-coded to `cpplint`.
* Before the formatting, the code was mostly following this style (imperfectly):
```
---
Language: Cpp
BasedOnStyle: Google
ColumnLimit: 120
BinPackArguments: false
BinPackParameters: false
AllowShortFunctionsOnASingleLine: Empty
IndentWidth: 4
NamespaceIndentation: All
AccessModifierOffset: -4
FixNamespaceComments: false
SpaceAfterTemplateKeyword: false
BreakConstructorInitializers: AfterColon
SpacesBeforeTrailingComments: 1
...
```

## Examples
* Break formatting/code style somewhere in the code, and run `./lint.sh`. For example, we can remove `explicit` on line 22 of Match.cpp, and add a spurious space on the line below:
```
> ./lint.sh 
--- libSetReplace/Match.cpp
+++ formatted
@@ -24 +24 @@
-  bool  operator()(const MatchPtr& a, const MatchPtr& b) const {
+  bool operator()(const MatchPtr& a, const MatchPtr& b) const {

libSetReplace/Match.cpp:22:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
Done processing libSetReplace/Match.cpp
Total errors found: 1
```

* We can run `./lint.sh -i` to fix the space automatically:
```
> ./lint.sh -i
--- libSetReplace/Match.cpp
+++ formatted
@@ -24 +24 @@
-  bool  operator()(const MatchPtr& a, const MatchPtr& b) const {
+  bool operator()(const MatchPtr& a, const MatchPtr& b) const {

libSetReplace/Match.cpp:22:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
Done processing libSetReplace/Match.cpp
Total errors found: 1
```

* The output is the same, however, if we run `./lint.sh` again, there will be no diff:
```
> ./lint.sh   
libSetReplace/Match.cpp:22:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [5]
Done processing libSetReplace/Match.cpp
Total errors found: 1
```

* Finally, if we put explicit back in, there will be no output, which means everything is ok:
```
> ./lint.sh
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/361)
<!-- Reviewable:end -->
