### PR TITLE
CMake: Fix name of test file

### DIFF
--- a/libSetReplace/test/CMakeLists.txt
+++ b/libSetReplace/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(_link_libraries SetReplace ${GTEST_LIBRARIES})
 
-add_executable(SetTest SetTest.cpp)
-target_link_libraries(SetTest ${_link_libraries})
+add_executable(Set_test Set_test.cpp)
+target_link_libraries(Set_test ${_link_libraries})
 
-gtest_discover_tests(SetTest)
+gtest_discover_tests(Set_test)


### PR DESCRIPTION
The file is named `Set_test.cpp`, changed from `SetTest.cpp`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/366)
<!-- Reviewable:end -->
