### PR TITLE
Fix Xcode project

### DIFF
--- a/SetReplace.xcodeproj/project.pbxproj
+++ b/SetReplace.xcodeproj/project.pbxproj
@@ -286,12 +286,16 @@
 		69CAF86A2257B062006F9C60 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 4FZCW36HH2;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				EXECUTABLE_PREFIX = lib;
-				HEADER_SEARCH_PATHS = "/Applications/Wolfram\\ Desktop.app/Contents/SystemFiles/IncludeFiles/C";
+				HEADER_SEARCH_PATHS = (
+					"/Applications/Wolfram\\ Desktop.app/Contents/SystemFiles/IncludeFiles/C",
+					/Applications/Mathematica.app/Contents/SystemFiles/IncludeFiles/C,
+				);
 				LIBRARY_SEARCH_PATHS = "";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -301,12 +305,16 @@
 		69CAF86B2257B062006F9C60 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 4FZCW36HH2;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				EXECUTABLE_PREFIX = lib;
-				HEADER_SEARCH_PATHS = "/Applications/Wolfram\\ Desktop.app/Contents/SystemFiles/IncludeFiles/C";
+				HEADER_SEARCH_PATHS = (
+					"/Applications/Wolfram\\ Desktop.app/Contents/SystemFiles/IncludeFiles/C",
+					/Applications/Mathematica.app/Contents/SystemFiles/IncludeFiles/C,
+				);
 				LIBRARY_SEARCH_PATHS = "";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;


### PR DESCRIPTION
## Changes
* Resolves #369.
* Removes "Development Team" from the Xcode project, so that it can now be immediately compiled by anyone.
* Changes C++ dialect to gnu++17 from gnu++14 (it does not compile otherwise).
* Adds Mathematica.app to the headers search path.

## Comments
* Not sure if anyone is using Xcode except for me, I'll leave this open for now. If there are no reviews until Friday night, I'll just merge it myself.
* If you see this and are using Xcode, please either review or leave a comment if you don't have access.

## Examples
<img width="521" alt="Screen Shot 2020-06-04 at 4 34 41 PM" src="https://user-images.githubusercontent.com/1479325/83807564-4b261380-a681-11ea-95cf-e9365bdfe4df.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/374)
<!-- Reviewable:end -->
