### PR TITLE
Confluence and Causal Invariance: Remove MultiwaySystem quotes

### DIFF
--- a/Research/ConfluenceAndCausalInvariance/ConfluenceAndCausalInvariance.md
+++ b/Research/ConfluenceAndCausalInvariance/ConfluenceAndCausalInvariance.md
@@ -165,7 +165,7 @@ Out[] = False
 Therefore, confluence *does not imply* causal invariance.
 
 Note that the `"CausalInvariantQ"` property of
-[`"MultiwaySystem"`](https://resources.wolframcloud.com/FunctionRepository/resources/MultiwaySystem) checks for
+[`MultiwaySystem`](https://resources.wolframcloud.com/FunctionRepository/resources/MultiwaySystem) checks for
 confluence despite its name:
 
 ```wl


### PR DESCRIPTION
## Changes
* Removes unnecessary quotes around `MultiwaySystem`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/502)
<!-- Reviewable:end -->
