### PR TITLE
Fix test header formatting

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -6,5 +6,18 @@ BinPackArguments: false
 BinPackParameters: false
 ColumnLimit: 120
 DerivePointerAlignment: false
+IncludeCategories:
+  - Regex:           '^<ext/.*\.h>'
+    Priority:        2
+    SortPriority:    0
+  - Regex:           '^<.*\.h>'
+    Priority:        2
+    SortPriority:    0
+  - Regex:           '^<.*'
+    Priority:        1
+    SortPriority:    0
+  - Regex:           '.*'
+    Priority:        3
+    SortPriority:    0
 Standard: c++17
 ...

--- a/libSetReplace/test/Set_test.cpp
+++ b/libSetReplace/test/Set_test.cpp
@@ -1,8 +1,8 @@
 #include "Set.hpp"
 
-#include <gtest/gtest.h>
-
 #include <vector>
+
+#include <gtest/gtest.h>
 
 #include "Match.hpp"
 #include "Rule.hpp"


### PR DESCRIPTION
## Changes
* Changes the order of headers in `Set_test.cpp`, so that `cpplint` does not fail an Mac.
* Adds the corresponding rules to `.clang-format` (taken from #357).

## Comments
* Apparently, the difference is due to version 1.5.0 that was released 4 days ago. Updating the CI now.

## Examples
* Before:
```
➜  SetReplace git:(master) ./lint.sh
libSetReplace/test/Set_test.cpp:5:  Found C++ system header after other system header.
  Should be: Set_test.h, c system, c++ system, other.  [build/include_order] [4]
Done processing libSetReplace/test/Set_test.cpp
Total errors found: 1
```
* After:
```
➜  SetReplace git:(fixTestHeaderOrder) ./lint.sh
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/373)
<!-- Reviewable:end -->
