### PR TITLE
Added support for passing WolframModelEvolutionObject to RulePlot

### DIFF
--- a/Kernel/RulePlot.m
+++ b/Kernel/RulePlot.m
@@ -59,6 +59,16 @@ WolframModel /: func : RulePlot[wm : WolframModel[args___] /; Quiet[Developer`Ch
     result /; result =!= $Failed
   ]
 
+(* Evolution object *)
+
+WolframModelEvolutionObject /: RulePlot[evo : WolframModelEvolutionObject[data_ ? evolutionDataQ], opts___] :=
+  Module[{result},
+    result = rulePlot$parse[{evo["Rules"]}, {opts}];
+    If[Head[result] === rulePlot$parse,
+      result = $Failed];
+    result /; result =!= $Failed
+  ]
+
 (* Arguments parsing *)
 
 rulePlot$parse[{

--- a/Kernel/WolframModelEvolutionObject.m
+++ b/Kernel/WolframModelEvolutionObject.m
@@ -6,6 +6,7 @@ PackageExport["WolframModelEvolutionObject"]
    different steps. *)
 
 PackageScope["propertyEvaluate"]
+PackageScope["evolutionDataQ"]
 
 PackageScope["$propertiesParameterless"]
 PackageScope["$newParameterlessProperties"]

--- a/Tests/RulePlot.wlt
+++ b/Tests/RulePlot.wlt
@@ -86,6 +86,18 @@
         graphicsQ[RulePlot[WolframModel[{{{1}} -> {{2}}, {{1}} -> {{2}}}]]]
       ],
 
+      (** malformed WolframModelEvolutionObject **)
+
+      testUnevaluated[
+        RulePlot[WolframModelEvolutionObject[],
+        {WolframModelEvolutionObject::argx}
+      ],
+
+      testUnevaluated[
+        RulePlot[WolframModelEvolutionObject[<|"Version" -> 2|>]],
+        {WolframModelEvolutionObject::corrupt}
+      ],
+
       (* Options *)
 
       (** EdgeType **)

--- a/Tests/RulePlot.wlt
+++ b/Tests/RulePlot.wlt
@@ -299,6 +299,12 @@
         RulePlot::elementwiseStyle
       ] & /@ {VertexStyle, EdgeStyle, "EdgePolygonStyle"},
 
+      (** WolframModelEvolutionObject (#230) **)
+      VerificationTest[
+        RulePlot[WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}]],
+        RulePlot[WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}]]
+      ],
+
       VerificationTest[
         FirstCase[
           checkGraphics @ RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], VertexSize -> 0.213],

--- a/Tests/RulePlot.wlt
+++ b/Tests/RulePlot.wlt
@@ -89,7 +89,7 @@
       (** malformed WolframModelEvolutionObject **)
 
       testUnevaluated[
-        RulePlot[WolframModelEvolutionObject[],
+        RulePlot[WolframModelEvolutionObject[]],
         {WolframModelEvolutionObject::argx}
       ],
 

--- a/performanceTest.wls
+++ b/performanceTest.wls
@@ -118,7 +118,7 @@ differenceString[meanAround_] := With[{
   If[5 * magnitude[[2]] < Abs[magnitude[[1]]], If[magnitude[[1]] > 0, $greenColor, $redColor], $whiteColor] <>
   FirstCase[
     MakeBoxes[magnitude, StandardForm],
-    TemplateBox[{value_, error_}, "Around"] :> value <> " \[PlusMinus] " <> error <> " %"] <>
+    TemplateBox[{value_, error_}, "Around", ___] :> value <> " \[PlusMinus] " <> error <> " %"] <>
   $endColor
 ]
 


### PR DESCRIPTION
## Changes
* Closes #230.
* Added support for passing `WolframModelEvolutionObject` to `RulePlot`.
* Adding `PackageScope[evolutionDataQ]` to test the wellness of the object.

## Comments
* Is `evolutionDataQ` the best way to test that an evolution object is correct?

## Examples

```wl
In[] := obj = WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}];
RulePlot[obj]
```
![image](https://user-images.githubusercontent.com/40190339/96029868-dd54da00-0e20-11eb-9f09-394ab26f8984.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/471)
<!-- Reviewable:end -->
