### PR TITLE
Fully store test report in a notebook

### DIFF
--- a/test.wls
+++ b/test.wls
@@ -120,20 +120,24 @@ $results = Association[KeyValueMap[Function[{testGroupName, testGroup}, Module[{
   ];
 
   (* Return the report, we'll need it later *)
-  testGroupName -> Iconize @ testReport
+  testGroupName -> testReport
 ]], $testGroups]];
 
 (* Create a notebook with results *)
 
-$reportFile = UsingFrontEnd @ Export[
-  FileNameJoin[Join[FileNameSplit[CreateDirectory[]], {"testReport.nb"}]],
-  Notebook @ Catenate @ Prepend[KeyValueMap[
-    {Cell[Last @ FileNameSplit @ #1, "Section"],
-      Cell[
-        BoxData[RowBox[{"TestReport", "[", "\"" <> #1 <> "\"", "]"}]],
-        "Input"],
-      Cell[BoxData[ToBoxes[#2]], "Output"]} &,
-    $results], {Cell["SetReplace Test Report", "Title"]}]];
+$reportFile = UsingFrontEnd[
+  $NotebookInlineStorageLimit = Infinity;
+  Export[
+    FileNameJoin[Join[FileNameSplit[CreateDirectory[]], {"testReport.nb"}]],
+    Notebook @ Catenate @ Prepend[KeyValueMap[
+      {Cell[Last @ FileNameSplit @ #1, "Section"],
+        Cell[
+          BoxData[RowBox[{"TestReport", "[", "\"" <> #1 <> "\"", "]"}]],
+          "Input"],
+        Cell[BoxData[ToBoxes[#2]], "Output"]} &,
+      $results], {Cell["SetReplace Test Report", "Title"]}]
+  ]
+];
 
 
 Print["Report file: ", $reportFile];

--- a/test.wls
+++ b/test.wls
@@ -120,7 +120,7 @@ $results = Association[KeyValueMap[Function[{testGroupName, testGroup}, Module[{
   ];
 
   (* Return the report, we'll need it later *)
-  testGroupName -> testReport
+  testGroupName -> Iconize @ testReport
 ]], $testGroups]];
 
 (* Create a notebook with results *)


### PR DESCRIPTION
## Changes
* Resolves https://github.com/maxitg/SetReplace/issues/70
* Fixes test results not being saved in report notebooks.

## Examples
### Before:
![image](https://user-images.githubusercontent.com/1057888/82750525-5f346000-9db9-11ea-9a31-782586658007.png)
### After:
![image](https://user-images.githubusercontent.com/1057888/82750533-6ce9e580-9db9-11ea-8012-e2cbd5b3d40e.png)
### Notebook:
[testReport.nb.zip](https://github.com/maxitg/SetReplace/files/4674806/testReport.nb.zip)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/363)
<!-- Reviewable:end -->
