### PR TITLE
Fix replaceOnce

### DIFF
--- a/libSetReplace/Set.cpp
+++ b/libSetReplace/Set.cpp
@@ -51,7 +51,10 @@ class Set::Implementation {
             randomSeed,
             [this](const int64_t& expressionID) -> const AtomsVector& { return expressions_.at(expressionID); }) {}
 
-  int64_t replaceOnce(const std::function<bool()> shouldAbort) {
+  int64_t replaceOnce(const std::function<bool()> shouldAbort, bool resetStepSpec = false) {
+    if (resetStepSpec) {
+      updateStepSpec(StepSpecification{});
+    }
     terminationReason_ = TerminationReason::NotTerminated;
 
     if (causalGraph_.eventsCount() >= static_cast<size_t>(stepSpec_.maxEvents)) {
@@ -345,7 +348,9 @@ Set::Set(const std::vector<Rule>& rules,
     : implementation_(std::make_shared<Implementation>(
           rules, initialExpressions, eventSelectionFunction, orderingSpec, randomSeed)) {}
 
-int64_t Set::replaceOnce(const std::function<bool()>& shouldAbort) { return implementation_->replaceOnce(shouldAbort); }
+int64_t Set::replaceOnce(const std::function<bool()>& shouldAbort) {
+  return implementation_->replaceOnce(shouldAbort, true);
+}
 
 int64_t Set::replace(const StepSpecification& stepSpec, const std::function<bool()>& shouldAbort) {
   return implementation_->replace(stepSpec, shouldAbort);

--- a/libSetReplace/test/Set_test.cpp
+++ b/libSetReplace/test/Set_test.cpp
@@ -57,7 +57,7 @@ TEST(Set, matchAllMultiway) {
             (std::vector<AtomsVector>{{1}, {1, 2}, {3}, {3, 4}, {2, 5}, {4, 5}, {5, 6}, {2}, {4}, {5}, {5}, {6}, {6}}));
 }
 
-TEST(Set, ReplaceOnce) {
+TEST(Set, replaceOnce) {
   Matcher::OrderingSpec orderingSpec = {
       {Matcher::OrderingFunction::SortedExpressionIDs, Matcher::OrderingDirection::Normal},
       {Matcher::OrderingFunction::ReverseSortedExpressionIDs, Matcher::OrderingDirection::Normal},

--- a/libSetReplace/test/Set_test.cpp
+++ b/libSetReplace/test/Set_test.cpp
@@ -56,4 +56,15 @@ TEST(Set, matchAllMultiway) {
   EXPECT_EQ(aSet.expressions(),
             (std::vector<AtomsVector>{{1}, {1, 2}, {3}, {3, 4}, {2, 5}, {4, 5}, {5, 6}, {2}, {4}, {5}, {5}, {6}, {6}}));
 }
+
+TEST(Set, ReplaceOnce) {
+  Matcher::OrderingSpec orderingSpec = {
+      {Matcher::OrderingFunction::SortedExpressionIDs, Matcher::OrderingDirection::Normal},
+      {Matcher::OrderingFunction::ReverseSortedExpressionIDs, Matcher::OrderingDirection::Normal},
+      {Matcher::OrderingFunction::ExpressionIDs, Matcher::OrderingDirection::Normal},
+      {Matcher::OrderingFunction::RuleIndex, Matcher::OrderingDirection::Normal}};
+
+  Set set({{{{-1}}, {{-1, -1}}}}, {{1}}, {}, orderingSpec, 0);
+  EXPECT_EQ(set.replaceOnce(doNotAbort), 1);
+}
 }  // namespace SetReplace


### PR DESCRIPTION
## Changes
* Fix Set::replaceOnce() such that it does not always fail.

## Examples
Before fix:
```c++
TEST(Set, ReplaceOnce) {
  Matcher::OrderingSpec orderingSpec = {
      {Matcher::OrderingFunction::SortedExpressionIDs, Matcher::OrderingDirection::Normal},
      {Matcher::OrderingFunction::ReverseSortedExpressionIDs, Matcher::OrderingDirection::Normal},
      {Matcher::OrderingFunction::ExpressionIDs, Matcher::OrderingDirection::Normal},
      {Matcher::OrderingFunction::RuleIndex, Matcher::OrderingDirection::Normal}};

  Set set({{{{-1}}, {{-1, -1}}}}, {{1}}, {}, orderingSpec, 0);
  EXPECT_EQ(set.replaceOnce(doNotAbort), 1);
}
```
yields
```
Expected equality of these values:
  set.replaceOnce(doNotAbort)
    Which is: 0
  1
```

After fix:
```
[ RUN      ] Set.ReplaceOnce
[       OK ] Set.ReplaceOnce (0 ms)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/395)
<!-- Reviewable:end -->
