### PR TITLE
Fix C++ tests

### DIFF
--- a/libSetReplace/test/Set_test.cpp
+++ b/libSetReplace/test/Set_test.cpp
@@ -66,7 +66,8 @@ TEST(Set, replaceOnce) {
       {Matcher::OrderingFunction::ExpressionIDs, Matcher::OrderingDirection::Normal},
       {Matcher::OrderingFunction::RuleIndex, Matcher::OrderingDirection::Normal}};
 
-  Set set({{{{-1}}, {{-1, -1}}}}, {{1}}, Set::SystemType::Singleway, orderingSpec, Matcher::EventDeduplication::None, 0);
+  Set set(
+      {{{{-1}}, {{-1, -1}}}}, {{1}}, Set::SystemType::Singleway, orderingSpec, Matcher::EventDeduplication::None, 0);
   EXPECT_EQ(set.replaceOnce(doNotAbort), 1);
 }
 }  // namespace SetReplace

--- a/libSetReplace/test/Set_test.cpp
+++ b/libSetReplace/test/Set_test.cpp
@@ -8,10 +8,10 @@
 #include "Rule.hpp"
 
 namespace SetReplace {
-Set testSet(const Set::EventSelectionFunction eventSelectionFunction) {
+Set testSet(const Set::SystemType systemType, const EventSelectionFunction eventSelectionFunction) {
   // Negative atoms refer to patterns (useful for rules)
   std::vector<Rule> rules;
-  auto aRule = Rule({{{-1}, {-1, -2}}, {{-2}}});
+  auto aRule = Rule({{{-1}, {-1, -2}}, {{-2}}, eventSelectionFunction});
   rules.push_back(aRule);
 
   // make two "particles" {1} and {3} which will traverse the graph deleting edges in their path
@@ -22,14 +22,16 @@ Set testSet(const Set::EventSelectionFunction eventSelectionFunction) {
       {Matcher::OrderingFunction::ReverseSortedExpressionIDs, Matcher::OrderingDirection::Normal},
       {Matcher::OrderingFunction::ExpressionIDs, Matcher::OrderingDirection::Normal},
       {Matcher::OrderingFunction::RuleIndex, Matcher::OrderingDirection::Normal}};
+  Matcher::EventDeduplication eventDeduplication = Matcher::EventDeduplication::None;
   unsigned int randomSeed = 0;
-  return Set(rules, initialExpressions, eventSelectionFunction, orderingSpec, randomSeed);
+  return Set(rules, initialExpressions, systemType, orderingSpec, eventDeduplication, randomSeed);
 }
 
 constexpr auto doNotAbort = []() { return false; };
 
 TEST(Set, globalSpacelike) {
-  Set aSet = testSet(Set::EventSelectionFunction::GlobalSpacelike);
+  // Singleway systems are always spacelike, so it's not necessary to specify a spacelike selection function
+  Set aSet = testSet(Set::SystemType::Singleway, EventSelectionFunction::All);
   Set::StepSpecification stepSpec;
   stepSpec.maxEvents = 2;
   EXPECT_EQ(aSet.replace(stepSpec, doNotAbort), 2);
@@ -49,7 +51,7 @@ TEST(Set, globalSpacelike) {
 }
 
 TEST(Set, matchAllMultiway) {
-  Set aSet = testSet(Set::EventSelectionFunction::None);
+  Set aSet = testSet(Set::SystemType::Multiway, EventSelectionFunction::All);
   // Unlike the global spacelike case, the edge {5, 6} can now be used twice, so there is an extra event
   EXPECT_EQ(aSet.replace(Set::StepSpecification(), doNotAbort), 6);
   // and two {6}'s in the list of expressions
@@ -64,7 +66,7 @@ TEST(Set, replaceOnce) {
       {Matcher::OrderingFunction::ExpressionIDs, Matcher::OrderingDirection::Normal},
       {Matcher::OrderingFunction::RuleIndex, Matcher::OrderingDirection::Normal}};
 
-  Set set({{{{-1}}, {{-1, -1}}}}, {{1}}, {}, orderingSpec, 0);
+  Set set({{{{-1}}, {{-1, -1}}}}, {{1}}, Set::SystemType::Singleway, orderingSpec, Matcher::EventDeduplication::None, 0);
   EXPECT_EQ(set.replaceOnce(doNotAbort), 1);
 }
 }  // namespace SetReplace


### PR DESCRIPTION
## Changes
* Fixes existing C++ tests.
* `Set_test.cpp` became stale after a change to the *libSetReplace* API. It is now updated and works.

## Examples
* Tests now build as expected:
```bash
mkdir build && cd build 
cmake .. -DSET_REPLACE_BUILD_TESTING=ON
cmake --build .
```
```
Scanning dependencies of target SetReplace
[  5%] Building CXX object CMakeFiles/SetReplace.dir/libSetReplace/Event.cpp.o
[ 11%] Building CXX object CMakeFiles/SetReplace.dir/libSetReplace/Expression.cpp.o
[ 17%] Building CXX object CMakeFiles/SetReplace.dir/libSetReplace/Match.cpp.o
[ 23%] Building CXX object CMakeFiles/SetReplace.dir/libSetReplace/Set.cpp.o
[ 29%] Linking CXX static library libSetReplace.a
[ 29%] Built target SetReplace
Scanning dependencies of target gtest
[ 35%] Building CXX object _deps/googletest-build/googlemock/gtest/CMakeFiles/gtest.dir/src/gtest-all.cc.o
[ 41%] Linking CXX static library libgtest.a
[ 41%] Built target gtest
Scanning dependencies of target gmock
[ 47%] Building CXX object _deps/googletest-build/googlemock/CMakeFiles/gmock.dir/src/gmock-all.cc.o
[ 52%] Linking CXX static library libgmock.a
[ 52%] Built target gmock
Scanning dependencies of target gmock_main
[ 58%] Building CXX object _deps/googletest-build/googlemock/CMakeFiles/gmock_main.dir/src/gmock_main.cc.o
[ 64%] Linking CXX static library libgmock_main.a
[ 64%] Built target gmock_main
Scanning dependencies of target gtest_main
[ 70%] Building CXX object _deps/googletest-build/googlemock/gtest/CMakeFiles/gtest_main.dir/src/gtest_main.cc.o
[ 76%] Linking CXX static library libgtest_main.a
[ 76%] Built target gtest_main
Scanning dependencies of target profile_tests
[ 82%] Building CXX object libSetReplace/test/CMakeFiles/profile_tests.dir/profile_tests.cpp.o
[ 88%] Linking CXX executable profile_tests
[ 88%] Built target profile_tests
Scanning dependencies of target Set_test
[ 94%] Building CXX object libSetReplace/test/CMakeFiles/Set_test.dir/Set_test.cpp.o
[100%] Linking CXX executable Set_test
[100%] Built target Set_test
```
* Run the tests:
```bash
libSetReplace/test/Set_test
```
```
Running main() from [...]/build/_deps/googletest-src/googletest/src/gtest_main.cc
[==========] Running 3 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 3 tests from Set
[ RUN      ] Set.globalSpacelike
[       OK ] Set.globalSpacelike (0 ms)
[ RUN      ] Set.matchAllMultiway
[       OK ] Set.matchAllMultiway (1 ms)
[ RUN      ] Set.replaceOnce
[       OK ] Set.replaceOnce (0 ms)
[----------] 3 tests from Set (1 ms total)

[----------] Global test environment tear-down
[==========] 3 tests from 1 test case ran. (1 ms total)
[  PASSED  ] 3 tests.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/444)
<!-- Reviewable:end -->
