### PR TITLE
Add IndexHypergraph function

### DIFF
--- a/Kernel/HypergraphUnifications.m
+++ b/Kernel/HypergraphUnifications.m
@@ -92,7 +92,7 @@ vertexIdentificationRules[match_] :=
 findUnion[e1_, e2_, edgeMatch_, vertexMatch_] := With[{
     uniqueE1Edges = Complement[Range[Length[e1]], Keys[edgeMatch]],
     uniqueE2Edges = Complement[Range[Length[e2]], Values[edgeMatch]]}, {
-  indexHypergraph[Replace[
+  IndexHypergraph[Replace[
     Join[e1[[uniqueE1Edges]], e2[[uniqueE2Edges]], e1[[Keys[edgeMatch]]]],
     vertexIdentificationRules[vertexMatch],
     {2}]],

--- a/Kernel/IndexHypergraph.m
+++ b/Kernel/IndexHypergraph.m
@@ -25,9 +25,9 @@ expr : IndexHypergraph[hgraph_, r : _ : 1] := ModuleScope[
 ]
 
 (* Normal form *)
-indexHypergraph[_, hgraph_ ? hypergraphQ, r : _Integer?IntegerQ] := ModuleScope[
+indexHypergraph[_, hgraph_ ? hypergraphQ, start : _Integer ? IntegerQ] := ModuleScope[
   vertices = vertexList @ hgraph;
-  vertexIndices = Range[0, Length[vertices] - 1] + r;
+  vertexIndices = Range[0, Length[vertices] - 1] + start;
   Replace[hgraph, Thread[vertices -> vertexIndices], {2}]
 ]
 

--- a/Kernel/IndexHypergraph.m
+++ b/Kernel/IndexHypergraph.m
@@ -1,0 +1,41 @@
+Package["SetReplace`"]
+
+PackageImport["GeneralUtilities`"]
+
+PackageExport["IndexHypergraph"]
+
+(* Documentation *)
+IndexHypergraph::usage = usageString[
+  "IndexHypergraph[`h`] replaces the vertices of the hypergraph `h` by its vertex indices.",
+  "\n",
+  "IndexHypergraph[`h`, `r`] replaces the vertices with integers `r`, `r + 1`, \[Ellipsis]."];
+
+(* SyntaxInformation *)
+SyntaxInformation[IndexHypergraph] =
+  {"ArgumentsPattern" -> {_, _.}};
+
+(* Argument count *)
+IndexHypergraph[args___] := 0 /;
+  !Developer`CheckArgumentCount[IndexHypergraph[args], 1, 2] && False
+
+(* main *)
+expr : IndexHypergraph[hgraph_, r : _ : 1] := ModuleScope[
+  res = Catch[indexHypergraph[HoldForm @ expr, hgraph, r]];
+  res /; res =!= $Failed
+]
+
+(* Normal form *)
+indexHypergraph[_, hgraph_ ? hypergraphQ, r : _Integer?IntegerQ] := ModuleScope[
+  vertices = vertexList @ hgraph;
+  vertexIndices = Range[0, Length[vertices] - 1] + r;
+  Replace[hgraph, Thread[vertices -> vertexIndices], {2}]
+]
+
+(* Incorrect arguments messages *)
+indexHypergraph[expr_, hgraph_ ? (Not @* hypergraphQ), ___] :=
+  (Message[IndexHypergraph::invalidHypergraph, 1, HoldForm @ expr];
+  Throw[$Failed])
+
+indexHypergraph[expr_, _ , r_] :=
+  (Message[IndexHypergraph::int, expr, 2];
+  Throw[$Failed])

--- a/Kernel/IndexHypergraph.m
+++ b/Kernel/IndexHypergraph.m
@@ -19,8 +19,8 @@ IndexHypergraph[args___] := 0 /;
   !Developer`CheckArgumentCount[IndexHypergraph[args], 1, 2] && False
 
 (* main *)
-expr : IndexHypergraph[hgraph_, r : _ : 1] := ModuleScope[
-  res = Catch[indexHypergraph[HoldForm @ expr, hgraph, r]];
+expr : IndexHypergraph[hgraph_, start : _ : 1] := ModuleScope[
+  res = Catch[indexHypergraph[HoldForm @ expr, hgraph, start]];
   res /; res =!= $Failed
 ]
 
@@ -36,6 +36,6 @@ indexHypergraph[expr_, hgraph_ ? (Not @* hypergraphQ), ___] :=
   (Message[IndexHypergraph::invalidHypergraph, 1, HoldForm @ expr];
   Throw[$Failed])
 
-indexHypergraph[expr_, _ , r_] :=
+indexHypergraph[expr_, _ , _] :=
   (Message[IndexHypergraph::int, expr, 2];
   Throw[$Failed])

--- a/Kernel/Subhypergraph.m
+++ b/Kernel/Subhypergraph.m
@@ -49,9 +49,6 @@ expr : WeakSubhypergraph[args0___][args1___] := With[{res = Catch[weakSubhypergr
   res /; res =!= $Failed
 ]
 
-(* Helper *)
-hypergraphQ = MatchQ[#, {___List}] &;
-
 (* Normal form *)
 subhypergraph[_, h_ ? hypergraphQ, vertices_List] := Select[h, SubsetQ[vertices, #] &]
 
@@ -60,8 +57,6 @@ weakSubhypergraph[_, h_ ? hypergraphQ, vertices_List] := Select[h, ContainsAny[#
 (* Incorrect arguments messages *)
 
 (** hypergraph **)
-General::invalidHypergraph =
-  "The argument at position `1` in `2` is not a valid hypergraph.";
 
 subhypergraph[expr_, h_ ? (Not @* hypergraphQ), _] :=
   (Message[Subhypergraph::invalidHypergraph, 1, HoldForm @ expr];
@@ -72,8 +67,6 @@ weakSubhypergraph[expr_, h_ ? (Not @* hypergraphQ), _] :=
   Throw[$Failed])
 
 (** vertices **)
-General::invalidList =
-  "The argument at position `1` in `2` is not a list.";
 
 subhypergraph[expr_, _ , v : Except[_List]] :=
   (Message[Subhypergraph::invalidList, 2, expr];

--- a/Kernel/Subhypergraph.m
+++ b/Kernel/Subhypergraph.m
@@ -69,11 +69,11 @@ weakSubhypergraph[expr_, h_ ? (Not @* hypergraphQ), _] :=
 (** vertices **)
 
 subhypergraph[expr_, _ , v : Except[_List]] :=
-  (Message[Subhypergraph::invalidList, 2, expr];
+  (Message[Subhypergraph::invl, 2];
   Throw[$Failed])
 
 weakSubhypergraph[expr_, _ , v : Except[_List]] :=
-  (Message[WeakSubhypergraph::invalidList, 2, expr];
+  (Message[WeakSubhypergraph::invl, 2];
   Throw[$Failed])
 
 (* operator form *)
@@ -85,11 +85,11 @@ weakSubhypergraph[_][vertices_List][h_ ? hypergraphQ] := weakSubhypergraph[None,
 
 (** vertices **)
 subhypergraph[expr_][Except[_List]][_] :=
-  (Message[Subhypergraph::invalidList, {0, 1}, expr];
+  (Message[Subhypergraph::invl, {0, 1}];
   Throw[$Failed])
 
 weakSubhypergraph[expr_][Except[_List]][_] :=
-  (Message[WeakSubhypergraph::invalidList, {0, 1}, expr];
+  (Message[WeakSubhypergraph::invl, {0, 1}];
   Throw[$Failed])
 
 (** hypergraph **)

--- a/Kernel/utilities.m
+++ b/Kernel/utilities.m
@@ -53,6 +53,3 @@ hypergraphQ = MatchQ[#, {___List}] &;
 
 General::invalidHypergraph =
   "The argument at position `1` in `2` is not a valid hypergraph.";
-
-General::invalidList =
-  "The argument at position `1` in `2` is not a list.";

--- a/Kernel/utilities.m
+++ b/Kernel/utilities.m
@@ -7,10 +7,10 @@ PackageScope["multisetComplement"]
 PackageScope["multisetFilterRules"]
 PackageScope["toCanonicalHypergraphForm"]
 PackageScope["vertexList"]
-PackageScope["indexHypergraph"]
 PackageScope["connectedHypergraphQ"]
 PackageScope["mapHold"]
 PackageScope["heldPart"]
+PackageScope["hypergraphQ"]
 
 fromCounts[association_] := Catenate @ KeyValueMap[ConstantArray] @ association
 
@@ -33,11 +33,9 @@ toCanonicalEdgeForm[edge : Except[_List]] := {edge}
 
 toCanonicalEdgeForm[edge_List] := edge
 
-vertexList[edges_] := Sort[Union[Catenate[toCanonicalHypergraphForm[edges]]]]
+vertexList[canonicalHypergraph_ ? hypergraphQ] := Sort @ Union @ Catenate @ canonicalHypergraph
 
-indexHypergraph[e_] := With[{vertices = vertexList[e]},
-  Replace[toCanonicalHypergraphForm[e], Thread[vertices -> Range[Length[vertices]]], {2}]
-]
+vertexList[edges_] := vertexList[toCanonicalHypergraphForm @ edges]
 
 connectedHypergraphQ[edges_] := ConnectedGraphQ[Graph[Catenate[toNormalEdges /@ toCanonicalHypergraphForm[edges]]]]
 
@@ -50,3 +48,11 @@ mapHold[expr_, level_ : {1}] := Map[Hold, Unevaluated[expr], level]
 SetAttributes[heldPart, HoldFirst];
 
 heldPart[expr_, part__Integer] := Extract[Unevaluated[expr], {part}, Hold]
+
+hypergraphQ = MatchQ[#, {___List}] &;
+
+General::invalidHypergraph =
+  "The argument at position `1` in `2` is not a valid hypergraph.";
+
+General::invalidList =
+  "The argument at position `1` in `2` is not a list.";

--- a/README.md
+++ b/README.md
@@ -2037,7 +2037,7 @@ In[]:= IndexHypergraph[{{x, y, z}, {w, y}, {z, {x}, {{y}}}}]
 Out[]= {{2, 3, 4}, {1, 3}, {4, 5, 6}}
 ```
 
-Replace the vertices with indices starting from -10:
+Replace the vertices with integers starting from -10:
 
 ```wl
 In[]:= IndexHypergraph[{{x, y, z}, {w, y}, {z, {x}, {{y}}}}, -10]

--- a/README.md
+++ b/README.md
@@ -2026,17 +2026,33 @@ In[] := RulePlot[WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}],
 
 ## Utility Functions
 
-[Subhypergraph](#subhypergraph) | [WolframModelRuleValue](#wolframmodelrulevalue) | [GeneralizedGridGraph](#generalizedgridgraph) | [HypergraphAutomorphismGroup](#hypergraphautomorphismgroup) | [HypergraphUnifications](#hypergraphunifications) | [WolframPhysicsProjectStyleData](#wolframphysicsprojectstyledata) | [Build Data](#build-data)
+[IndexHypergraph](#indexhypergraph) | [Subhypergraph](#subhypergraph) | [WolframModelRuleValue](#wolframmodelrulevalue) | [GeneralizedGridGraph](#generalizedgridgraph) | [HypergraphAutomorphismGroup](#hypergraphautomorphismgroup) | [HypergraphUnifications](#hypergraphunifications) | [WolframPhysicsProjectStyleData](#wolframphysicsprojectstyledata) | [Build Data](#build-data)
+
+### IndexHypergraph
+
+**`IndexHypergraph`** replaces the vertices of the hypergraph by its vertex indices:
+
+```wl
+In[]:= IndexHypergraph[{{x, y, z}, {w, y}, {z, {x}, {{y}}}}]
+Out[]= {{2, 3, 4}, {1, 3}, {4, 5, 6}}
+```
+
+Replace the vertices with indices starting from -10:
+
+```wl
+In[]:= IndexHypergraph[{{x, y, z}, {w, y}, {z, {x}, {{y}}}}, -10]
+Out[]= {{-9, -8, -7}, {-10, -8}, {-7, -6, -5}}
+```
 
 ### Subhypergraph
 
-**`Subhypergraph`** is a small utility function that selects hyperedges that only contain vertices from the requested list.
+**`Subhypergraph`** is a small utility function that selects hyperedges that only contain vertices from the requested list:
 
 ```wl
 In[]:= Subhypergraph[{{1, 1, 1}, {1, 2}, {2, 3, 3}, {2, 3, 4}}, {2, 3, 4}]
 Out[]= {{2, 3, 3}, {2, 3, 4}}
 ```
-**`WeakSubhypergraph`** is the weak version of the previous function, where hyperedges are selected if they contain any vertex from the requested list.
+**`WeakSubhypergraph`** is the weak version of the previous function, where hyperedges are selected if they contain any vertex from the requested list:
 
 ```wl
 In[]:= WeakSubhypergraph[{{1, 1}, {2, 3}, {3, 4, 4}}, {1, 3}]

--- a/Tests/IndexHypergraph.wlt
+++ b/Tests/IndexHypergraph.wlt
@@ -1,0 +1,65 @@
+<|
+  "Subhypergraph" -> <|
+    "init" -> (
+      Attributes[Global`testUnevaluated] = {HoldAll};
+      Global`testUnevaluated[args___] := SetReplace`PackageScope`testUnevaluated[VerificationTest, args];
+    ),
+    "tests" -> {
+
+      VerificationTest[
+        IndexHypergraph[{}],
+        {}
+      ],
+
+      VerificationTest[
+        IndexHypergraph[{{{1}}}],
+        {{1}}
+      ],
+
+      VerificationTest[
+        Subhypergraph[{}, {1}],
+        {}
+      ],
+
+      VerificationTest[
+        IndexHypergraph[{Range[5]}, -10],
+        {{-10, -9, -8, -7, -6}}
+      ],
+
+      VerificationTest[
+        IndexHypergraph[{{x, y, z}, {y, z}, {y, y, x, z}}, 2],
+        {{2, 3, 4}, {3, 4}, {3, 3, 2, 4}}
+      ],
+
+      (* unevaluated *)
+
+      (** argument count **)
+      testUnevaluated[
+        IndexHypergraph[],
+        {IndexHypergraph::argt}
+      ],
+
+      testUnevaluated[
+        IndexHypergraph[{{x, y, z}, {y, z}}, 2, 3],
+        {IndexHypergraph::argt}
+      ],
+
+      (** first argument **)
+      testUnevaluated[
+        IndexHypergraph[{x, y, {z}}],
+        {IndexHypergraph::invalidHypergraph}
+      ],
+
+      testUnevaluated[
+        IndexHypergraph[{x, y, {z}}, 2],
+        {IndexHypergraph::invalidHypergraph}
+      ],
+
+      (** second argument **)
+      testUnevaluated[
+        IndexHypergraph[{{x, y, z}, {y, z, y}}, x],
+        {IndexHypergraph::int}
+      ]
+    }
+  |>
+|>

--- a/Tests/IndexHypergraph.wlt
+++ b/Tests/IndexHypergraph.wlt
@@ -12,6 +12,11 @@
       ],
 
       VerificationTest[
+        IndexHypergraph[{{}}],
+        {{}}
+      ],
+
+      VerificationTest[
         IndexHypergraph[{{{1}}}],
         {{1}}
       ],
@@ -24,6 +29,11 @@
       VerificationTest[
         IndexHypergraph[{{x, y, z}, {y, z}, {y, y, x, z}}, 2],
         {{2, 3, 4}, {3, 4}, {3, 3, 2, 4}}
+      ],
+
+      VerificationTest[
+        IndexHypergraph[{Range[10, 6, -1], Range[-5, -1]}],
+        {{10, 9, 8, 7, 6}, {1, 2, 3, 4, 5}}
       ],
 
       (* unevaluated *)

--- a/Tests/IndexHypergraph.wlt
+++ b/Tests/IndexHypergraph.wlt
@@ -1,5 +1,5 @@
 <|
-  "Subhypergraph" -> <|
+  "IndexHypergraph" -> <|
     "init" -> (
       Attributes[Global`testUnevaluated] = {HoldAll};
       Global`testUnevaluated[args___] := SetReplace`PackageScope`testUnevaluated[VerificationTest, args];
@@ -17,7 +17,7 @@
       ],
 
       VerificationTest[
-        Subhypergraph[{}, {1}],
+        IndexHypergraph[{}, {1}],
         {}
       ],
 

--- a/Tests/IndexHypergraph.wlt
+++ b/Tests/IndexHypergraph.wlt
@@ -17,11 +17,6 @@
       ],
 
       VerificationTest[
-        IndexHypergraph[{}, {1}],
-        {}
-      ],
-
-      VerificationTest[
         IndexHypergraph[{Range[5]}, -10],
         {{-10, -9, -8, -7, -6}}
       ],

--- a/Tests/Subhypergraph.wlt
+++ b/Tests/Subhypergraph.wlt
@@ -57,7 +57,7 @@
       (** Wrong second argument **)
       testUnevaluated[
         Subhypergraph[{{1, 1, 2}, {2, 3}, {2, 3, 4}}, 1],
-        {Subhypergraph::invalidList}
+        {Subhypergraph::invl}
       ],
 
       (* Subhypergraph / operator form *)
@@ -86,12 +86,12 @@
       (** Wrong zeroth argument **)
       testUnevaluated[
         Subhypergraph[1][{{1, 2}, {2, 3, 4}}],
-        {Subhypergraph::invalidList}
+        {Subhypergraph::invl}
       ],
 
       testUnevaluated[
         Subhypergraph[1][{2, 3, 4}],
-        {Subhypergraph::invalidList}
+        {Subhypergraph::invl}
       ],
 
       (** Wrong first argument **)
@@ -152,7 +152,7 @@
       (** Wrong second argument **)
       testUnevaluated[
         WeakSubhypergraph[{{1, 1, 2}, {2, 3}, {2, 3, 4}}, 1],
-        {WeakSubhypergraph::invalidList}
+        {WeakSubhypergraph::invl}
       ],
 
       (* WeakSubhypergraph / operator form *)
@@ -181,12 +181,12 @@
       (** Wrong zeroth argument **)
       testUnevaluated[
         WeakSubhypergraph[1][{{1, 2}, {2, 3, 4}}],
-        {WeakSubhypergraph::invalidList}
+        {WeakSubhypergraph::invl}
       ],
 
       testUnevaluated[
         WeakSubhypergraph[1][{2, 3, 4}],
-        {WeakSubhypergraph::invalidList}
+        {WeakSubhypergraph::invl}
       ],
 
       (** Wrong first argument **)


### PR DESCRIPTION
## Changes
* Closes #80.
* Expose `IndexHypergraph` utility function.
* Moving `hypergraphQ` and some `General` messages to `Kernel/utilities.m`

## Comments
* Better examples of the use of this function are appreciated.

## Examples
```wl
In[] := IndexHypergraph[{{x, y, z}, {y, z, {y}}}]
Out[] = {{1, 2, 3}, {2, 3, 4}}
```

```wl
In[] := IndexHypergraph[{{x, y, z}, {y, z, y}}, -5]
Out[] = {{-5, -4, -3}, {-4, -3, -4}}
```

```wl
In[] := IndexHypergraph[]

During evaluation of In[] := IndexHypergraph::argt: IndexHypergraph called with 0 arguments; 1 or 2 arguments are expected.

Out[] = IndexHypergraph[]
```

```wl
In[] := IndexHypergraph[{x, y, {z}}, 2]

During evaluation of In[] := IndexHypergraph::invalidHypergraph: The argument at position 1 in IndexHypergraph[{x,y,{z}},2] is not a valid hypergraph.

Out[] = IndexHypergraph[{x, y, {z}}, 2]
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/473)
<!-- Reviewable:end -->
