### PR TITLE
Removing "performance" tests from CI

### DIFF
--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 rm -f exit_status.txt
-STATUS_FILE=1 ./test.wls
+STATUS_FILE=1 ./test.wls -e performance
 [[ -f exit_status.txt && $(< exit_status.txt) == "0" ]]

--- a/test.wls
+++ b/test.wls
@@ -14,7 +14,13 @@ $successQ = True;
 (* Get test files *)
 
 $testFiles = If[Length @ $ScriptCommandLine >= 2,
-  FileNameJoin[{AbsoluteFileName["."], "Tests", # <> ".wlt"}] & /@ $ScriptCommandLine[[2 ;; ]],
+  Replace[$ScriptCommandLine[[2 ;; ]], {
+    args : {"-e", ___} :> Select[
+      FileNames[FileNameJoin[{AbsoluteFileName["."], "Tests", "*.wlt"}]],
+      !MatchQ[FileBaseName @ #, Alternatives @@ Rest[args]] &
+    ],
+    args_List :> (FileNameJoin[{AbsoluteFileName["."], "Tests", # <> ".wlt"}] & /@ args)}
+  ],
   FileNames[FileNameJoin[{AbsoluteFileName["."], "Tests", "*.wlt"}]]
 ];
 


### PR DESCRIPTION
## Changes
* Close #223.
* Adding `-e` option in `./test.wls`: this runs all tests except the ones specified after `-e`.
* Modifying `.circleci/test.sh` to run `./test.wls -e performance` instead of `./test.wls`.

## Examples
```
./test.wls -e performance evolutionConsistency WolframModelPlot matching WolframModel WolframModelEvolutionObject
```
![image](https://user-images.githubusercontent.com/40190339/95693820-f9bfff00-0bf3-11eb-9d9a-066bbc80c0c9.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/451)
<!-- Reviewable:end -->
