### PR TITLE
Avoid unnecessary step limit checks

### DIFF
--- a/libSetReplace/Set.cpp
+++ b/libSetReplace/Set.cpp
@@ -86,9 +86,7 @@ class Set::Implementation {
     const auto explicitRuleOutputs = matcher_.matchOutputAtomsVectors(match);
 
     // only makes sense to have final state step limits for a singleway system.
-    if (!isMultiway() &&
-        (stepSpec_.maxFinalAtomDegree != stepLimitDisabled || stepSpec_.maxFinalAtoms != stepLimitDisabled ||
-         stepSpec_.maxFinalExpressions != stepLimitDisabled)) {
+    if (!isMultiway()) {
       for (const auto function : {&Implementation::willExceedAtomLimits, &Implementation::willExceedExpressionsLimit}) {
         const auto willExceedAtomLimitsStatus = (this->*function)(explicitRuleInputs, explicitRuleOutputs);
         if (willExceedAtomLimitsStatus != TerminationReason::NotTerminated) {
@@ -229,6 +227,10 @@ class Set::Implementation {
 
   TerminationReason willExceedAtomLimits(const std::vector<AtomsVector>& explicitRuleInputs,
                                          const std::vector<AtomsVector>& explicitRuleOutputs) const {
+    if (stepSpec_.maxFinalAtoms == stepLimitDisabled || stepSpec_.maxFinalAtomDegree == stepLimitDisabled) {
+      return TerminationReason::NotTerminated;
+    }
+
     const int64_t currentAtomsCount = static_cast<int64_t>(atomDegrees_.size());
 
     std::unordered_map<Atom, int64_t> atomDegreeDeltas;
@@ -276,6 +278,10 @@ class Set::Implementation {
 
   TerminationReason willExceedExpressionsLimit(const std::vector<AtomsVector>& explicitRuleInputs,
                                                const std::vector<AtomsVector>& explicitRuleOutputs) const {
+    if (stepSpec_.maxFinalExpressions == stepLimitDisabled) {
+      return TerminationReason::NotTerminated;
+    }
+
     const int64_t currentExpressionsCount = causalGraph_.expressionsCount() - destroyedExpressionsCount_;
     const int64_t newExpressionsCount = currentExpressionsCount - static_cast<int64_t>(explicitRuleInputs.size()) +
                                         static_cast<int64_t>(explicitRuleOutputs.size());

--- a/libSetReplace/Set.cpp
+++ b/libSetReplace/Set.cpp
@@ -227,7 +227,7 @@ class Set::Implementation {
 
   TerminationReason willExceedAtomLimits(const std::vector<AtomsVector>& explicitRuleInputs,
                                          const std::vector<AtomsVector>& explicitRuleOutputs) const {
-    if (stepSpec_.maxFinalAtoms == stepLimitDisabled || stepSpec_.maxFinalAtomDegree == stepLimitDisabled) {
+    if (stepSpec_.maxFinalAtoms == stepLimitDisabled && stepSpec_.maxFinalAtomDegree == stepLimitDisabled) {
       return TerminationReason::NotTerminated;
     }
 

--- a/libSetReplace/Set.cpp
+++ b/libSetReplace/Set.cpp
@@ -86,7 +86,9 @@ class Set::Implementation {
     const auto explicitRuleOutputs = matcher_.matchOutputAtomsVectors(match);
 
     // only makes sense to have final state step limits for a singleway system.
-    if (!isMultiway()) {
+    if (!isMultiway() &&
+        (stepSpec_.maxFinalAtomDegree != stepLimitDisabled || stepSpec_.maxFinalAtoms != stepLimitDisabled ||
+         stepSpec_.maxFinalExpressions != stepLimitDisabled)) {
       for (const auto function : {&Implementation::willExceedAtomLimits, &Implementation::willExceedExpressionsLimit}) {
         const auto willExceedAtomLimitsStatus = (this->*function)(explicitRuleInputs, explicitRuleOutputs);
         if (willExceedAtomLimitsStatus != TerminationReason::NotTerminated) {


### PR DESCRIPTION
## Changes
* Avoid performing unnecessary checks for step limits (final expressions/atoms count, and atom degrees) if the corresponding step limits are disabled.

## Comments
* Find while browsing results from #428.

## Examples
* Run performance tests:
```
> ./performanceTest.wls master avoidUnnecessaryTerminationChecks 20
Testing master
Build done.
Uninstalling previous SetReplace at /Users/maxitg/Library/Mathematica/Paclets/Repository/SetReplace-0.3.64
Installed to /Users/maxitg/Library/Mathematica/Paclets/Repository/SetReplace-0.3.66
Restart running kernels to complete installation.

CloudConnect::clver: Connecting to a cloud running an earlier version of the Wolfram Engine: 12.1

Testing avoidUnnecessaryTerminationChecks
Build done.
Uninstalling previous SetReplace at /Users/maxitg/Library/Mathematica/Paclets/Repository/SetReplace-0.3.66
Installed to /Users/maxitg/Library/Mathematica/Paclets/Repository/SetReplace-0.3.66
Restart running kernels to complete installation.

Single-input rule                       2.0 ± 0.4 %
Medium rule                             2.3 ± 0.4 %
Sequential rule                         4.8 ± 0.4 %
Large rule                              0.2 ± 0.6 %
Exponential-match-count rule            -1.4 ± 0.6 %
CA emulator                             1.8 ± 1.0 %
```


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/469)
<!-- Reviewable:end -->
