### PR TITLE
Fix incorrect expression indexing if trimming incomplete generations

### DIFF
--- a/Kernel/WolframModelEvolutionObject.m
+++ b/Kernel/WolframModelEvolutionObject.m
@@ -241,15 +241,15 @@ deleteIncompleteGenerations[WolframModelEvolutionObject[data_]] := Module[{
 	eventIndicesToKeep = Position[data[$eventGenerations], _ ? (# <= maxCompleteGeneration &)][[All, 1]];
 	newEventOutputs = data[$eventOutputs][[eventIndicesToKeep]];
 	expressionIndicesToKeep = Union[Catenate[newEventOutputs]];
-	oldToNewExpressionIndices = Thread[expressionIndicesToKeep -> Range[Length[expressionIndicesToKeep]]];
+	oldToNewExpressionIndices = Dispatch @ Thread[expressionIndicesToKeep -> Range[Length[expressionIndicesToKeep]]];
 	WolframModelEvolutionObject[<|$version -> data[$version],
 		$rules -> data[$rules],
 		$maxCompleteGeneration -> data[$maxCompleteGeneration],
 		$terminationReason -> data[$terminationReason],
 		$atomLists -> data[$atomLists][[expressionIndicesToKeep]],
 		$eventRuleIDs -> data[$eventRuleIDs][[eventIndicesToKeep]],
-		$eventInputs -> data[$eventInputs][[eventIndicesToKeep]],
-		$eventOutputs -> newEventOutputs,
+		$eventInputs -> Replace[data[$eventInputs][[eventIndicesToKeep]], oldToNewExpressionIndices, {2}],
+		$eventOutputs -> Replace[newEventOutputs, oldToNewExpressionIndices, {2}],
 		$eventGenerations -> data[$eventGenerations][[eventIndicesToKeep]]|>]
 ]
 

--- a/Tests/WolframModel.wlt
+++ b/Tests/WolframModel.wlt
@@ -1518,6 +1518,29 @@
         Range[13]
       ],
 
+      VerificationTest[
+        SeedRandom[2];
+        ConnectedGraphQ[UndirectedGraph[WolframModel[
+          {{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}},
+          {{1, 1}},
+          <|"MaxEvents" -> 200|>,
+          "ExpressionsEventsGraph",
+          "EventOrderingFunction" -> "Random",
+          "IncludePartialGenerations" -> False]]]
+      ],
+
+      VerificationTest[
+        SeedRandom[2];
+        Sort[Catenate[WolframModel[
+          {{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}},
+          {{1, 1}},
+          <|"MaxEvents" -> 200|>,
+          "AllEventsList",
+          "EventOrderingFunction" -> "Random",
+          "IncludePartialGenerations" -> False][[All, 2, 2]]]],
+        Range[2, 40]
+      ],
+
       testUnevaluated[
         WolframModel[{{1, 2, 3}} -> {{1, 2, 3}}, {{1, 2, 3}}, 1, "IncludePartialGenerations" -> $$$invalid$$$],
         {WolframModel::invalidFiniteOption}


### PR DESCRIPTION
## Changes
* Fixes #386.
* Expression indices in event inputs/outputs are now sequential as expected.

## Comments
* The rules for replacing all with new indices were already there, apparently I just forgot to use them.
* Tests introduced in #171 did not detect this because event indices were non-sequential then, not expressions.

## Examples
* Trimming incomplete generations now works correctly:
```wl
In[] := SeedRandom[7]; 
WolframModel[{{1, 2}, {3, 2}} -> {{4, 1}, {4, 2}, {1, 2}, {4, 
     3}}, {{1, 1}, {1, 1}}, <|"MaxEvents" -> 14|>, 
  "EventOrderingFunction" -> "Random", 
  "IncludePartialGenerations" -> False]["ExpressionsEventsGraph", 
 VertexLabels -> Automatic]
```
<img width="399" alt="image" src="https://user-images.githubusercontent.com/1479325/87966688-9eb2bc00-ca8b-11ea-937e-41a410ce738e.png">

* Evolution objects now index expressions correctly:
```wl
In[] := SeedRandom[7];
WolframModel[{{1, 2}, {3, 2}} -> {{4, 1}, {4, 2}, {1, 2}, {4, 
     3}}, {{1, 1}, {1, 1}}, <|"MaxEvents" -> 14|>, 
  "EventOrderingFunction" -> "Random", 
  "IncludePartialGenerations" -> False][[1]]
```
```wl
Out[] = <|"Version" -> 2, 
 "Rules" -> {{1, 2}, {3, 2}} -> {{4, 1}, {4, 2}, {1, 2}, {4, 3}}, 
 "MaxCompleteGeneration" -> 2, "TerminationReason" -> "MaxEvents", 
 "AtomLists" -> {{1, 1}, {1, 1}, {2, 1}, {2, 1}, {1, 1}, {2, 1}, {3, 
    2}, {3, 1}, {2, 1}, {3, 2}, {6, 2}, {6, 1}, {2, 1}, {6, 1}}, 
 "EventRuleIDs" -> {0, 1, 1, 1}, 
 "EventInputs" -> {{}, {1, 2}, {3, 4}, {6, 5}}, 
 "EventOutputs" -> {{1, 2}, {3, 4, 5, 6}, {7, 8, 9, 10}, {11, 12, 13, 
    14}}, "EventGenerations" -> {0, 1, 2, 2}|>
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/387)
<!-- Reviewable:end -->
