### PR TITLE
mapHold and heldPart

### DIFF
--- a/Kernel/utilities.m
+++ b/Kernel/utilities.m
@@ -45,12 +45,8 @@ toNormalEdges[edge_] := UndirectedEdge @@@ Partition[edge, 2, 1, 1]
 
 SetAttributes[mapHold, HoldFirst];
 
-mapHold[expr_, level_List : {1}] := ReleaseHold[Map[Hold, Hold[expr], level + 1]]
-
-mapHold[expr_, level : (_Integer | Infinity)] := mapHold[expr, {1, level}]
+mapHold[expr_, level_ : {1}] := Map[Hold, Unevaluated[expr], level]
 
 SetAttributes[heldPart, HoldFirst];
 
-(* Part 0 (head) will not be held, Association keys not supported. *)
-
-heldPart[expr_, part__] := mapHold[expr, {0, Length[{part}]}][[##]] & @@ Riffle[{part}, 1, {1, -2, 2}]
+heldPart[expr_, part__Integer] := Extract[Unevaluated[expr], {part}, Hold]

--- a/Kernel/utilities.m
+++ b/Kernel/utilities.m
@@ -53,4 +53,4 @@ SetAttributes[heldPart, HoldFirst];
 
 (* Part 0 (head) will not be held, Association keys not supported. *)
 
-heldPart[expr_, part__] := mapHold[expr, {Length[{part}]}][[part]]
+heldPart[expr_, part__] := mapHold[expr, {0, Length[{part}]}][[##]] & @@ Riffle[{part}, 1, {1, -2, 2}]

--- a/Kernel/utilities.m
+++ b/Kernel/utilities.m
@@ -9,6 +9,8 @@ PackageScope["toCanonicalHypergraphForm"]
 PackageScope["vertexList"]
 PackageScope["indexHypergraph"]
 PackageScope["connectedHypergraphQ"]
+PackageScope["mapHold"]
+PackageScope["heldPart"]
 
 fromCounts[association_] := Catenate @ KeyValueMap[ConstantArray] @ association
 
@@ -40,3 +42,15 @@ indexHypergraph[e_] := With[{vertices = vertexList[e]},
 connectedHypergraphQ[edges_] := ConnectedGraphQ[Graph[Catenate[toNormalEdges /@ toCanonicalHypergraphForm[edges]]]]
 
 toNormalEdges[edge_] := UndirectedEdge @@@ Partition[edge, 2, 1, 1]
+
+SetAttributes[mapHold, HoldFirst];
+
+mapHold[expr_, level_List : {1}] := ReleaseHold[Map[Hold, Hold[expr], level + 1]]
+
+mapHold[expr_, level : (_Integer | Infinity)] := mapHold[expr, {1, level}]
+
+SetAttributes[heldPart, HoldFirst];
+
+(* Part 0 (head) will not be held, Association keys not supported. *)
+
+heldPart[expr_, part__] := mapHold[expr, {Length[{part}]}][[part]]

--- a/Tests/utilities.wlt
+++ b/Tests/utilities.wlt
@@ -283,7 +283,7 @@
 
       VerificationTest[
         heldPart[{1 + 1, 2 - 2}, 0],
-        List
+        Hold[List]
       ],
 
       VerificationTest[
@@ -292,28 +292,8 @@
       ],
 
       VerificationTest[
-        heldPart[{1 + 1, 2 - 2, 0 * 1}, {1, 3}],
-        {Hold[1 + 1], Hold[0 * 1]}
-      ],
-
-      VerificationTest[
-        heldPart[{1 + 1, 2 - 2, 0 * 1}, {0, 1}],
-        {List, Hold[1 + 1]}
-      ],
-
-      VerificationTest[
-        heldPart[{1 + 1, 2 - 2, 0 * 1}, 1 ;; 2],
-        {Hold[1 + 1], Hold[2 - 2]}
-      ],
-
-      VerificationTest[
         heldPart[OddQ[2 + 3], 1],
         Hold[2 + 3]
-      ],
-
-      VerificationTest[
-        heldPart[OddQ[2 + 3], 1, All],
-        Hold[2] + Hold[3]
       ]
     }
   |>

--- a/Tests/utilities.wlt
+++ b/Tests/utilities.wlt
@@ -304,6 +304,16 @@
       VerificationTest[
         heldPart[{1 + 1, 2 - 2, 0 * 1}, 1 ;; 2],
         {Hold[1 + 1], Hold[2 - 2]}
+      ],
+
+      VerificationTest[
+        heldPart[OddQ[2 + 3], 1],
+        Hold[2 + 3]
+      ],
+
+      VerificationTest[
+        heldPart[OddQ[2 + 3], 1, All],
+        Hold[2] + Hold[3]
       ]
     }
   |>

--- a/Tests/utilities.wlt
+++ b/Tests/utilities.wlt
@@ -5,6 +5,8 @@
       Global`multisetFilterRules = SetReplace`PackageScope`multisetFilterRules;
       Global`multisetUnion = SetReplace`PackageScope`multisetUnion;
       Global`connectedHypergraphQ = SetReplace`PackageScope`connectedHypergraphQ;
+      Global`mapHold = SetReplace`PackageScope`mapHold;
+      Global`heldPart = SetReplace`PackageScope`heldPart;
     ),
     "tests" -> {
       (* multisetComplement *)
@@ -223,6 +225,85 @@
       VerificationTest[
         connectedHypergraphQ[{{13, 1, 14}, {13, 2, 16}, {16, 14, 18}, {6, 10, 15}, {1, 13, 15}, {13, 13, 15}}],
         True
+      ],
+
+      (* mapHold *)
+
+      VerificationTest[
+        mapHold[{1 + 1, 2 - 3}],
+        {Hold[1 + 1], Hold[2 - 3]}
+      ],
+
+      VerificationTest[
+        mapHold[f[2 + 4, OddQ[3]]],
+        f[Hold[2 + 4], Hold[OddQ[3]]]
+      ],
+
+      VerificationTest[
+        mapHold[2 + 2, 0],
+        4
+      ],
+
+      VerificationTest[
+        mapHold[{OddQ[1 + 0], EvenQ[0 + 1]}, 2],
+        {Hold[OddQ[Hold[1 + 0]]], Hold[EvenQ[Hold[0 + 1]]]}
+      ],
+
+      VerificationTest[
+        mapHold[{OddQ[1 + (0 * 5)], EvenQ[0 + 1]}, Infinity],
+        {Hold[OddQ[Hold[Hold[1] + Hold[Hold[0] * Hold[5]]]]], Hold[EvenQ[Hold[Hold[0] + Hold[1]]]]}
+      ],
+
+      VerificationTest[
+        mapHold[{(1 + 0) * (0 + 1), 4}, {2}],
+        {Hold[1 + 0] * Hold[0 + 1], 4}
+      ],
+
+      VerificationTest[
+        mapHold[{1 + 3, 2 - 2}, {0}],
+        Hold[{1 + 3, 2 - 2}]
+      ],
+
+      VerificationTest[
+        mapHold[{(1 + 0) * (0 + 1), 4}, {0, 2}],
+        Hold[{Hold[Hold[1 + 0] * Hold[0 + 1]], Hold[4]}]
+      ],
+
+      (* heldPart *)
+
+      VerificationTest[
+        heldPart[{1 + 1, 2 - 2}, 1],
+        Hold[1 + 1]
+      ],
+
+      VerificationTest[
+        heldPart[{1 + 1, 2 - 2}, -1],
+        Hold[2 - 2]
+      ],
+
+      VerificationTest[
+        heldPart[{1 + 1, 2 - 2}, 0],
+        List
+      ],
+
+      VerificationTest[
+        heldPart[{{1 * 4, 1}, 2 - 2}, 1, 1],
+        Hold[1 * 4]
+      ],
+
+      VerificationTest[
+        heldPart[{1 + 1, 2 - 2, 0 * 1}, {1, 3}],
+        {Hold[1 + 1], Hold[0 * 1]}
+      ],
+
+      VerificationTest[
+        heldPart[{1 + 1, 2 - 2, 0 * 1}, {0, 1}],
+        {List, Hold[1 + 1]}
+      ],
+
+      VerificationTest[
+        heldPart[{1 + 1, 2 - 2, 0 * 1}, 1 ;; 2],
+        {Hold[1 + 1], Hold[2 - 2]}
       ]
     }
   |>


### PR DESCRIPTION
## Changes
* Adds two utility functions: `mapHold` and `heldPart`.
* `mapHold` maps `Hold` over specified levels. Note, it's not as simple as `Map[Hold, ...]` because `Map` will not hold its second argument.
* `heldPart` holds and returns a specified part of an expression. This is also non-trivial because `Part` does not hold it's contents.

## Comments
* This is useful for Wolfram Language (`Method -> "Symbolic"`) implementation of `WolframModel`, as it deconstructs/reconstructs pattern rules, parts of which need to be held.
* This is an internal utility, it's not meant to be used outside of *SetReplace*, so it does not check its arguments.

## Examples
* Extract held parts of an expression:
```wl
In[] := SetReplace`PackageScope`heldPart[{1 + 1, 2 - 2, 0*1}, 1]
Out[] = Hold[1 + 1]
```

* Map `Hold` over a list:
```wl
In[] := SetReplace`PackageScope`mapHold[{1 + 1, 2 - 2, 0*1}]
Out[] = {Hold[1 + 1], Hold[2 - 2], Hold[0 1]}
```

* It's possible to use arbitrary level specs in both functions:
```wl
In[] := SetReplace`PackageScope`mapHold[{1 3 + 1, 3}, {2}]
Out[] = {Hold[1] + Hold[1 3], 3}
```

```wl
In[] := SetReplace`PackageScope`heldPart[{1 3 + 1, 3}, 1, All]
Out[] = Hold[1] + Hold[1 3]
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/398)
<!-- Reviewable:end -->
