### PR TITLE
Fix Evolution object with multiple numeric arguments leaking internal symbols

### DIFF
--- a/Kernel/WolframModelEvolutionObject.m
+++ b/Kernel/WolframModelEvolutionObject.m
@@ -247,7 +247,7 @@ propertyEvaluate[___][
   Throw[$Failed]
 )
 
-General::invalidNargs = "`1` is called with `2` arguments. " <>
+WolframModelEvolutionObject::invalidNargs = "`1` is called with `2` arguments. " <>
   "Either 1 argument is expected for implicit \"Generation\", or a property " <>
   "name is expected as the first argument.";
 
@@ -256,7 +256,10 @@ propertyEvaluate[___][
     caller_,
     g_Integer,
     args__] := (
-  Message[caller::invalidNargs, HoldForm[WolframModelEvolutionObject[data][g, args]], Length @ {g, args}];
+  Message[
+    WolframModelEvolutionObject::invalidNargs,
+    HoldForm[WolframModelEvolutionObject[data][g, args]],
+    Length @ {g, args}];
   Throw[$Failed]
 )
 

--- a/Kernel/WolframModelEvolutionObject.m
+++ b/Kernel/WolframModelEvolutionObject.m
@@ -247,6 +247,19 @@ propertyEvaluate[___][
   Throw[$Failed]
 )
 
+General::invalidNargs = "`1` is called with `2` arguments. " <>
+  "Either 1 argument is expected for implicit \"Generation\", or a property " <>
+  "name is expected as the first argument.";
+
+propertyEvaluate[___][
+    WolframModelEvolutionObject[data_ ? evolutionDataQ],
+    caller_,
+    g_Integer,
+    args__] := (
+  Message[caller::invalidNargs, HoldForm[WolframModelEvolutionObject[data][g, args]], Length @ {g, args}];
+  Throw[$Failed]
+)
+
 (* Check options *)
 
 $newCausalGraphOptions = {Background -> Automatic, VertexStyle -> Automatic, EdgeStyle -> Automatic};

--- a/Tests/WolframModelEvolutionObject.wlt
+++ b/Tests/WolframModelEvolutionObject.wlt
@@ -24,6 +24,13 @@
 
       (** Argument checks **)
 
+      (** Leaking internal symbols when implicit "Generations" called with more than 1 argument (#160)  **)
+
+      testUnevaluated[
+        WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}][1, 2],
+        {WolframModelEvolutionObject::invalidNargs}
+      ],
+
       (* Corrupt object *)
 
       testUnevaluated[

--- a/Tests/WolframModelEvolutionObject.wlt
+++ b/Tests/WolframModelEvolutionObject.wlt
@@ -24,11 +24,13 @@
 
       (** Argument checks **)
 
-      (** Leaking internal symbols when implicit "Generations" called with more than 1 argument (#160)  **)
+      (** Leaking internal symbols when implicit "Generations" is called with more than 1 argument (#160)  **)
 
-      testUnevaluated[
+      VerificationTest[
         WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}][1, 2],
-        {WolframModelEvolutionObject::invalidNargs}
+        WolframModelEvolutionObject[___][1, 2],
+        {WolframModelEvolutionObject::invalidNargs},
+        SameTest -> MatchQ
       ],
 
       (* Corrupt object *)


### PR DESCRIPTION
## Changes
* Closes #160.
* Adding error message when implicit `"Generations"` is called with additional arguments.

## Comments
* I'm unsure whether I should put the message in `makeMessage.m`.

## Examples
```wl
In[] := obj = WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}];
obj[1, 1]
```
![image](https://user-images.githubusercontent.com/40190339/96023071-7b43a700-0e17-11eb-9c1e-128ecff34639.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/470)
<!-- Reviewable:end -->
