### PR TITLE
EventSelectionFunction in libSetReplace

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ message(STATUS "SET_REPLACE_WITH_MATHEMATICA: ${SET_REPLACE_WITH_MATHEMATICA}")
 message(STATUS "SET_REPLACE_EXTRA_COMPILE_OPTIONS: ${SET_REPLACE_EXTRA_COMPILE_OPTIONS}")
 
 set(libSetReplace_headers
+    Event.hpp
     Rule.hpp
     IDTypes.hpp
     Expression.hpp
@@ -52,6 +53,7 @@ set(libSetReplace_headers
     Set.hpp
     )
 set(libSetReplace_sources
+    Event.cpp
     Expression.cpp
     Match.cpp
     Set.cpp

--- a/Kernel/setSubstitutionSystem$cpp.m
+++ b/Kernel/setSubstitutionSystem$cpp.m
@@ -155,7 +155,9 @@ decodeEvents[list_List] := Module[{
 (* assumes a single creator/destroyer event per edge, which is ok because we are only currently calling libSetReplace*)
 (*with EventSelectionFunction -> GlobalSpacelike.*)
 expressionEvents[expressionsCount_][inputsOrOutputs_, missingEventID_] :=
-	Replace[Position[inputsOrOutputs, #], {{{event_, _}} :> event, {} -> missingEventID}] & /@ Range[expressionsCount]
+	Sort[Join[
+		Catenate[Thread /@ Transpose[{inputsOrOutputs, Range[Length[inputsOrOutputs]]}]],
+		Thread[{Complement[Range[expressionsCount], Catenate[inputsOrOutputs]], missingEventID}]]][[All, 2]]
 
 
 decodeExpressions[atomLists_List, events_Association] := Module[{creators, destroyers, eventToGeneration},

--- a/Kernel/setSubstitutionSystem$cpp.m
+++ b/Kernel/setSubstitutionSystem$cpp.m
@@ -235,8 +235,8 @@ $cppSetReplaceAvailable = $cpp$setReplace =!= $Failed;
 (*setSubstitutionSystem$cpp*)
 
 
-$maxInt = 2^31 - 1;
-$maxUnsignedInt = 2^32 - 1;
+$maxInt64 = 2^63 - 1;
+$maxUInt32 = 2^32 - 1;
 
 
 $terminationReasonCodes = <|
@@ -292,14 +292,14 @@ setSubstitutionSystem$cpp[rules_, set_, stepSpec_, returnOnAbortQ_, timeConstrai
 		encodeNestedLists[mappedSet],
 		Replace[$globalSpacelike, $eventSelectionFunctionCodes], (* hardcode global spacelike (singleway) system for now *)
 		Catenate[Replace[eventOrderingFunction, $orderingFunctionCodes, {2}]],
-		RandomInteger[{0, $maxUnsignedInt}]];
+		RandomInteger[{0, $maxUInt32}]];
 	TimeConstrained[
 		CheckAbort[
 			$cpp$setReplace[
 				setPtr,
 				stepSpec /@ {
 						$maxEvents, $maxGenerationsLocal, $maxFinalVertices, $maxFinalVertexDegree, $maxFinalExpressions} /.
-					{Infinity | (_ ? MissingQ) -> $maxInt}],
+					{Infinity | (_ ? MissingQ) -> $maxInt64}],
 			If[!returnOnAbortQ, Abort[], terminationReason = $Aborted]],
 		timeConstraint,
 		If[!returnOnAbortQ, Return[$Aborted], terminationReason = $timeConstraint]];

--- a/Kernel/setSubstitutionSystem$cpp.m
+++ b/Kernel/setSubstitutionSystem$cpp.m
@@ -315,11 +315,12 @@ setSubstitutionSystem$cpp[rules_, set_, stepSpec_, returnOnAbortQ_, timeConstrai
 	inverseGlobalMap = Association @ Thread[resultAtoms
 		-> (Lookup[inversePartialGlobalMap, #, Unique["v", {Temporary}]] & /@ resultAtoms)];
 	WolframModelEvolutionObject[Join[
-		cppOutput,
+		KeyDrop[cppOutput, $eventRuleIDs],
 		<|$atomLists ->
 				ReleaseHold @ Map[inverseGlobalMap, cppOutput[$atomLists], {2}],
 			$rules -> rules,
 			$maxCompleteGeneration -> maxCompleteGeneration,
-			$terminationReason -> terminationReason
+			$terminationReason -> terminationReason,
+			$eventRuleIDs -> cppOutput[$eventRuleIDs]
 		|>]]
 ]

--- a/Kernel/setSubstitutionSystem$cpp.m
+++ b/Kernel/setSubstitutionSystem$cpp.m
@@ -156,20 +156,19 @@ decodeEvents[list_List] := Module[{
 (*with EventSelectionFunction -> GlobalSpacelike.*)
 expressionEvents[expressionsCount_][inputsOrOutputs_, missingEventID_] :=
 	Sort[Join[
-		Catenate[Thread /@ Transpose[{inputsOrOutputs, Range[Length[inputsOrOutputs]]}]],
+		Catenate[Thread /@ Transpose[{inputsOrOutputs, Range[Length[inputsOrOutputs]] - 1}]],
 		Thread[{Complement[Range[expressionsCount], Catenate[inputsOrOutputs]], missingEventID}]]][[All, 2]]
 
 
 decodeExpressions[atomLists_List, events_Association] := Module[{creators, destroyers, eventToGeneration},
 	{creators, destroyers} =
 		expressionEvents[Length[atomLists]] @@@ {{events[$eventOutputs], 0}, {events[$eventInputs], Infinity}};
-	eventToGeneration =
-		Association[Append[Thread[Range[Length[events[$eventGenerations]]] -> events[$eventGenerations]], 0 -> 0]];
+	eventToGeneration = Association[Thread[Range[Length[events[$eventGenerations]]] - 1 -> events[$eventGenerations]]];
 	<|$creatorEvents -> creators,
 		$destroyerEvents -> destroyers,
 		$generations -> eventToGeneration /@ creators,
 		$atomLists -> atomLists,
-		$eventRuleIDs -> events[$eventRuleIDs]|>
+		$eventRuleIDs -> Rest[events[$eventRuleIDs]]|>
 ]
 
 

--- a/Kernel/setSubstitutionSystem$wl.m
+++ b/Kernel/setSubstitutionSystem$wl.m
@@ -363,7 +363,6 @@ setSubstitutionSystem$wl[
 		$destroyerEvents -> result[[All, 3]],
 		$generations -> result[[All, 4]],
 		$atomLists -> result[[All, 5]],
-		$eventRuleIDs -> If[outputWithMetadata[[2, 2]] == {}, {}, outputWithMetadata[[2, 2, 1]]],
 		$rules -> rules,
 		$maxCompleteGeneration -> CheckAbort[
 			maxCompleteGeneration[outputWithMetadata[[1, 1]], renamedRules],
@@ -371,7 +370,8 @@ setSubstitutionSystem$wl[
 				Missing["Unknown", $Aborted],
 				Return[$Aborted]
 			]],
-		$terminationReason -> outputWithMetadata[[1, 2]]|>];
+		$terminationReason -> outputWithMetadata[[1, 2]],
+		$eventRuleIDs -> If[outputWithMetadata[[2, 2]] == {}, {}, outputWithMetadata[[2, 2, 1]]]|>];
 	WolframModelEvolutionObject[
 		Join[
 			intermediateEvolution[[1]],

--- a/Kernel/setSubstitutionSystem$wl.m
+++ b/Kernel/setSubstitutionSystem$wl.m
@@ -363,6 +363,7 @@ setSubstitutionSystem$wl[
 		$destroyerEvents -> result[[All, 3]],
 		$generations -> result[[All, 4]],
 		$atomLists -> result[[All, 5]],
+		$eventRuleIDs -> If[outputWithMetadata[[2, 2]] == {}, {}, outputWithMetadata[[2, 2, 1]]],
 		$rules -> rules,
 		$maxCompleteGeneration -> CheckAbort[
 			maxCompleteGeneration[outputWithMetadata[[1, 1]], renamedRules],
@@ -370,8 +371,7 @@ setSubstitutionSystem$wl[
 				Missing["Unknown", $Aborted],
 				Return[$Aborted]
 			]],
-		$terminationReason -> outputWithMetadata[[1, 2]],
-		$eventRuleIDs -> If[outputWithMetadata[[2, 2]] == {}, {}, outputWithMetadata[[2, 2, 1]]]|>];
+		$terminationReason -> outputWithMetadata[[1, 2]]|>];
 	WolframModelEvolutionObject[
 		Join[
 			intermediateEvolution[[1]],

--- a/SetReplace.xcodeproj/project.pbxproj
+++ b/SetReplace.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		691C67D42486A44100BC0D82 /* Event.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 691C67D22486A44100BC0D82 /* Event.cpp */; };
+		691C67D52486A44100BC0D82 /* Event.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 691C67D32486A44100BC0D82 /* Event.hpp */; };
 		6961A1D623184ABC009461C8 /* Expression.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6961A1D523184ABC009461C8 /* Expression.cpp */; };
 		69CAF86D2257B162006F9C60 /* Match.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6909EBA922258611001458D2 /* Match.cpp */; };
 		69CAF86E2257B162006F9C60 /* Set.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 695F486E222443F20058E057 /* Set.cpp */; };
@@ -22,6 +24,8 @@
 /* Begin PBXFileReference section */
 		6909EBA922258611001458D2 /* Match.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = Match.cpp; sourceTree = "<group>"; };
 		6909EBAA22258611001458D2 /* Match.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = Match.hpp; sourceTree = "<group>"; };
+		691C67D22486A44100BC0D82 /* Event.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = Event.cpp; sourceTree = "<group>"; };
+		691C67D32486A44100BC0D82 /* Event.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = Event.hpp; sourceTree = "<group>"; };
 		691E077A2471CED500D2BDD5 /* CMakeLists.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = CMakeLists.txt; sourceTree = "<group>"; };
 		691E077C2471D1DD00D2BDD5 /* Set_test.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = Set_test.cpp; sourceTree = "<group>"; };
 		695F486E222443F20058E057 /* Set.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = Set.cpp; sourceTree = "<group>"; };
@@ -74,6 +78,8 @@
 		695F4865222440B90058E057 /* libSetReplace */ = {
 			isa = PBXGroup;
 			children = (
+				691C67D32486A44100BC0D82 /* Event.hpp */,
+				691C67D22486A44100BC0D82 /* Event.cpp */,
 				69B2D41122244AFC008778A3 /* Expression.hpp */,
 				6961A1D523184ABC009461C8 /* Expression.cpp */,
 				69ED0F4023170D5D0014A48E /* IDTypes.hpp */,
@@ -101,6 +107,7 @@
 				69CAF8702257B1CE006F9C60 /* Match.hpp in Headers */,
 				69CAF8712257B1D0006F9C60 /* Rule.hpp in Headers */,
 				69CAF8722257B1D2006F9C60 /* Set.hpp in Headers */,
+				691C67D52486A44100BC0D82 /* Event.hpp in Headers */,
 				69ED0F4123170D5D0014A48E /* IDTypes.hpp in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -165,6 +172,7 @@
 				6961A1D623184ABC009461C8 /* Expression.cpp in Sources */,
 				69CAF86D2257B162006F9C60 /* Match.cpp in Sources */,
 				69CAF86E2257B162006F9C60 /* Set.cpp in Sources */,
+				691C67D42486A44100BC0D82 /* Event.cpp in Sources */,
 				69CB70E0231C245400488D26 /* SetReplace.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/libSetReplace/Event.cpp
+++ b/libSetReplace/Event.cpp
@@ -1,0 +1,90 @@
+#include "Event.hpp"
+
+#include <algorithm>
+
+namespace SetReplace {
+class CausalGraph::Implementation {
+  // the first event is the "fake" initialization event
+  std::vector<Event> events_;
+  std::vector<EventID> creatorEvents_;
+
+  // needed to return the largest generation in O(1)
+  Generation largestGeneration_ = 0;
+
+  static constexpr RuleID initialConditionRule = -1;
+
+ public:
+  explicit Implementation(const int initialExpressionsCount) {
+    events_.push_back({initialConditionRule, {}, createExpressions(initialConditionEvent, initialExpressionsCount), 0});
+  }
+
+  std::vector<ExpressionID> addEvent(const RuleID ruleID,
+                                     const std::vector<ExpressionID>& inputExpressions,
+                                     const int outputExpressionsCount) {
+    const auto newExpressions = createExpressions(events_.size(), outputExpressionsCount);
+    const Generation generation = newEventGeneration(inputExpressions);
+    events_.push_back({ruleID, inputExpressions, newExpressions, generation});
+    largestGeneration_ = std::max(largestGeneration_, generation);
+    return newExpressions;
+  }
+
+  std::vector<Event> events() const { return std::vector<Event>(events_.begin() + 1, events_.end()); }
+
+  size_t eventsCount() const { return events_.size() - 1; }
+
+  std::vector<ExpressionID> allExpressionIDs() const { return idsRange(0, creatorEvents_.size()); }
+
+  size_t expressionsCount() const { return creatorEvents_.size(); }
+
+  Generation expressionGeneration(const ExpressionID id) const { return events_[creatorEvents_[id]].generation; }
+
+  Generation largestGeneration() const { return largestGeneration_; }
+
+ private:
+  std::vector<ExpressionID> createExpressions(const EventID creatorEvent, const int count) {
+    const size_t beginIndex = creatorEvents_.size();
+    creatorEvents_.insert(creatorEvents_.end(), count, creatorEvent);
+    return idsRange(beginIndex, creatorEvents_.size());
+  }
+
+  static std::vector<ExpressionID> idsRange(const ExpressionID beginIndex, const ExpressionID endIndex) {
+    std::vector<ExpressionID> result;
+    result.reserve(endIndex - beginIndex);
+    for (ExpressionID i = beginIndex; i < endIndex; ++i) {
+      result.push_back(i);
+    }
+    return result;
+  }
+
+  Generation newEventGeneration(const std::vector<ExpressionID>& inputExpressions) const {
+    Generation newEventGeneration = 0;
+    for (const auto& inputExpression : inputExpressions) {
+      newEventGeneration = std::max(newEventGeneration, events_[creatorEvents_[inputExpression]].generation + 1);
+    }
+    return newEventGeneration;
+  }
+};
+
+CausalGraph::CausalGraph(const int initialExpressionsCount)
+    : implementation_(std::make_shared<Implementation>(initialExpressionsCount)) {}
+
+std::vector<ExpressionID> CausalGraph::addEvent(const RuleID ruleID,
+                                                const std::vector<ExpressionID>& inputExpressions,
+                                                const int outputExpressionsCount) {
+  return implementation_->addEvent(ruleID, inputExpressions, outputExpressionsCount);
+}
+
+std::vector<Event> CausalGraph::events() const { return implementation_->events(); }
+
+size_t CausalGraph::eventsCount() const { return implementation_->eventsCount(); }
+
+std::vector<ExpressionID> CausalGraph::allExpressionIDs() const { return implementation_->allExpressionIDs(); }
+
+size_t CausalGraph::expressionsCount() const { return implementation_->expressionsCount(); }
+
+Generation CausalGraph::expressionGeneration(const ExpressionID id) const {
+  return implementation_->expressionGeneration(id);
+}
+
+Generation CausalGraph::largestGeneration() const { return implementation_->largestGeneration(); }
+}  // namespace SetReplace

--- a/libSetReplace/Event.cpp
+++ b/libSetReplace/Event.cpp
@@ -11,8 +11,6 @@ class CausalGraph::Implementation {
   // needed to return the largest generation in O(1)
   Generation largestGeneration_ = 0;
 
-  static constexpr RuleID initialConditionRule = -1;
-
  public:
   explicit Implementation(const int initialExpressionsCount) {
     addEvent(initialConditionRule, {}, initialExpressionsCount);
@@ -28,7 +26,7 @@ class CausalGraph::Implementation {
     return newExpressions;
   }
 
-  std::vector<Event> events() const { return std::vector<Event>(events_.begin() + 1, events_.end()); }
+  const std::vector<Event>& events() const { return events_; }
 
   size_t eventsCount() const { return events_.size() - 1; }
 
@@ -77,7 +75,7 @@ std::vector<ExpressionID> CausalGraph::addEvent(const RuleID ruleID,
   return implementation_->addEvent(ruleID, inputExpressions, outputExpressionsCount);
 }
 
-std::vector<Event> CausalGraph::events() const { return implementation_->events(); }
+const std::vector<Event>& CausalGraph::events() const { return implementation_->events(); }
 
 size_t CausalGraph::eventsCount() const { return implementation_->eventsCount(); }
 

--- a/libSetReplace/Event.hpp
+++ b/libSetReplace/Event.hpp
@@ -10,7 +10,7 @@ namespace SetReplace {
 /** @brief Event is an instantiated replacement that has taken place in the system.
  */
 struct Event {
-  /** @brief ID for the rule this match corresponds to.
+  /** @brief ID for the rule this event corresponds to.
    */
   const RuleID rule;
 
@@ -22,18 +22,22 @@ struct Event {
    */
   const std::vector<ExpressionID> outputExpressions;
 
-  /** @brief Layer of the causal network this event belongs to.
+  /** @brief Layer of the causal graph this event belongs to.
    */
   const Generation generation;
 };
 
+/** @brief CausalGraph keeps track of causal relationships between events and expressions.
+ @details It does not care and does not know about atoms at all because they are only used for matching. Expressions are
+ only identified by IDs.
+ */
 class CausalGraph {
  public:
-  /** @brief Constructs a CausalGraph with an initial condition represented by initialExpressions.
+  /** @brief Creates a new CausalGraph with a given number of initial expressions.
    */
   explicit CausalGraph(int initialExpressionsCount);
 
-  /** @brief Adds new event, names its output expressions, and returns their IDs.
+  /** @brief Adds a new event, names its output expressions, and returns their IDs.
    */
   std::vector<ExpressionID> addEvent(RuleID ruleID,
                                      const std::vector<ExpressionID>& inputExpressions,

--- a/libSetReplace/Event.hpp
+++ b/libSetReplace/Event.hpp
@@ -1,0 +1,73 @@
+#ifndef LIBSETREPLACE_EVENT_HPP_
+#define LIBSETREPLACE_EVENT_HPP_
+
+#include <memory>
+#include <vector>
+
+#include "IDTypes.hpp"
+
+namespace SetReplace {
+/** @brief Event is an instantiated replacement that has taken place in the system.
+ */
+struct Event {
+  /** @brief ID for the rule this match corresponds to.
+   */
+  const RuleID rule;
+
+  /** @brief Expressions matching the rule inputs.
+   */
+  const std::vector<ExpressionID> inputExpressions;
+
+  /** @brief Expressions created from the rule outputs.
+   */
+  const std::vector<ExpressionID> outputExpressions;
+
+  /** @brief Layer of the causal network this event belongs to.
+   */
+  const Generation generation;
+};
+
+class CausalGraph {
+ public:
+  /** @brief Constructs a CausalGraph with an initial condition represented by initialExpressions.
+   */
+  explicit CausalGraph(int initialExpressionsCount);
+
+  /** @brief Adds new event, names its output expressions, and returns their IDs.
+   */
+  std::vector<ExpressionID> addEvent(RuleID ruleID,
+                                     const std::vector<ExpressionID>& inputExpressions,
+                                     int outputExpressionsCount);
+
+  /** @brief Yields a vector of all events throughout history.
+   */
+  std::vector<Event> events() const;
+
+  /** @brief Total number of events.
+   */
+  size_t eventsCount() const;
+
+  /** @brief Yields a vector of IDs for all expressions in the causal graph.
+   */
+  std::vector<ExpressionID> allExpressionIDs() const;
+
+  /** @brief Total number of expressions.
+   */
+  size_t expressionsCount() const;
+
+  /** @brief Generation for a given expression.
+   * @details This is the same as the generation of its creator event.
+   */
+  Generation expressionGeneration(ExpressionID id) const;
+
+  /** @brief Largest generation of any event.
+   */
+  Generation largestGeneration() const;
+
+ private:
+  class Implementation;
+  std::shared_ptr<Implementation> implementation_;
+};
+}  // namespace SetReplace
+
+#endif  // LIBSETREPLACE_EVENT_HPP_

--- a/libSetReplace/Event.hpp
+++ b/libSetReplace/Event.hpp
@@ -44,8 +44,9 @@ class CausalGraph {
                                      int outputExpressionsCount);
 
   /** @brief Yields a vector of all events throughout history.
+   @details This includes the initial event, so the size of the result is one larger than eventsCount().
    */
-  std::vector<Event> events() const;
+  const std::vector<Event>& events() const;
 
   /** @brief Total number of events.
    */

--- a/libSetReplace/Expression.hpp
+++ b/libSetReplace/Expression.hpp
@@ -13,26 +13,6 @@ namespace SetReplace {
  */
 using AtomsVector = std::vector<Atom>;
 
-/** @brief Expression, as a part of the set, i.e., (hyper)edges in the graph.
- */
-struct SetExpression {
-  /** @brief Ordered list of atoms the expression contains.
-   */
-  AtomsVector atoms;
-
-  /** @brief Substitution event that has this expression as part of its output.
-   */
-  EventID creatorEvent;
-
-  /** @brief Substitution events that have this expression as part of their inputs.
-   */
-  std::vector<EventID> destroyerEvents = {};
-
-  /** @brief Layer of the causal network this expression belongs to.
-   */
-  Generation generation;
-};
-
 /** @brief AtomsIndex keeps references to set expressions accessible by atoms, which is useful for matching.
  */
 class AtomsIndex {

--- a/libSetReplace/Expression.hpp
+++ b/libSetReplace/Expression.hpp
@@ -24,9 +24,9 @@ struct SetExpression {
    */
   EventID creatorEvent;
 
-  /** @brief Substitution event that has this expression as part of its input.
+  /** @brief Substitution events that have this expression as part of their inputs.
    */
-  EventID destroyerEvent = finalStateEvent;
+  std::vector<EventID> destroyerEvents = {};
 
   /** @brief Layer of the causal network this expression belongs to.
    */

--- a/libSetReplace/IDTypes.hpp
+++ b/libSetReplace/IDTypes.hpp
@@ -23,7 +23,6 @@ using ExpressionID = int64_t;
  */
 using EventID = int64_t;
 constexpr EventID initialConditionEvent = 0;
-constexpr EventID finalStateEvent = -1;
 
 /** @brief Layer this expression belongs to in the causal network.
  * @details Specifically, if the largest generation of expressions in the event inputs is n, the generation of its

--- a/libSetReplace/IDTypes.hpp
+++ b/libSetReplace/IDTypes.hpp
@@ -13,6 +13,7 @@ using Atom = int64_t;
 /** @brief Identifiers for rules, which stay the same for the entire evolution of the system.
  */
 using RuleID = int;
+constexpr RuleID initialConditionRule = -1;
 
 /** @brief Identifiers for expressions, which are the elements of the set, and contain ordered sequences of atoms, i.e.,
  * (hyper)edges in the graph.

--- a/libSetReplace/Match.hpp
+++ b/libSetReplace/Match.hpp
@@ -78,6 +78,10 @@ class Matcher {
    */
   void removeMatchesInvolvingExpressions(const std::vector<ExpressionID>& expressionIDs);
 
+  /** @brief Removes a single match from the index.
+   */
+  void deleteMatch(const MatchPtr matchPtr);
+
   /** @brief Yields true if there are no matches left.
    */
   bool empty() const;

--- a/libSetReplace/Set.cpp
+++ b/libSetReplace/Set.cpp
@@ -16,7 +16,7 @@ class Set::Implementation {
   const std::vector<Rule> rules_;
 
   // Determines the limiting conditions for the evaluation.
-  StepSpecification stepSpec_ = {0, 0, 0, 0, 0}; // don't evolve unless asked to.
+  StepSpecification stepSpec_ = {0, 0, 0, 0, 0};  // don't evolve unless asked to.
   const EventSelectionFunction eventSelectionFunction_;
   TerminationReason terminationReason_ = TerminationReason::NotTerminated;
 
@@ -202,7 +202,8 @@ class Set::Implementation {
   void checkStepSpec(const StepSpecification& stepSpec) const {
     if (eventSelectionFunction_ != EventSelectionFunction::GlobalSpacelike) {
       // cannot support final state step limiters for a multiway system.
-      const std::vector<int64_t> finalStateStepLimits = {stepSpec.maxFinalAtoms, stepSpec.maxFinalAtomDegree, stepSpec.maxFinalExpressions};
+      const std::vector<int64_t> finalStateStepLimits = {
+          stepSpec.maxFinalAtoms, stepSpec.maxFinalAtomDegree, stepSpec.maxFinalExpressions};
       for (const auto stepLimit : finalStateStepLimits) {
         if (stepLimit != maxStepLimit) throw Error::FinalStateStepSpecificationForMultiwaySystem;
       }
@@ -216,9 +217,7 @@ class Set::Implementation {
     unindexedExpressions_.clear();
   }
 
-  bool isMultiway() const {
-    return eventSelectionFunction_ != EventSelectionFunction::GlobalSpacelike;
-  }
+  bool isMultiway() const { return eventSelectionFunction_ != EventSelectionFunction::GlobalSpacelike; }
 
   TerminationReason willExceedAtomLimits(const std::vector<AtomsVector>& explicitRuleInputs,
                                          const std::vector<AtomsVector>& explicitRuleOutputs) const {

--- a/libSetReplace/Set.cpp
+++ b/libSetReplace/Set.cpp
@@ -187,7 +187,7 @@ class Set::Implementation {
   }
 
   void updateStepSpec(const StepSpecification newStepSpec) {
-    checkStepSpec(newStepSpec);
+    throwIfInvalidStepSpec(newStepSpec);
     const auto previousMaxGeneration = stepSpec_.maxGenerationsLocal;
     stepSpec_ = newStepSpec;
     if (newStepSpec.maxGenerationsLocal > previousMaxGeneration) {
@@ -199,13 +199,13 @@ class Set::Implementation {
     }
   }
 
-  void checkStepSpec(const StepSpecification& stepSpec) const {
-    if (eventSelectionFunction_ != EventSelectionFunction::GlobalSpacelike) {
+  void throwIfInvalidStepSpec(const StepSpecification& stepSpec) const {
+    if (isMultiway()) {
       // cannot support final state step limiters for a multiway system.
       const std::vector<int64_t> finalStateStepLimits = {
           stepSpec.maxFinalAtoms, stepSpec.maxFinalAtomDegree, stepSpec.maxFinalExpressions};
       for (const auto stepLimit : finalStateStepLimits) {
-        if (stepLimit != maxStepLimit) throw Error::FinalStateStepSpecificationForMultiwaySystem;
+        if (stepLimit != stepLimitDisabled) throw Error::FinalStateStepSpecificationForMultiwaySystem;
       }
     }
   }

--- a/libSetReplace/Set.cpp
+++ b/libSetReplace/Set.cpp
@@ -155,7 +155,7 @@ class Set::Implementation {
 
   TerminationReason terminationReason() const { return terminationReason_; }
 
-  std::vector<Event> events() const { return causalGraph_.events(); }
+  const std::vector<Event>& events() const { return causalGraph_.events(); }
 
  private:
   Implementation(std::vector<Rule> rules,
@@ -358,5 +358,5 @@ Generation Set::maxCompleteGeneration(const std::function<bool()>& shouldAbort) 
 
 Set::TerminationReason Set::terminationReason() const { return implementation_->terminationReason(); }
 
-std::vector<Event> Set::events() const { return implementation_->events(); }
+const std::vector<Event>& Set::events() const { return implementation_->events(); }
 }  // namespace SetReplace

--- a/libSetReplace/Set.hpp
+++ b/libSetReplace/Set.hpp
@@ -17,7 +17,14 @@ class Set {
  public:
   /** @brief Type of the error occurred during evaluation.
    */
-  enum class Error { Aborted, DisconnectedInputs, NonPositiveAtoms, AtomCountOverflow, InvalidEventSelectionFunction, FinalStateStepSpecificationForMultiwaySystem };
+  enum class Error {
+    Aborted,
+    DisconnectedInputs,
+    NonPositiveAtoms,
+    AtomCountOverflow,
+    InvalidEventSelectionFunction,
+    FinalStateStepSpecificationForMultiwaySystem
+  };
 
   static constexpr int64_t maxStepLimit = std::numeric_limits<int64_t>::max();
 

--- a/libSetReplace/Set.hpp
+++ b/libSetReplace/Set.hpp
@@ -16,7 +16,7 @@ class Set {
  public:
   /** @brief Type of the error occurred during evaluation.
    */
-  enum class Error { Aborted, DisconnectedInputs, NonPositiveAtoms, AtomCountOverflow };
+  enum class Error { Aborted, DisconnectedInputs, NonPositiveAtoms, AtomCountOverflow, InvalidEventSelectionFunction };
 
   /** @brief Specification of conditions upon which to stop evaluation.
    * @details Each of these is UpTo, i.e., the evolution is terminated when the first of these, fixed point, or an abort
@@ -38,6 +38,13 @@ class Set {
     int64_t maxFinalExpressions = 0;
   };
 
+  /** @brief All possible functions available to select events. Some of these will cause multiway evolution.
+   */
+  enum class EventSelectionFunction {
+    GlobalSpacelike = 0,  // default singleway evolution, a single branch of the multiway system
+    None = 1              // match-all multiway system, a single event can match branchlike and timelike expressions
+  };
+
   /** @brief Status of evaluation / termination reason if evaluation is finished.
    */
   enum class TerminationReason {
@@ -54,11 +61,13 @@ class Set {
   /** @brief Creates a new set with a given set of evolution rules, and initial condition.
    * @param rules substittion rules used for evolution. Note, these rules cannot be changed.
    * @param initialExpressions initial condition. It will be lazily indexed before the first replacement.
+   * @param selectionFunction which events to apply (i.e., singleway vs. different types of multiway systems).
    * @param orderingSpec in which order to apply events.
    * @param randomSeed the seed to use for selecting matches in random evaluation case.
    */
   Set(const std::vector<Rule>& rules,
       const std::vector<AtomsVector>& initialExpressions,
+      const EventSelectionFunction& selectionFunction,
       const Matcher::OrderingSpec& orderingSpec,
       unsigned int randomSeed = 0);
 

--- a/libSetReplace/Set.hpp
+++ b/libSetReplace/Set.hpp
@@ -5,6 +5,7 @@
 #include <memory>
 #include <vector>
 
+#include "Event.hpp"
 #include "Expression.hpp"
 #include "Match.hpp"
 #include "Rule.hpp"
@@ -86,7 +87,7 @@ class Set {
 
   /** @brief List of all expressions in the set, past and present.
    */
-  std::vector<SetExpression> expressions() const;
+  std::vector<AtomsVector> expressions() const;
 
   /** @brief Returns the largest generation that has both been reached, and has no matches that would produce
    * expressions with that or lower generation.
@@ -102,7 +103,7 @@ class Set {
 
   /** @brief Yields rule IDs corresponding to each event.
    */
-  const std::vector<RuleID>& eventRuleIDs() const;
+  std::vector<Event> events() const;
 
  private:
   class Implementation;

--- a/libSetReplace/Set.hpp
+++ b/libSetReplace/Set.hpp
@@ -2,6 +2,7 @@
 #define LIBSETREPLACE_SET_HPP_
 
 #include <functional>
+#include <limits>
 #include <memory>
 #include <vector>
 

--- a/libSetReplace/Set.hpp
+++ b/libSetReplace/Set.hpp
@@ -17,11 +17,13 @@ class Set {
  public:
   /** @brief Type of the error occurred during evaluation.
    */
-  enum class Error { Aborted, DisconnectedInputs, NonPositiveAtoms, AtomCountOverflow, InvalidEventSelectionFunction };
+  enum class Error { Aborted, DisconnectedInputs, NonPositiveAtoms, AtomCountOverflow, InvalidEventSelectionFunction, FinalStateStepSpecificationForMultiwaySystem };
+
+  static constexpr int64_t maxStepLimit = std::numeric_limits<int64_t>::max();
 
   /** @brief Specification of conditions upon which to stop evaluation.
    * @details Each of these is UpTo, i.e., the evolution is terminated when the first of these, fixed point, or an abort
-   * is reached.
+   * is reached. Set to maxStepLimit to disable.
    * @var maxEvents Total number of events to produce.
    * @var maxGenerationsLocal Total number of generations. Local means the expressions of max generation will never even
    * be matched, which means the evaluation order might be different than if the equivalent number of events is
@@ -32,11 +34,11 @@ class Set {
    * @var maxFinalExpressions Same as for the atoms above, but for expressions.
    */
   struct StepSpecification {
-    int64_t maxEvents = 0;
-    int64_t maxGenerationsLocal = 0;
-    int64_t maxFinalAtoms = 0;
-    int64_t maxFinalAtomDegree = 0;
-    int64_t maxFinalExpressions = 0;
+    int64_t maxEvents = maxStepLimit;
+    int64_t maxGenerationsLocal = maxStepLimit;
+    int64_t maxFinalAtoms = maxStepLimit;
+    int64_t maxFinalAtomDegree = maxStepLimit;
+    int64_t maxFinalExpressions = maxStepLimit;
   };
 
   /** @brief All possible functions available to select events. Some of these will cause multiway evolution.

--- a/libSetReplace/Set.hpp
+++ b/libSetReplace/Set.hpp
@@ -27,11 +27,11 @@ class Set {
     FinalStateStepSpecificationForMultiwaySystem
   };
 
-  static constexpr int64_t maxStepLimit = std::numeric_limits<int64_t>::max();
+  static constexpr int64_t stepLimitDisabled = std::numeric_limits<int64_t>::max();
 
   /** @brief Specification of conditions upon which to stop evaluation.
    * @details Each of these is UpTo, i.e., the evolution is terminated when the first of these, fixed point, or an abort
-   * is reached. Set to maxStepLimit to disable.
+   * is reached.
    * @var maxEvents Total number of events to produce.
    * @var maxGenerationsLocal Total number of generations. Local means the expressions of max generation will never even
    * be matched, which means the evaluation order might be different than if the equivalent number of events is
@@ -42,11 +42,11 @@ class Set {
    * @var maxFinalExpressions Same as for the atoms above, but for expressions.
    */
   struct StepSpecification {
-    int64_t maxEvents = maxStepLimit;
-    int64_t maxGenerationsLocal = maxStepLimit;
-    int64_t maxFinalAtoms = maxStepLimit;
-    int64_t maxFinalAtomDegree = maxStepLimit;
-    int64_t maxFinalExpressions = maxStepLimit;
+    int64_t maxEvents = stepLimitDisabled;
+    int64_t maxGenerationsLocal = stepLimitDisabled;
+    int64_t maxFinalAtoms = stepLimitDisabled;
+    int64_t maxFinalAtomDegree = stepLimitDisabled;
+    int64_t maxFinalExpressions = stepLimitDisabled;
   };
 
   /** @brief All possible functions available to select events. Some of these will cause multiway evolution.

--- a/libSetReplace/Set.hpp
+++ b/libSetReplace/Set.hpp
@@ -113,7 +113,7 @@ class Set {
 
   /** @brief Yields rule IDs corresponding to each event.
    */
-  std::vector<Event> events() const;
+  const std::vector<Event>& events() const;
 
  private:
   class Implementation;

--- a/libSetReplace/SetReplace.cpp
+++ b/libSetReplace/SetReplace.cpp
@@ -102,23 +102,15 @@ Set::StepSpecification getStepSpec(WolframLibraryData libData, MTensor stepsTens
   }
 }
 
-MTensor putSet(const std::vector<SetExpression>& expressions, WolframLibraryData libData) {
-  // creator event + destroyer events pointer + generation + atoms list pointer
-  // add fake event at the end to specify the length of the last expression
-  size_t tensorLength = 1 + 4 * (expressions.size() + 1);
+MTensor putSet(const std::vector<AtomsVector>& expressions, WolframLibraryData libData) {
+  // count + atoms list pointer for each expression + an extra pointer at the end to the element one past the end
+  size_t tensorLength = 1 + (expressions.size() + 1);
 
   // Atoms are next, positions to which are referenced in each expression spec.
   // This is where the first atom will be located.
   size_t atomsPointer = tensorLength + 1;
   for (const auto& expression : expressions) {
-    tensorLength += expression.atoms.size();
-  }
-
-  // Finally, destroyer events.
-  // This is where the first list of destroyer events is located.
-  size_t destroyerPointer = tensorLength + 1;
-  for (const auto& expression : expressions) {
-    tensorLength += expression.destroyerEvents.size();
+    tensorLength += expression.size();
   }
 
   const mint dimensions[1] = {static_cast<mint>(tensorLength)};
@@ -136,29 +128,70 @@ MTensor putSet(const std::vector<SetExpression>& expressions, WolframLibraryData
 
   appendToTensor({static_cast<mint>(expressions.size())});
   for (const auto& expression : expressions) {
-    appendToTensor({static_cast<mint>(expression.creatorEvent),
-                    static_cast<mint>(destroyerPointer),
-                    static_cast<mint>(expression.generation),
-                    static_cast<mint>(atomsPointer)});
-    atomsPointer += expression.atoms.size();
-    destroyerPointer += expression.destroyerEvents.size();
+    appendToTensor({static_cast<mint>(atomsPointer)});
+    atomsPointer += expression.size();
   }
-
-  // Put fake event at the end so that the length of final expression can be determined on WL side.
-  constexpr EventID fakeEvent = -3;
-  constexpr Generation fakeGeneration = -1;
-  appendToTensor({static_cast<mint>(fakeEvent),
-                  static_cast<mint>(destroyerPointer),
-                  static_cast<mint>(fakeGeneration),
-                  static_cast<mint>(atomsPointer)});
+  appendToTensor({static_cast<mint>(atomsPointer)});
 
   for (const auto& expression : expressions) {
     // Cannot do static_cast due to 32-bit Windows support
-    appendToTensor(std::vector<mint>(expression.atoms.begin(), expression.atoms.end()));
+    appendToTensor(std::vector<mint>(expression.begin(), expression.end()));
   }
 
-  for (const auto& expression : expressions) {
-    appendToTensor(expression.destroyerEvents);
+  return output;
+}
+
+MTensor putEvents(const std::vector<Event>& events, WolframLibraryData libData) {
+  // ruleID + input expressions pointer + output expressions pointer + generation
+  // add fake rule ID and generation at the end to specify the length of the last expression
+  size_t tensorLength = 1 + 4 * (events.size() + 1);
+
+  size_t inputsPointer = tensorLength + 1;
+  size_t outputsPointer = tensorLength + 1;
+  for (const auto& event : events) {
+    tensorLength += event.inputExpressions.size() + event.outputExpressions.size();
+    outputsPointer += event.inputExpressions.size();
+  }
+
+  const mint dimensions[1] = {static_cast<mint>(tensorLength)};
+  MTensor output;
+  libData->MTensor_new(MType_Integer, 1, dimensions, &output);
+
+  mint writeIndex = 0;
+  mint position[1];
+  const auto appendToTensor = [libData, &writeIndex, &position, &output](const std::vector<mint>& numbers) {
+    for (const auto number : numbers) {
+      position[0] = ++writeIndex;
+      libData->MTensor_setInteger(output, position, number);
+    }
+  };
+
+  appendToTensor({static_cast<mint>(events.size())});
+  for (const auto& event : events) {
+    appendToTensor({static_cast<mint>(event.rule),
+      static_cast<mint>(inputsPointer),
+      static_cast<mint>(outputsPointer),
+      static_cast<mint>(event.generation)});
+    inputsPointer += event.inputExpressions.size();
+    outputsPointer += event.outputExpressions.size();
+  }
+
+  // Put fake event at the end so that the length of final expression can be determined on WL side.
+  constexpr ExpressionID fakeRule = -2;
+  constexpr Generation fakeGeneration = -1;
+  appendToTensor({static_cast<mint>(fakeRule),
+    static_cast<mint>(inputsPointer),
+    static_cast<mint>(outputsPointer),
+    static_cast<mint>(fakeGeneration)});
+
+  for (const auto& event : events) {
+    // Cannot do static_cast due to 32-bit Windows support
+    appendToTensor(event.inputExpressions);
+    outputsPointer += event.inputExpressions.size();
+  }
+
+  for (const auto& event : events) {
+    appendToTensor(event.outputExpressions);
   }
 
   return output;
@@ -260,7 +293,7 @@ int setExpressions(WolframLibraryData libData, mint argc, MArgument* argv, MArgu
 
   const SetID setID = MArgument_getInteger(argv[0]);
 
-  std::vector<SetExpression> expressions;
+  std::vector<AtomsVector> expressions;
   try {
     expressions = setFromID(setID).expressions();
   } catch (...) {
@@ -268,6 +301,25 @@ int setExpressions(WolframLibraryData libData, mint argc, MArgument* argv, MArgu
   }
 
   MArgument_setMTensor(result, putSet(expressions, libData));
+
+  return LIBRARY_NO_ERROR;
+}
+
+int setEvents(WolframLibraryData libData, mint argc, MArgument* argv, MArgument result) {
+  if (argc != 1) {
+    return LIBRARY_FUNCTION_ERROR;
+  }
+
+  const SetID setID = MArgument_getInteger(argv[0]);
+
+  std::vector<Event> events;
+  try {
+    events = setFromID(setID).events();
+  } catch (...) {
+    return LIBRARY_FUNCTION_ERROR;
+  }
+
+  MArgument_setMTensor(result, putEvents(events, libData));
 
   return LIBRARY_NO_ERROR;
 }
@@ -309,34 +361,6 @@ int terminationReason([[maybe_unused]] WolframLibraryData, mint argc, MArgument*
 
   return LIBRARY_NO_ERROR;
 }
-
-int eventRuleIDs(WolframLibraryData libData, mint argc, MArgument* argv, MArgument result) {
-  if (argc != 1) {
-    return LIBRARY_FUNCTION_ERROR;
-  }
-
-  const SetID setID = MArgument_getInteger(argv[0]);
-
-  try {
-    const auto ruleIDs = setFromID(setID).eventRuleIDs();
-    const mint dimensions[1] = {static_cast<mint>(ruleIDs.size() - 1)};
-    MTensor output;
-    libData->MTensor_new(MType_Integer, 1, dimensions, &output);
-
-    mint writeIndex = 0;
-    mint position[1];
-    for (size_t event = 1; event < ruleIDs.size(); ++event) {
-      position[0] = ++writeIndex;
-      libData->MTensor_setInteger(output, position, static_cast<mint>(ruleIDs[event]) + 1);
-    }
-
-    MArgument_setMTensor(result, output);
-  } catch (...) {
-    return LIBRARY_FUNCTION_ERROR;
-  }
-
-  return LIBRARY_NO_ERROR;
-}
 }  // namespace SetReplace
 
 EXTERN_C mint WolframLibrary_getVersion() { return WolframLibraryVersion; }
@@ -361,14 +385,14 @@ EXTERN_C int setExpressions(WolframLibraryData libData, mint argc, MArgument* ar
   return SetReplace::setExpressions(libData, argc, argv, result);
 }
 
+EXTERN_C int setEvents(WolframLibraryData libData, mint argc, MArgument* argv, MArgument result) {
+  return SetReplace::setEvents(libData, argc, argv, result);
+}
+
 EXTERN_C int maxCompleteGeneration(WolframLibraryData libData, mint argc, MArgument* argv, MArgument result) {
   return SetReplace::maxCompleteGeneration(libData, argc, argv, result);
 }
 
 EXTERN_C int terminationReason(WolframLibraryData libData, mint argc, MArgument* argv, MArgument result) {
   return SetReplace::terminationReason(libData, argc, argv, result);
-}
-
-EXTERN_C int eventRuleIDs(WolframLibraryData libData, mint argc, MArgument* argv, MArgument result) {
-  return SetReplace::eventRuleIDs(libData, argc, argv, result);
 }

--- a/libSetReplace/SetReplace.cpp
+++ b/libSetReplace/SetReplace.cpp
@@ -165,7 +165,7 @@ MTensor putSet(const std::vector<SetExpression>& expressions, WolframLibraryData
 }
 
 int setCreate(WolframLibraryData libData, mint argc, const MArgument* argv, MArgument result) {
-  if (argc != 4) {
+  if (argc != 5) {
     return LIBRARY_FUNCTION_ERROR;
   }
 

--- a/libSetReplace/SetReplace.cpp
+++ b/libSetReplace/SetReplace.cpp
@@ -169,9 +169,9 @@ MTensor putEvents(const std::vector<Event>& events, WolframLibraryData libData) 
   appendToTensor({static_cast<mint>(events.size())});
   for (const auto& event : events) {
     appendToTensor({static_cast<mint>(event.rule),
-      static_cast<mint>(inputsPointer),
-      static_cast<mint>(outputsPointer),
-      static_cast<mint>(event.generation)});
+                    static_cast<mint>(inputsPointer),
+                    static_cast<mint>(outputsPointer),
+                    static_cast<mint>(event.generation)});
     inputsPointer += event.inputExpressions.size();
     outputsPointer += event.outputExpressions.size();
   }
@@ -180,9 +180,9 @@ MTensor putEvents(const std::vector<Event>& events, WolframLibraryData libData) 
   constexpr ExpressionID fakeRule = -2;
   constexpr Generation fakeGeneration = -1;
   appendToTensor({static_cast<mint>(fakeRule),
-    static_cast<mint>(inputsPointer),
-    static_cast<mint>(outputsPointer),
-    static_cast<mint>(fakeGeneration)});
+                  static_cast<mint>(inputsPointer),
+                  static_cast<mint>(outputsPointer),
+                  static_cast<mint>(fakeGeneration)});
 
   for (const auto& event : events) {
     // Cannot do static_cast due to 32-bit Windows support

--- a/libSetReplace/SetReplace.cpp
+++ b/libSetReplace/SetReplace.cpp
@@ -312,14 +312,12 @@ int setEvents(WolframLibraryData libData, mint argc, MArgument* argv, MArgument 
 
   const SetID setID = MArgument_getInteger(argv[0]);
 
-  std::vector<Event> events;
   try {
-    events = setFromID(setID).events();
+    const auto& events = setFromID(setID).events();
+    MArgument_setMTensor(result, putEvents(events, libData));
   } catch (...) {
     return LIBRARY_FUNCTION_ERROR;
   }
-
-  MArgument_setMTensor(result, putEvents(events, libData));
 
   return LIBRARY_NO_ERROR;
 }

--- a/libSetReplace/SetReplace.hpp
+++ b/libSetReplace/SetReplace.hpp
@@ -29,6 +29,10 @@ EXTERN_C DLLEXPORT int setReplace(WolframLibraryData libData, mint argc, MArgume
  */
 EXTERN_C DLLEXPORT int setExpressions(WolframLibraryData libData, mint argc, MArgument* argv, MArgument result);
 
+/** @brief Returns the list of events for a specified set pointer.
+ */
+EXTERN_C DLLEXPORT int setEvents(WolframLibraryData libData, mint argc, MArgument* argv, MArgument result);
+
 /** @brief Returns the largest generation that has both been reached, and has no matches that would produce expressions
  * with that or lower generation.
  * @details Is abortable, in which case returns LIBRARY_FUNCTION_ERROR.
@@ -38,9 +42,5 @@ EXTERN_C DLLEXPORT int maxCompleteGeneration(WolframLibraryData libData, mint ar
 /** @brief Returns a number corresponding to the termination reason.
  */
 EXTERN_C DLLEXPORT int terminationReason(WolframLibraryData libData, mint argc, MArgument* argv, MArgument result);
-
-/** @brief Returns the list of indices of rules used for each event.
- */
-EXTERN_C DLLEXPORT int eventRuleIDs(WolframLibraryData libData, mint argc, MArgument* argv, MArgument result);
 
 #endif  // LIBSETREPLACE_SETREPLACE_HPP_

--- a/libSetReplace/test/Set_test.cpp
+++ b/libSetReplace/test/Set_test.cpp
@@ -18,10 +18,10 @@ Set testSet(const Set::EventSelectionFunction eventSelectionFunction) {
   std::vector<AtomsVector> initialExpressions = {{1}, {1, 2}, {3}, {3, 4}, {2, 5}, {4, 5}, {5, 6}};
 
   Matcher::OrderingSpec orderingSpec = {
-    {Matcher::OrderingFunction::SortedExpressionIDs, Matcher::OrderingDirection::Normal},
-    {Matcher::OrderingFunction::ReverseSortedExpressionIDs, Matcher::OrderingDirection::Normal},
-    {Matcher::OrderingFunction::ExpressionIDs, Matcher::OrderingDirection::Normal},
-    {Matcher::OrderingFunction::RuleIndex, Matcher::OrderingDirection::Normal}};
+      {Matcher::OrderingFunction::SortedExpressionIDs, Matcher::OrderingDirection::Normal},
+      {Matcher::OrderingFunction::ReverseSortedExpressionIDs, Matcher::OrderingDirection::Normal},
+      {Matcher::OrderingFunction::ExpressionIDs, Matcher::OrderingDirection::Normal},
+      {Matcher::OrderingFunction::RuleIndex, Matcher::OrderingDirection::Normal}};
   unsigned int randomSeed = 0;
   return Set(rules, initialExpressions, eventSelectionFunction, orderingSpec, randomSeed);
 }
@@ -44,13 +44,16 @@ TEST(Set, globalSpacelike) {
 
   EXPECT_EQ(aSet.replace(Set::StepSpecification(), doNotAbort), 3);
   // in the global spacelike case, only one of the {5}'s can make it to {6} because there is only one {5, 6} to use.
-  EXPECT_EQ(aSet.expressions(), (std::vector<AtomsVector>{{1}, {1, 2}, {3}, {3, 4}, {2, 5}, {4, 5}, {5, 6}, {2}, {4}, {5}, {5}, {6}}));}
+  EXPECT_EQ(aSet.expressions(),
+            (std::vector<AtomsVector>{{1}, {1, 2}, {3}, {3, 4}, {2, 5}, {4, 5}, {5, 6}, {2}, {4}, {5}, {5}, {6}}));
+}
 
 TEST(Set, matchAllMultiway) {
   Set aSet = testSet(Set::EventSelectionFunction::None);
   // Unlike the global spacelike case, the edge {5, 6} can now be used twice, so there is an extra event
   EXPECT_EQ(aSet.replace(Set::StepSpecification(), doNotAbort), 6);
   // and two {6}'s in the list of expressions
-  EXPECT_EQ(aSet.expressions(), (std::vector<AtomsVector>{{1}, {1, 2}, {3}, {3, 4}, {2, 5}, {4, 5}, {5, 6}, {2}, {4}, {5}, {5}, {6}, {6}}));
+  EXPECT_EQ(aSet.expressions(),
+            (std::vector<AtomsVector>{{1}, {1, 2}, {3}, {3, 4}, {2, 5}, {4, 5}, {5, 6}, {2}, {4}, {5}, {5}, {6}, {6}}));
 }
 }  // namespace SetReplace

--- a/libSetReplace/test/Set_test.cpp
+++ b/libSetReplace/test/Set_test.cpp
@@ -8,29 +8,49 @@
 #include "Rule.hpp"
 
 namespace SetReplace {
-TEST(SetReplace, createSetAndReplace) {
+Set testSet(const Set::EventSelectionFunction eventSelectionFunction) {
   // Negative atoms refer to patterns (useful for rules)
   std::vector<Rule> rules;
-  auto a_rule = Rule({{{-1, -2}, {-2, -3}}, {{-1, -3}, {-4, -2}, {-1, -4}}});
-  rules.push_back(a_rule);
+  auto aRule = Rule({{{-1}, {-1, -2}}, {{-2}}});
+  rules.push_back(aRule);
 
-  std::vector<AtomsVector> initialExpressions = {{1, 2}, {2, 3}};
+  // make two "particles" {1} and {3} which will traverse the graph deleting edges in their path
+  std::vector<AtomsVector> initialExpressions = {{1}, {1, 2}, {3}, {3, 4}, {2, 5}, {4, 5}, {5, 6}};
 
   Matcher::OrderingSpec orderingSpec = {
-      {Matcher::OrderingFunction::SortedExpressionIDs, Matcher::OrderingDirection::Normal},
-      {Matcher::OrderingFunction::ReverseSortedExpressionIDs, Matcher::OrderingDirection::Normal},
-      {Matcher::OrderingFunction::ExpressionIDs, Matcher::OrderingDirection::Normal},
-      {Matcher::OrderingFunction::RuleIndex, Matcher::OrderingDirection::Normal}};
+    {Matcher::OrderingFunction::SortedExpressionIDs, Matcher::OrderingDirection::Normal},
+    {Matcher::OrderingFunction::ReverseSortedExpressionIDs, Matcher::OrderingDirection::Normal},
+    {Matcher::OrderingFunction::ExpressionIDs, Matcher::OrderingDirection::Normal},
+    {Matcher::OrderingFunction::RuleIndex, Matcher::OrderingDirection::Normal}};
   unsigned int randomSeed = 0;
-  auto a_set = Set(rules, initialExpressions, orderingSpec, randomSeed);
+  return Set(rules, initialExpressions, eventSelectionFunction, orderingSpec, randomSeed);
+}
 
-  auto shouldAbort = []() { return false; };
+constexpr auto doNotAbort = []() { return false; };
+
+TEST(Set, globalSpacelike) {
+  Set aSet = testSet(Set::EventSelectionFunction::GlobalSpacelike);
   Set::StepSpecification stepSpec;
-  stepSpec.maxEvents = 10;
-  stepSpec.maxGenerationsLocal = 100;
-  stepSpec.maxFinalAtoms = 100000;
-  stepSpec.maxFinalAtomDegree = 100000;
-  stepSpec.maxFinalExpressions = 100000;
-  EXPECT_TRUE(a_set.replace(stepSpec, shouldAbort));
+  stepSpec.maxEvents = 2;
+  EXPECT_EQ(aSet.replace(stepSpec, doNotAbort), 2);
+  EXPECT_EQ(aSet.maxCompleteGeneration(doNotAbort), 1);
+  EXPECT_EQ(aSet.terminationReason(), Set::TerminationReason::MaxEvents);
+  EXPECT_EQ(aSet.expressions(), (std::vector<AtomsVector>{{1}, {1, 2}, {3}, {3, 4}, {2, 5}, {4, 5}, {5, 6}, {2}, {4}}));
+
+  EXPECT_EQ(aSet.events()[1].generation, 1);
+  EXPECT_EQ(aSet.events()[1].inputExpressions, (std::vector<ExpressionID>{2, 3}));
+  EXPECT_EQ(aSet.events()[1].outputExpressions, (std::vector<ExpressionID>{8}));
+  EXPECT_EQ(aSet.events()[1].rule, 0);
+
+  EXPECT_EQ(aSet.replace(Set::StepSpecification(), doNotAbort), 3);
+  // in the global spacelike case, only one of the {5}'s can make it to {6} because there is only one {5, 6} to use.
+  EXPECT_EQ(aSet.expressions(), (std::vector<AtomsVector>{{1}, {1, 2}, {3}, {3, 4}, {2, 5}, {4, 5}, {5, 6}, {2}, {4}, {5}, {5}, {6}}));}
+
+TEST(Set, matchAllMultiway) {
+  Set aSet = testSet(Set::EventSelectionFunction::None);
+  // Unlike the global spacelike case, the edge {5, 6} can now be used twice, so there is an extra event
+  EXPECT_EQ(aSet.replace(Set::StepSpecification(), doNotAbort), 6);
+  // and two {6}'s in the list of expressions
+  EXPECT_EQ(aSet.expressions(), (std::vector<AtomsVector>{{1}, {1, 2}, {3}, {3, 4}, {2, 5}, {4, 5}, {5, 6}, {2}, {4}, {5}, {5}, {6}, {6}}));
 }
 }  // namespace SetReplace

--- a/libSetReplace/test/Set_test.cpp
+++ b/libSetReplace/test/Set_test.cpp
@@ -37,10 +37,10 @@ TEST(Set, globalSpacelike) {
   EXPECT_EQ(aSet.terminationReason(), Set::TerminationReason::MaxEvents);
   EXPECT_EQ(aSet.expressions(), (std::vector<AtomsVector>{{1}, {1, 2}, {3}, {3, 4}, {2, 5}, {4, 5}, {5, 6}, {2}, {4}}));
 
-  EXPECT_EQ(aSet.events()[1].generation, 1);
-  EXPECT_EQ(aSet.events()[1].inputExpressions, (std::vector<ExpressionID>{2, 3}));
-  EXPECT_EQ(aSet.events()[1].outputExpressions, (std::vector<ExpressionID>{8}));
-  EXPECT_EQ(aSet.events()[1].rule, 0);
+  EXPECT_EQ(aSet.events()[2].generation, 1);
+  EXPECT_EQ(aSet.events()[2].inputExpressions, (std::vector<ExpressionID>{2, 3}));
+  EXPECT_EQ(aSet.events()[2].outputExpressions, (std::vector<ExpressionID>{8}));
+  EXPECT_EQ(aSet.events()[2].rule, 0);
 
   EXPECT_EQ(aSet.replace(Set::StepSpecification(), doNotAbort), 3);
   // in the global spacelike case, only one of the {5}'s can make it to {6} because there is only one {5, 6} to use.


### PR DESCRIPTION
## Changes
* Partially implements #335.
* Adds `EventSelectionFunction` to `libSetReplace`. Two are supported at the moment:
  * `GlobalSpacelike`: default singleway evolution;
  * `None`: match-all multiway system.
* `libSetReplace` fully supports both now, however, WL code always calls `GlobalSpacelike` (for now).
* Refactors the causal relationships tracking in `libSetReplace`. Specifically, the evolution history is now events-based instead of expressions-based, and is tracked by the `CausalGraph` class outside of `Set`:
  * In my opinion, this is a better approach. Besides addressing the performance problem which would otherwise arise from tracking multiple destroyer events, it lets us fix #372, and makes it easier to deal with things like partially empty events.
  * Currently, there is nothing algorithmically complex in it, but eventually, it will track the spacelike/branchlike/timelike relationships between edges/events, which is quite complicated, and will require a nontrivial data structure.
  * WL code still uses expressions-based structure for the evolution object, and [converts](https://github.com/maxitg/SetReplace/blob/ba7803bc9ff9a339631860678e63c8e288cebbb6/Kernel/setSubstitutionSystem%24cpp.m#L163) to it immediately after receiving the object from `libSetReplace`. That will be changed in a future PR.
* Note, this ***breaks the API of `libSetReplace`***. Constructor for `Set` and `SetExpression` members are changed. Not marked as breaking in the PR because it does not break the Wolfram Language API.

## Comments
* The only part that is not pure refactoring is [here](https://github.com/maxitg/SetReplace/blob/ba7803bc9ff9a339631860678e63c8e288cebbb6/libSetReplace/Set.cpp#L109), but it's not currently accessible from WL.
* `None` event selection function only deletes the match that was used but leaves all the input expressions in the set, allowing them to be matched again.
* Tests will be implemented in a future PR (in Wolfram Language).
* There is a slight dip in performance for simple-to-match rules, but it is caused by [`decodeExpressions`](https://github.com/maxitg/SetReplace/blob/ba7803bc9ff9a339631860678e63c8e288cebbb6/Kernel/setSubstitutionSystem%24cpp.m#L163), the function that converts the evolution object from events- to expressions-based representation. Since this function will be removed in a future PR, this performance dip is temporary.

## Examples
* No examples yet because no functionality is changed in the Wolfram Language. There are examples using slightly different code but implementing the same system [here](https://github.com/maxitg/SetReplace/blob/localMultiwayProposal/Research/LocalMultiwaySystem/LocalMultiwaySystem.md).
* Performance results:
```
Single-input rule                       -19.8 ± 2.6 %
Medium rule                             -5.0 ± 0.8 %
Sequential rule                         -4.9 ± 1.2 %
Large rule                              -0.4 ± 0.4 %
Exponential-match-count rule            -0.8 ± 1.7 %
CA emulator                             -1.0 ± 1.4 %
```
* Disabling `decodeExpressions` 98f7a15b03cca65e3e0135ed8255453cd6d4f5f3 we get:
```
Single-input rule                       -9. ± 4. %
Medium rule                             0.2 ± 1.0 %
Sequential rule                         -1.3 ± 1.1 %
Large rule                              -0.04 ± 0.30 %
Exponential-match-count rule            0.9 ± 0.8 %
CA emulator                             0.3 ± 1.7 %
```
* Run `gtest`:
```
➜  mkdir build && cd build && cmake .. -DSET_REPLACE_BUILD_TESTING=YES && make && make test
Running tests...
Test project /Users/maxitg/Development/SetReplace/build
    Start 1: Set.globalSpacelike
1/2 Test #1: Set.globalSpacelike ..............   Passed    0.00 sec
    Start 2: Set.matchAllMultiway
2/2 Test #2: Set.matchAllMultiway .............   Passed    0.00 sec

100% tests passed, 0 tests failed out of 2

Total Test time (real) =   0.01 sec
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/368)
<!-- Reviewable:end -->
