### PR TITLE
Fix broken message for invalid options in WolframModel

### DIFF
--- a/Kernel/WolframModel.m
+++ b/Kernel/WolframModel.m
@@ -137,7 +137,7 @@ expr : WolframModel[
       initSpec_ ? wolframModelInitSpecQ,
       stepsSpec : _ ? wolframModelStepsSpecQ : 1,
       property : _ ? wolframModelPropertyQ : "EvolutionObject",
-      o : OptionsPattern[]] /; recognizedOptionsQ[expr, WolframModel, {o}]:=
+      o : OptionsPattern[]] /; recognizedOptionsQ[expr, WolframModel, {o}] :=
   Module[{
       patternRules, initialSet, steps, terminationReasonOverride, optionsOverride, abortBehavior, overridenOptionValue,
       evolution, modifiedEvolution, propertyEvaluateWithOptions, result},

--- a/Kernel/WolframModel.m
+++ b/Kernel/WolframModel.m
@@ -137,7 +137,7 @@ expr : WolframModel[
       initSpec_ ? wolframModelInitSpecQ,
       stepsSpec : _ ? wolframModelStepsSpecQ : 1,
       property : _ ? wolframModelPropertyQ : "EvolutionObject",
-      o : OptionsPattern[] /; recognizedOptionsQ[expr, WolframModel, {o}]] :=
+      o : OptionsPattern[]] /; recognizedOptionsQ[expr, WolframModel, {o}]:=
   Module[{
       patternRules, initialSet, steps, terminationReasonOverride, optionsOverride, abortBehavior, overridenOptionValue,
       evolution, modifiedEvolution, propertyEvaluateWithOptions, result},


### PR DESCRIPTION
## Changes
* Closes #463.
* Taking outside the condition `recognizedOptionQ` in `WolframModel` so that `expr` can be passed correctly to it.

## Examples

```wl
In[] := WolframModel[1 -> 3, {1, 2}, Metho -> "WolframLanguage"]
```
![image](https://user-images.githubusercontent.com/40190339/95947910-2e2ee900-0db5-11eb-9853-0d2b293a1456.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/465)
<!-- Reviewable:end -->
