### PR TITLE
Reduce Copying in getAtomsVector

### DIFF
--- a/libSetReplace/Expression.cpp
+++ b/libSetReplace/Expression.cpp
@@ -10,12 +10,11 @@
 namespace SetReplace {
 class AtomsIndex::Implementation {
  private:
-  const std::function<AtomsVector(ExpressionID)> getAtomsVector_;
+  const GetAtomsVectorFunc getAtomsVector_;
   std::unordered_map<Atom, std::unordered_set<ExpressionID>> index_;
 
  public:
-  explicit Implementation(std::function<AtomsVector(ExpressionID)> getAtomsVector)
-      : getAtomsVector_(std::move(getAtomsVector)) {}
+  explicit Implementation(GetAtomsVectorFunc getAtomsVector) : getAtomsVector_(std::move(getAtomsVector)) {}
 
   void removeExpressions(const std::vector<ExpressionID>& expressionIDs) {
     const std::unordered_set<ExpressionID> expressionsToDelete(expressionIDs.begin(), expressionIDs.end());
@@ -57,7 +56,7 @@ class AtomsIndex::Implementation {
   }
 };
 
-AtomsIndex::AtomsIndex(const std::function<AtomsVector(ExpressionID)>& getAtomsVector)
+AtomsIndex::AtomsIndex(const GetAtomsVectorFunc& getAtomsVector)
     : implementation_(std::make_shared<Implementation>(getAtomsVector)) {}
 
 void AtomsIndex::removeExpressions(const std::vector<ExpressionID>& expressionIDs) {

--- a/libSetReplace/Expression.hpp
+++ b/libSetReplace/Expression.hpp
@@ -13,6 +13,10 @@ namespace SetReplace {
  */
 using AtomsVector = std::vector<Atom>;
 
+/** @brief Function type used to get an expression's corresponding AtomsVector.
+ */
+using GetAtomsVectorFunc = std::function<const AtomsVector&(const ExpressionID&)>;
+
 /** @brief AtomsIndex keeps references to set expressions accessible by atoms, which is useful for matching.
  */
 class AtomsIndex {
@@ -20,7 +24,7 @@ class AtomsIndex {
   /** @brief Creates an empty index.
    * @param getAtomsVector datasource function that returns the list of atoms for a requested expression.
    */
-  explicit AtomsIndex(const std::function<AtomsVector(ExpressionID)>& getAtomsVector);
+  explicit AtomsIndex(const GetAtomsVectorFunc& getAtomsVector);
 
   /** @brief Removes expressions with specified IDs from the index.
    */

--- a/libSetReplace/Match.cpp
+++ b/libSetReplace/Match.cpp
@@ -133,7 +133,7 @@ class Matcher::Implementation {
  private:
   const std::vector<Rule>& rules_;
   AtomsIndex& atomsIndex_;
-  const std::function<AtomsVector(ExpressionID)> getAtomsVector_;
+  const GetAtomsVectorFunc getAtomsVector_;
 
   // Matches are arranged in buckets. Each bucket contains matches that are equivalent in terms of the ordering
   // function, however, buckets themselves are ordered according to that function.
@@ -173,7 +173,7 @@ class Matcher::Implementation {
  public:
   Implementation(const std::vector<Rule>& rules,
                  AtomsIndex* atomsIndex,
-                 std::function<AtomsVector(ExpressionID)> getAtomsVector,
+                 GetAtomsVectorFunc getAtomsVector,
                  const OrderingSpec& orderingSpec,
                  const unsigned int randomSeed)
       : rules_(rules),
@@ -471,7 +471,7 @@ class Matcher::Implementation {
 
 Matcher::Matcher(const std::vector<Rule>& rules,
                  AtomsIndex* atomsIndex,
-                 const std::function<AtomsVector(ExpressionID)>& getAtomsVector,
+                 const GetAtomsVectorFunc& getAtomsVector,
                  const OrderingSpec& orderingSpec,
                  const unsigned int randomSeed)
     : implementation_(std::make_shared<Implementation>(rules, atomsIndex, getAtomsVector, orderingSpec, randomSeed)) {}

--- a/libSetReplace/Match.hpp
+++ b/libSetReplace/Match.hpp
@@ -63,7 +63,7 @@ class Matcher {
    */
   Matcher(const std::vector<Rule>& rules,
           AtomsIndex* atomsIndex,
-          const std::function<AtomsVector(ExpressionID)>& getAtomsVector,
+          const GetAtomsVectorFunc& getAtomsVector,
           const OrderingSpec& orderingSpec,
           unsigned int randomSeed = 0);
 

--- a/libSetReplace/Set.cpp
+++ b/libSetReplace/Set.cpp
@@ -43,12 +43,13 @@ class Set::Implementation {
                  const EventSelectionFunction& eventSelectionFunction,
                  const Matcher::OrderingSpec& orderingSpec,
                  const unsigned int randomSeed)
-      : Implementation(rules,
-                       initialExpressions,
-                       eventSelectionFunction,
-                       orderingSpec,
-                       randomSeed,
-                       [this](const int64_t expressionID) { return expressions_.at(expressionID); }) {}
+      : Implementation(
+            rules,
+            initialExpressions,
+            eventSelectionFunction,
+            orderingSpec,
+            randomSeed,
+            [this](const int64_t& expressionID) -> const AtomsVector& { return expressions_.at(expressionID); }) {}
 
   int64_t replaceOnce(const std::function<bool()> shouldAbort) {
     terminationReason_ = TerminationReason::NotTerminated;
@@ -163,7 +164,7 @@ class Set::Implementation {
                  const EventSelectionFunction& eventSelectionFunction,
                  const Matcher::OrderingSpec& orderingSpec,
                  const unsigned int randomSeed,
-                 const std::function<AtomsVector(ExpressionID)>& getAtomsVector)
+                 const GetAtomsVectorFunc& getAtomsVector)
       : rules_(std::move(rules)),
         eventSelectionFunction_(eventSelectionFunction),
         causalGraph_(static_cast<int>(initialExpressions.size())),


### PR DESCRIPTION
## Changes
* Added typedef for getAtomsVector for easier usage.
* Changed signature of getAtomsVector to take in a const reference.
* Changed signature of getAtomsVector to return a const reference, to reduce forgo copying if used in a const reference context.

## Comments
* Only a performance refactor.

## Examples
```bash
./performanceTest.wls 10
Single-input rule                       0.33 ▒ 0.25 %
Medium rule                             -0.6 ▒ 0.5 %
Sequential rule                         -1.55 ▒ 0.28 %
Large rule                              -0.4 ▒ 1.1 %
Exponential-match-count rule            -0.63 ▒ 0.25 %
CA emulator                             9. ▒ 4. %
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/384)
<!-- Reviewable:end -->
