### PR TITLE
Resetting Graph image size workaround

### DIFF
--- a/Kernel/WolframModelEvolutionObject.m
+++ b/Kernel/WolframModelEvolutionObject.m
@@ -846,6 +846,10 @@ rulesList[rules_List] := rules
 (*ExpressionsEventsGraph*)
 
 
+(* ImageSize -> Automatic (which is the default) causes the size of the output to be reset on re-evaluation *)
+filterGraphProperties[properties_] := FilterRules[properties, Except[ImageSize]]
+
+
 propertyEvaluate[True, boundary : includeBoundaryEventsPattern][
       obj : WolframModelEvolutionObject[data_ ? evolutionDataQ],
       caller_,
@@ -864,7 +868,7 @@ propertyEvaluate[True, boundary : includeBoundaryEventsPattern][
       {Values[expressionsToDestroyers], "Event", {2}}};
   graphVertices = Join[labeledEvents, labeledExpressions];
 
-  allOptionValues = Flatten[Join[{o}, $propertyOptions[property]]];
+  allOptionValues = Flatten[Join[{o}, filterGraphProperties[$propertyOptions[property]]]];
 
   vertexLabelsOptionValue = OptionValue[allOptionValues, VertexLabels];
   automaticVertexLabelsPattern = Automatic | Placed[Automatic, ___];
@@ -940,7 +944,8 @@ propertyEvaluate[True, boundary : includeBoundaryEventsPattern][
   eventsToEvents = Catenate /@ Map[expressionsToDestroyers, eventsToOutputs, {2}];
   causalEdges = Catenate[Thread /@ Normal[eventsToEvents]];
 
-  allOptionValues = Flatten[Join[{o}, $propertyOptions[property]]];
+  (* ImageSize -> Automatic (which is the default) causes the size of the output to be reset on re-evaluation *)
+  allOptionValues = Flatten[Join[{o}, filterGraphProperties[$propertyOptions[property]]]];
   Graph[
     Keys[eventsToOutputs],
     causalEdges,
@@ -972,7 +977,7 @@ propertyEvaluate[True, includeBoundaryEvents : includeBoundaryEventsPattern][
     propertyEvaluate[True, includeBoundaryEvents][evolution, caller, "CausalGraph", ##] & @@
       FilterRules[FilterRules[{o}, $causalGraphOptions], Except[$newLayeredCausalGraphOptions]],
     GraphLayout -> Replace[
-      OptionValue[Flatten[Join[{o}, $propertyOptions[property]]], GraphLayout],
+      OptionValue[Flatten[Join[{o}, filterGraphProperties[$propertyOptions[property]]]], GraphLayout],
       Automatic -> {
         "LayeredDigraphEmbedding",
         "VertexLayerPosition" ->

--- a/Kernel/WolframModelEvolutionObject.m
+++ b/Kernel/WolframModelEvolutionObject.m
@@ -976,7 +976,7 @@ propertyEvaluate[True, includeBoundaryEvents : includeBoundaryEventsPattern][
     propertyEvaluate[True, includeBoundaryEvents][evolution, caller, "CausalGraph", ##] & @@
       FilterRules[FilterRules[{o}, $causalGraphOptions], Except[$newLayeredCausalGraphOptions]],
     GraphLayout -> Replace[
-      OptionValue[Flatten[Join[{o}, filterGraphProperties[$propertyOptions[property]]]], GraphLayout],
+      OptionValue[Flatten[Join[{o}, $propertyOptions[property]]], GraphLayout],
       Automatic -> {
         "LayeredDigraphEmbedding",
         "VertexLayerPosition" ->

--- a/Kernel/WolframModelEvolutionObject.m
+++ b/Kernel/WolframModelEvolutionObject.m
@@ -846,7 +846,7 @@ rulesList[rules_List] := rules
 (*ExpressionsEventsGraph*)
 
 
-(* ImageSize -> Automatic (which is the default) causes the size of the output to be reset on re-evaluation *)
+(* ImageSize -> Automatic (which is the default) causes the size of the output to be reset on reevaluation *)
 filterGraphProperties[properties_] := FilterRules[properties, Except[ImageSize]]
 
 
@@ -944,7 +944,6 @@ propertyEvaluate[True, boundary : includeBoundaryEventsPattern][
   eventsToEvents = Catenate /@ Map[expressionsToDestroyers, eventsToOutputs, {2}];
   causalEdges = Catenate[Thread /@ Normal[eventsToEvents]];
 
-  (* ImageSize -> Automatic (which is the default) causes the size of the output to be reset on re-evaluation *)
   allOptionValues = Flatten[Join[{o}, filterGraphProperties[$propertyOptions[property]]]];
   Graph[
     Keys[eventsToOutputs],


### PR DESCRIPTION
## Changes
* Fixes #403.
* Reevaluating the input cell does no longer reset the image size in the following output cell.
* `WolframModelPlot` properties were not affected by this.

## Comments
* In Wolfram Language, `Graphics` and related functions (like `Graph`) would typically keep the output image the same size even if the code that generated it is changed and reevaluated.
* However, they only do that if `ImageSize` is not specified as an option. Note that even though `ImageSize -> Automatic` is a default, explicitly specifying `ImageSize -> Automatic` as an option will prevent this size-preserving behavior from happening.
* So, this change prevents the default `ImageSize -> Automatic` from being passed to `Graph`. Note if `ImageSize` is manually specified as an argument for the property (even if `ImageSize -> Automatic` is specified), it will be passed.

## Examples
* Make a `Graph`:
```wl
In[] := WolframModel[{{x, y}, {x, z}} -> {{x, y}, {x, w}, {y, w}, {z, 
     w}}, {{1, 1}, {1, 1}}, 2]["ExpressionsEventsGraph"]
```
<img width="399" alt="image" src="https://user-images.githubusercontent.com/1479325/93532195-87b70b80-f90e-11ea-8a19-8950c0f1b98d.png">

* Manually change the image size in the output, and reevaluate. The size of the image no longer changes, and remains the same as after the manual resize:
<img width="237" alt="image" src="https://user-images.githubusercontent.com/1479325/93532254-aa492480-f90e-11ea-8fe8-f8d600bed185.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/414)
<!-- Reviewable:end -->
