### PR TITLE
Make .clang-format consistent with cpplint

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -6,18 +6,5 @@ BinPackArguments: false
 BinPackParameters: false
 ColumnLimit: 120
 DerivePointerAlignment: false
-IncludeCategories:
-  - Regex:           '^<ext/.*\.h>'
-    Priority:        2
-    SortPriority:    0
-  - Regex:           '^<.*\.h>'
-    Priority:        2
-    SortPriority:    0
-  - Regex:           '^<.*'
-    Priority:        1
-    SortPriority:    0
-  - Regex:           '.*'
-    Priority:        3
-    SortPriority:    0
 Standard: c++17
 ...

--- a/libSetReplace/test/Set_test.cpp
+++ b/libSetReplace/test/Set_test.cpp
@@ -1,8 +1,8 @@
 #include "Set.hpp"
 
-#include <vector>
-
 #include <gtest/gtest.h>
+
+#include <vector>
 
 #include "Match.hpp"
 #include "Rule.hpp"


### PR DESCRIPTION
## Changes
* Apparently, there were some changes to `cpplint`, and it now expects gtest headers to go above C++ std headers.
* This PR reorders the headers and removes custom ordering from .clang-format.

## Examples
* `./lint.sh` no longer produces any error messages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/435)
<!-- Reviewable:end -->
