### PR TITLE
Correct replacement of rule symbols inside ToPatternRules

### DIFF
--- a/Kernel/ToPatternRules.m
+++ b/Kernel/ToPatternRules.m
@@ -48,7 +48,7 @@ toPatternRules[rule : _Rule, caller_] := Module[
   rightOnlyVertices = Complement[rightVertices, leftVertices];
   With[
       {moduleVariables = rightOnlyVertices,
-      moduleExpression = rule[[2]] /. Thread[symbols -> newVertexNames]},
+      moduleExpression = Replace[rule[[2]], Thread[symbols -> newVertexNames], {0, 2}]},
     If[moduleVariables =!= {},
       newLeft :> Module[moduleVariables, moduleExpression],
       newLeft :> moduleExpression

--- a/Kernel/ToPatternRules.m
+++ b/Kernel/ToPatternRules.m
@@ -43,8 +43,8 @@ toPatternRules[rule : _Rule, caller_] := Module[
     ToHeldExpression /@ StringTemplate["v``"] /@ Range @ Length @ symbols;
   vertexPatterns = Pattern[#, Blank[]] & /@ newVertexNames;
   newLeft = (rule[[1]] /. FilterRules[Thread[symbols -> vertexPatterns], leftSymbols]);
-  {leftVertices, rightVertices} =
-    {leftSymbols, rightSymbols} /. Thread[symbols -> newVertexNames];
+  leftVertices = (leftSymbols /. FilterRules[Thread[symbols -> newVertexNames], leftSymbols]);
+  rightVertices = rightSymbols /. Thread[symbols -> newVertexNames];
   rightOnlyVertices = Complement[rightVertices, leftVertices];
   With[
       {moduleVariables = rightOnlyVertices,

--- a/Kernel/ToPatternRules.m
+++ b/Kernel/ToPatternRules.m
@@ -42,6 +42,8 @@ toPatternRules[rule : _Rule, caller_] := Module[
   newVertexNames =
     ToHeldExpression /@ StringTemplate["v``"] /@ Range @ Length @ symbols;
   vertexPatterns = Pattern[#, Blank[]] & /@ newVertexNames;
+  (* In Replace expressions at deeper levels are matched first, unlike ReplaceAll.
+     Compare: {ReplaceAll[##], Replace[##, {0, 2}]} &[{{1}, {{1}}}, {1 -> "v1", {1} -> "v2"}] *)
   newLeft = Replace[rule[[1]], Thread[symbols -> vertexPatterns], {0, 2}];
   {leftVertices, rightVertices} =
     Replace[{leftSymbols, rightSymbols}, Thread[symbols -> newVertexNames], {1, 2}];

--- a/Kernel/ToPatternRules.m
+++ b/Kernel/ToPatternRules.m
@@ -42,9 +42,9 @@ toPatternRules[rule : _Rule, caller_] := Module[
   newVertexNames =
     ToHeldExpression /@ StringTemplate["v``"] /@ Range @ Length @ symbols;
   vertexPatterns = Pattern[#, Blank[]] & /@ newVertexNames;
-  newLeft = (rule[[1]] /. FilterRules[Thread[symbols -> vertexPatterns], leftSymbols]);
-  leftVertices = (leftSymbols /. FilterRules[Thread[symbols -> newVertexNames], leftSymbols]);
-  rightVertices = rightSymbols /. Thread[symbols -> newVertexNames];
+  newLeft = Replace[rule[[1]], Thread[symbols -> vertexPatterns], {0, 2}];
+  {leftVertices, rightVertices} =
+    Replace[{leftSymbols, rightSymbols}, Thread[symbols -> newVertexNames], {1, 2}];
   rightOnlyVertices = Complement[rightVertices, leftVertices];
   With[
       {moduleVariables = rightOnlyVertices,

--- a/Kernel/ToPatternRules.m
+++ b/Kernel/ToPatternRules.m
@@ -42,7 +42,7 @@ toPatternRules[rule : _Rule, caller_] := Module[
   newVertexNames =
     ToHeldExpression /@ StringTemplate["v``"] /@ Range @ Length @ symbols;
   vertexPatterns = Pattern[#, Blank[]] & /@ newVertexNames;
-  newLeft = (rule[[1]] /. Thread[symbols -> vertexPatterns]);
+  newLeft = (rule[[1]] /. FilterRules[Thread[symbols -> vertexPatterns], leftSymbols]);
   {leftVertices, rightVertices} =
     {leftSymbols, rightSymbols} /. Thread[symbols -> newVertexNames];
   rightOnlyVertices = Complement[rightVertices, leftVertices];

--- a/Tests/ToPatternRules.wlt
+++ b/Tests/ToPatternRules.wlt
@@ -131,10 +131,15 @@
         ToPatternRules[{{x, y}, {x, z}} -> {{x, y}, {x, w}, {y, w}, {z, w}}]
       ],
 
-      (** Replace the LHS with the appropriate patterns #149 **)
+      (** Replace symbols with the appropriate patterns #149 **)
       VerificationTest[
         ToPatternRules[{{1, 2}, {2, 3}, {3, 1}} -> {{{1, 4}, {1, 4}}}],
         {{v1_, v2_}, {v2_, v3_}, {v3_, v1_}} :> Module[{v4}, {{v4, v4}}]
+      ],
+
+      VerificationTest[
+        ToPatternRules[{} -> {{{1, 2}}, {1, 2}}],
+        {} :> Module[{v1, v2, v3}, {{v3}, {v1, v2}}]
       ]
     }
   |>

--- a/Tests/ToPatternRules.wlt
+++ b/Tests/ToPatternRules.wlt
@@ -140,6 +140,11 @@
       VerificationTest[
         ToPatternRules[{} -> {{{1, 2}}, {1, 2}}],
         {} :> Module[{v1, v2, v3}, {{v3}, {v1, v2}}]
+      ],
+
+      VerificationTest[
+        ToPatternRules[{{1, 2}} -> {{{1, 4}}, {1, 4}, {1, 2}, {{1, 2}}}],
+        {{v1_, v2_}} :> Module[{v3, v4, v5}, {{v5}, {v1, v3}, {v1, v2}, {v4}}]
       ]
     }
   |>

--- a/Tests/ToPatternRules.wlt
+++ b/Tests/ToPatternRules.wlt
@@ -150,6 +150,26 @@
       VerificationTest[
         ToPatternRules[{{{1, 2}}, {1, 2}, 2} -> {{1, 2}, 1, 2, {{1, 2}}, {1, 3}}],
         {{v3_}, {v1_, v2_}, v2_} :> Module[{v4}, {{v1, v2}, v1, v2, {v3}, {v1, v4}}]
+      ],
+
+      VerificationTest[
+        ToPatternRules[{1, 2} -> {{{1, 2}}}],
+        {v1_, v2_} :> Module[{v3}, {{v3}}]
+      ],
+
+      VerificationTest[
+        ToPatternRules[{{1, 2}} -> {{{1, 2}}}],
+        {{v1_, v2_}} :> Module[{v3}, {{v3}}]
+      ],
+
+      VerificationTest[
+        ToPatternRules[{{{1, 2}}} -> {1, 2}],
+        {{v1_}} :> Module[{v2, v3}, {v2, v3}]
+      ],
+
+      VerificationTest[
+        ToPatternRules[{{{1, 2}}} -> {{1, 2}}],
+        {{v1_}} :> Module[{v2, v3}, {{v2, v3}}]
       ]
     }
   |>

--- a/Tests/ToPatternRules.wlt
+++ b/Tests/ToPatternRules.wlt
@@ -131,7 +131,7 @@
         ToPatternRules[{{x, y}, {x, z}} -> {{x, y}, {x, w}, {y, w}, {z, w}}]
       ],
 
-      (** Replace symbols with the appropriate patterns #149 **)
+      (** Correct replacement of rule symbols #149 **)
       VerificationTest[
         ToPatternRules[{{1, 2}, {2, 3}, {3, 1}} -> {{{1, 4}, {1, 4}}}],
         {{v1_, v2_}, {v2_, v3_}, {v3_, v1_}} :> Module[{v4}, {{v4, v4}}]
@@ -145,6 +145,11 @@
       VerificationTest[
         ToPatternRules[{{1, 2}} -> {{{1, 4}}, {1, 4}, {1, 2}, {{1, 2}}}],
         {{v1_, v2_}} :> Module[{v3, v4, v5}, {{v5}, {v1, v3}, {v1, v2}, {v4}}]
+      ],
+
+      VerificationTest[
+        ToPatternRules[{{{1, 2}}, {1, 2}, 2} -> {{1, 2}, 1, 2, {{1, 2}}, {1, 3}}],
+        {{v3_}, {v1_, v2_}, v2_} :> Module[{v4}, {{v1, v2}, v1, v2, {v3}, {v1, v4}}]
       ]
     }
   |>

--- a/Tests/ToPatternRules.wlt
+++ b/Tests/ToPatternRules.wlt
@@ -129,6 +129,12 @@
       VerificationTest[
         ToPatternRules[{{1, 2}, {1, 3}} -> {{1, 2}, {1, 4}, {2, 4}, {3, 4}}],
         ToPatternRules[{{x, y}, {x, z}} -> {{x, y}, {x, w}, {y, w}, {z, w}}]
+      ],
+
+      (** Replace the LHS with the appropriate patterns #149 **)
+      VerificationTest[
+        ToPatternRules[{{1, 2}, {2, 3}, {3, 1}} -> {{{1, 4}, {1, 4}}}],
+        {{v1_, v2_}, {v2_, v3_}, {v3_, v1_}} :> Module[{v4}, {{v4, v4}}]
       ]
     }
   |>


### PR DESCRIPTION
## Changes
* Closes #149.
* Replacing `ReplaceAll` with `Replace` at the correct levels.

## Examples
```wl
In[]:= ToPatternRules[{{1, 2}, {2, 3}, {3, 1}} -> {{{1, 2}, {2, 3}, {3, 1}, {1, 4}, {2, 4}, {3, 4}}}]
Out[]= {{v1_, v2_}, {v2_, v3_}, {v3_, v1_}} :> Module[{v4, v5, v6, v7, v8, v9}, {{v4, v6, v8, v5, v7, v9}}]

In[]:= ToPatternRules[{{1, 2}, {2, 3}, {3, 1}} -> {{{1, 4}, {1, 4}}}]
Out[]= {{v1_, v2_}, {v2_, v3_}, {v3_, v1_}} :> Module[{v4}, {{v4, v4}}]

In[]:= ToPatternRules[{} -> {{{1, 2}}, {1, 2}}]
Out[]= {} :> Module[{v1, v2, v3}, {{v3}, {v1, v2}}]

In[]:= ToPatternRules[{{1, 2}} -> {{{1, 4}}, {1, 4}, {1, 2}, {{1, 2}}}]
Out[]= {{v1_, v2_}} :> Module[{v3, v4, v5}, {{v5}, {v1, v3}, {v1, v2}, {v4}}]

In[]:= ToPatternRules[{{{1, 2}}, {1, 2}} -> {}]
Out[]= {{v3_}, {v1_, v2_}} :> {}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/442)
<!-- Reviewable:end -->
