### PR TITLE
GenerationEdgeIndices

### DIFF
--- a/Kernel/WolframModelEvolutionObject.m
+++ b/Kernel/WolframModelEvolutionObject.m
@@ -136,6 +136,7 @@ $propertyArgumentCounts = Join[
 		"EventsStatesPlotsList" -> {0, Infinity},
 		"AllEventsStatesEdgeIndicesList" -> {0, 0},
 		"AllEventsStatesList" -> {0, 0},
+		"GenerationEdgeIndices" -> {1, 1},
 		"Generation" -> {1, 1},
 		"StateEdgeIndicesAfterEvent" -> {1, 1},
 		"StateAfterEvent" -> {1, 1},
@@ -593,6 +594,22 @@ propertyEvaluate[True, boundary : includeBoundaryEventsPattern][
 		Range[0, propertyEvaluate[True, None][WolframModelEvolutionObject[data], caller, "AllEventsCount"]]
 
 
+(* ::Subsection::  *)
+(*GenerationEdgeIndices*)
+
+
+propertyEvaluate[True, includeBoundaryEventsPattern][
+			obj : WolframModelEvolutionObject[data_ ? evolutionDataQ],
+			caller_,
+			"GenerationEdgeIndices",
+			g_] := Module[{positiveGeneration, eventsUpToGeneration},
+	positiveGeneration = toPositiveStep[
+		propertyEvaluate[True, None][obj, caller, "TotalGenerationsCount"], g, caller, "Generation"];
+	eventsUpToGeneration = First /@ Position[_ ? (# <= positiveGeneration &)] @ data[$eventGenerations] - 1;
+	stateEdgeIndicesAfterEvents[obj, caller, eventsUpToGeneration]
+]
+
+
 (* ::Subsection:: *)
 (*Generation*)
 
@@ -609,12 +626,7 @@ propertyEvaluate[True, includeBoundaryEventsPattern][
 			obj : WolframModelEvolutionObject[data_ ? evolutionDataQ],
 			caller_,
 			"Generation",
-			g_] := Module[{positiveGeneration, eventsUpToGeneration},
-	positiveGeneration = toPositiveStep[
-		propertyEvaluate[True, None][obj, caller, "TotalGenerationsCount"], g, caller, "Generation"];
-	eventsUpToGeneration = First /@ Position[_ ? (# <= positiveGeneration &)] @ data[$eventGenerations] - 1;
-	data[$atomLists][[stateEdgeIndicesAfterEvents[obj, caller, eventsUpToGeneration]]]
-]
+			g_] := data[$atomLists][[propertyEvaluate[True, None][obj, caller, "GenerationEdgeIndices", g]]]
 
 
 (* ::Subsubsection:: *)

--- a/README.md
+++ b/README.md
@@ -753,6 +753,18 @@ Out[] = {18, 19, 29, 34, 35, 36, 37, 39, 40, 42, 43, 44, 45, 49, 50, 51, 52,
   88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101}
 ```
 
+and **`"GenerationEdgeIndices"`** is an analog of [`"Generation"`](#states):
+
+```wl
+In[] := WolframModel[{{1, 2, 3}, {4, 5, 6}, {1, 4}} ->
+   {{2, 7, 8}, {3, 9, 10}, {5, 11, 12}, {6, 13, 14}, {8, 12}, {11,
+     10}, {13, 7}, {14, 9}},
+  {{1, 1, 1}, {1, 1, 1}, {1, 1}, {1, 1}, {1, 1}},
+  6]["GenerationEdgeIndices", 2]
+Out[] = {10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
+  27, 28, 29}
+```
+
 #### Events
 
 **`"AllEventsList"`** (aka `"EventsList"`) and **`"GenerationEventsList"`** both return all replacement events throughout the evolution. The only difference is how the events are arranged. `"AllEventsList"` returns the flat list of all events, whereas `"GenerationEventsList"` splits them into sublists for each generation:

--- a/Tests/WolframModelEvolutionObject.wlt
+++ b/Tests/WolframModelEvolutionObject.wlt
@@ -197,6 +197,16 @@
         SameTest -> MatchQ
       ],
 
+      VerificationTest[
+        WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4]["GenerationEdgeIndices", 5],
+        WolframModelEvolutionObject[___]["GenerationEdgeIndices", 5],
+        {WolframModelEvolutionObject::stepTooLarge},
+        SameTest -> MatchQ
+      ],
+
       (* IncludeBoundaryEvents *)
 
       With[{evo = WolframModel[{{1, 2}} -> {{1, 2}}, {{1, 1}}, 1]},
@@ -879,19 +889,56 @@
         WolframModel[{{{1, 2}, {2, 3}} -> {{1, 3}}, {{1, 2}, {1, 2}} -> {}},
                      {{1, 2}, {2, 3}, {3, 4}, {2, 5}},
                      Infinity,
-                     "EventSelectionFunction" -> None]["Generation", 0],
-        {{1, 2}, {2, 3}, {3, 4}, {2, 5}}
-      ],
+                     "EventSelectionFunction" -> None][#1, 0],
+        #2
+      ] & @@@ {{"Generation", {{1, 2}, {2, 3}, {3, 4}, {2, 5}}}, {"GenerationEdgeIndices", Range[4]}},
 
       With[{evolution = WolframModel[{{{1, 2}, {2, 3}} -> {{1, 3}}, {{1, 2}, {1, 2}} -> {}},
                                      {{1, 2}, {2, 3}, {3, 4}, {2, 5}},
                                      Infinity,
                                      "EventSelectionFunction" -> None]},
         testUnevaluated[
-          evolution["Generation", #],
+          evolution[#1, #2],
           {WolframModelEvolutionObject::multiwayState}
         ]
-      ] & /@ {1, 2, 3},
+      ] & @@@ Tuples[{{"Generation", "GenerationEdgeIndices"}, {1, 2, 3}}],
+
+      (* GenerationEdgeIndices *)
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4]["GenerationEdgeIndices", 0],
+        Range[Length[pathGraph17]]
+      ],
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4]["GenerationEdgeIndices", 1],
+        Range[Length[pathGraph17] + 1, Length[pathGraph17] + Length[pathGraph17] / 2]
+      ],
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4]["GenerationEdgeIndices", 3],
+        {29, 30}
+      ],
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4]["GenerationEdgeIndices", -2],
+        WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4]["GenerationEdgeIndices", 3]
+      ],
 
       (* StatesList *)
 


### PR DESCRIPTION
## Changes
* Adds `"GenerationEdgeIndices"` property which returns the list of edge indices at a particular generation (i.e., edge indices for the output of `"Generation"`).

## Examples
* Return edge indices:
```wl
In[] := WolframModel[{{1, 2, 3}, {4, 5, 6}, {1, 4}} -> {{2, 7, 8}, {3, 9, 
     10}, {5, 11, 12}, {6, 13, 14}, {8, 12}, {11, 10}, {13, 7}, {14, 
     9}}, {{1, 1, 1}, {1, 1, 1}, {1, 1}, {1, 1}, {1, 1}}, 
  6]["GenerationEdgeIndices", 2]
Out[] = {10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 
  27, 28, 29}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/385)
<!-- Reviewable:end -->
