### PR TITLE
Fix macOS compilation for std::shared_mutex

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ You only need three things to use **SetReplace**:
 
 * Windows, macOS 10.12+, or Linux.
 * [Wolfram Language 12.1+](https://www.wolfram.com/language/) including [WolframScript](https://www.wolfram.com/wolframscript/). A free version is available as [Wolfram Engine](https://www.wolfram.com/engine/).
-* A C++ compiler to build the low-level part of the package. Instructions on how to set up a compiler to use in WolframScript are [here](https://reference.wolfram.com/language/CCompilerDriver/tutorial/SpecificCompilers.html#509267359).
+* A C++17 compiler to build the low-level part of the package. Instructions on how to set up a compiler to use in WolframScript are [here](https://reference.wolfram.com/language/CCompilerDriver/tutorial/SpecificCompilers.html#509267359).
 
 ## Build Instructions
 

--- a/README.md
+++ b/README.md
@@ -94,8 +94,9 @@ Exploring the hypergraph models of this variety is the primary purpose of this p
 
 ## Dependencies
 
-You only need two things to use **SetReplace**:
+You only need three things to use **SetReplace**:
 
+* Windows, macOS 10.12+, or Linux.
 * [Wolfram Language 12.1+](https://www.wolfram.com/language/) including [WolframScript](https://www.wolfram.com/wolframscript/). A free version is available as [Wolfram Engine](https://www.wolfram.com/engine/).
 * A C++ compiler to build the low-level part of the package. Instructions on how to set up a compiler to use in WolframScript are [here](https://reference.wolfram.com/language/CCompilerDriver/tutorial/SpecificCompilers.html#509267359).
 

--- a/scripts/buildInit.wl
+++ b/scripts/buildInit.wl
@@ -19,6 +19,12 @@ tryEnvironment[var_, default_] := If[# === $Failed, default, #] & @ Environment[
 
 buildLibSetReplace::fail = "Compilation failed. Paclet will be created without low level implementation.";
 
+$warningsFlags = {
+  "-Wall", "-Wextra", "-Werror", "-pedantic", "-Wcast-align", "-Wcast-qual", "-Wctor-dtor-privacy",
+  "-Wdisabled-optimization", "-Wformat=2", "-Winit-self", "-Wmissing-include-dirs", "-Wold-style-cast",
+  "-Woverloaded-virtual", "-Wredundant-decls", "-Wshadow", "-Wsign-promo", "-Wswitch-default", "-Wundef",
+  "-Wno-unused"};
+
 buildLibSetReplace[] := With[{
     libSetReplaceSource = FileNameJoin[{$repoRoot, "libSetReplace"}],
     systemID = If[$internalBuildQ, AntProperty["system_id"], $SystemID]},
@@ -30,11 +36,10 @@ buildLibSetReplace[] := With[{
       "CompileOptions" -> Switch[$OperatingSystem,
         "Windows",
           {"/std:c++17", "/EHsc"},
-        _,
-          {"-std=c++17", "-Wall", "-Wextra", "-Werror", "-pedantic", "-Wcast-align", "-Wcast-qual",
-           "-Wctor-dtor-privacy", "-Wdisabled-optimization", "-Wformat=2", "-Winit-self", "-Wmissing-include-dirs",
-           "-Wold-style-cast", "-Woverloaded-virtual", "-Wredundant-decls", "-Wshadow", "-Wsign-promo",
-           "-Wswitch-default", "-Wundef", "-Wno-unused"}],
+        "MacOSX",
+          Join[{"-std=c++17"}, $warningsFlags, {"-mmacosx-version-min=10.12"}],
+        "Unix",
+          Join[{"-std=c++17"}, $warningsFlags]],
       "Compiler" -> ToExpression @ tryEnvironment["COMPILER", Automatic],
       "CompilerInstallation" -> tryEnvironment["COMPILER_INSTALLATION", Automatic],
       "Language" -> "C++",

--- a/scripts/buildInit.wl
+++ b/scripts/buildInit.wl
@@ -37,7 +37,7 @@ buildLibSetReplace[] := With[{
         "Windows",
           {"/std:c++17", "/EHsc"},
         "MacOSX",
-          Join[{"-std=c++17"}, $warningsFlags, {"-mmacosx-version-min=10.12"}],
+          Join[{"-std=c++17"}, $warningsFlags, {"-mmacosx-version-min=10.12"}], (* for std::shared_mutex support *)
         "Unix",
           Join[{"-std=c++17"}, $warningsFlags]],
       "Compiler" -> ToExpression @ tryEnvironment["COMPILER", Automatic],


### PR DESCRIPTION
## Changes
* Fixes failing compilation on Mac introduced in #364.
* The minimum macOS target is now 10.12 (the previous ones don't support `std::shared_mutex`).

## Review Comments
* I'm aware you might not have macOS, but I don't know where to find a reviewer who does.

## Examples
* Before:
```
➜  SetReplace git:(master) ./build.wls  

CreateLibrary::cmperr: Compile error:
  /Users/maxitg/Development/SetReplace/libSetReplace/Match.cpp:165:16: error:
  'shared_mutex' is unavailable: introduced in macOS 10.12

buildLibSetReplace::fail: Compilation failed.
  Paclet will be created without low level implementation.
Build failed.
```
* After:
```
➜  SetReplace git:(fixMacSharedMutex) ./build.wls 
Build done.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/370)
<!-- Reviewable:end -->
