### PR TITLE
Rasterization functions to produce inputs & outputs

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -465,17 +465,19 @@ code.
 #### Markdown
 We are using GitHub-flavored Markdown for documentation and research notes.
 
-Images (e.g., of output cells) should be made by selecting the relevant cells in the Front End, copying them as bitmaps, and saving them as .png files to [Documentation/Images](/Documentation/Images) (in the documentation) or to the Images directory of the corresponding research note. They should then be inserted using the code similar to this:
+Images of input and/or output cells can be easily produced using Mathematica by running the command 
+`RasterizePreviousCell[]` in the cell that follows the output you want to capture. These images should be saved 
+to [Documentation/Images](/Documentation/Images) as PNG files. This can be done totally automatically using 
+the function `ExportImageForEmbedding["name", image]`, where "name" should be a CamelCaseDescriptiveName that 
+describes the content and intent of the image. The following code captures the previous cell and saves it in one go:
 
-  ```html
-  <img src="/Documentation/Images/image.png" width="xxx">
-  ```
+```wl
+ExportImageForEmbedding["AGoodNameGoesHere", RasterizePreviousCell[]]
+```
 
-  where the `width` should be computed as
-
-  ```wl
-  Round[0.6 First @ Import["$RepoRoot/Documentation/Images/image.png", "ImageSize"]]
-  ```
+This function will return markdown-compatible code that you can paste straight into the relevant readme or research
+note. In fact, the function will copy this code straight into your clipboard so that you can simply paste it into
+the markdown file. If you wish to capture an output without the Out[] tag, and without the corresponding input cell, you can use `RasterizeExpression[output]` in place of `RasterizePreviousCell[]`.
 
 # Research
 

--- a/Kernel/init.m
+++ b/Kernel/init.m
@@ -3,7 +3,11 @@ Unprotect["SetReplace`*"];
 ClearAll @@ (# <> "*" & /@ Contexts["SetReplace`*"]);
 
 Block[
-  {GeneralUtilities`Control`PackagePrivate`$DesugaringRules = {}},
+  {GeneralUtilities`Control`PackagePrivate`$DesugaringRules = {	
+      HoldPattern[$Unreachable] :> Unreachable[$LHSHead],
+	    HoldPattern[ReturnFailed[msg_String, args___]] :> ReturnFailed[MessageName[$LHSHead, msg], args],
+	    HoldPattern[ReturnFailure[msg_String, args___]] :> ReturnFailure[MessageName[$LHSHead, msg], args]
+  }},
   Get[FileNameJoin[{FileNameDrop[$InputFileName], "usageString.m"}]];
 ];
 

--- a/Kernel/init.m
+++ b/Kernel/init.m
@@ -5,7 +5,7 @@ ClearAll @@ (# <> "*" & /@ Contexts["SetReplace`*"]);
 SetReplace`$SetReplaceBaseDirectory = FileNameDrop[$InputFileName, -2];
 
 Block[
-  {GeneralUtilities`Control`PackagePrivate`$DesugaringRules = {	
+  {GeneralUtilities`Control`PackagePrivate`$DesugaringRules = {
       HoldPattern[$Unreachable] :> Unreachable[$LHSHead],
 	    HoldPattern[ReturnFailed[msg_String, args___]] :> ReturnFailed[MessageName[$LHSHead, msg], args],
 	    HoldPattern[ReturnFailure[msg_String, args___]] :> ReturnFailure[MessageName[$LHSHead, msg], args]

--- a/Kernel/init.m
+++ b/Kernel/init.m
@@ -2,13 +2,15 @@ Unprotect["SetReplace`*"];
 
 ClearAll @@ (# <> "*" & /@ Contexts["SetReplace`*"]);
 
+SetReplace`$SetReplaceBaseDirectory = FileNameDrop[$InputFileName, -2];
+
 Block[
   {GeneralUtilities`Control`PackagePrivate`$DesugaringRules = {	
       HoldPattern[$Unreachable] :> Unreachable[$LHSHead],
 	    HoldPattern[ReturnFailed[msg_String, args___]] :> ReturnFailed[MessageName[$LHSHead, msg], args],
 	    HoldPattern[ReturnFailure[msg_String, args___]] :> ReturnFailure[MessageName[$LHSHead, msg], args]
   }},
-  Get[FileNameJoin[{FileNameDrop[$InputFileName], "usageString.m"}]];
+  Get[FileNameJoin[{SetReplace`$SetReplaceBaseDirectory, "Kernel", "usageString.m"}]];
 ];
 
 SetAttributes[#, {Protected, ReadProtected}] & /@ Evaluate @ Names @ "SetReplace`*";

--- a/Kernel/rasterization.m
+++ b/Kernel/rasterization.m
@@ -6,8 +6,6 @@ PackageExport["RasterizeAsOutput"]
 PackageExport["RasterizeAsInput"]
 PackageExport["RasterizeAsInputOutputPair"]
 
-ClearAll[RasterizeAsOutput, RasterizeAsInput, RasterizeAsInputOutputPair]
-
 SetRelatedSymbolGroup[RasterizeAsOutput, RasterizeAsInput, RasterizeAsInputOutputPair]
 
 cellToExportPacket[cell_] := ExportPacket[cell,

--- a/Kernel/rasterization.m
+++ b/Kernel/rasterization.m
@@ -73,8 +73,8 @@ SetUsage @ "
 RasterizeAsInputOutputPair[expr$] creates an Image of expr$ formatted as both an input, \
 and the corresponding resulting output expression.
 * RasterizeAsInputOutputPair Holds expr$, preventing it from evaluating.
-* RasterAsInput[expr$] is used to create the Image of the input.
-* RasterAsOutput[expr$] is used to create the Image of the result.
+* RasterizeAsInput[expr$] is used to create the Image of the input.
+* RasterizeAsOutput[expr$] is used to create the Image of the result.
 * The Image is produced at high DPI, suitable for Retina displays.
 "
 

--- a/Kernel/rasterization.m
+++ b/Kernel/rasterization.m
@@ -45,6 +45,8 @@ RasterizeAsOutput[expr$] creates an Image of expr$, formatted graphically as an 
 * The Image is produced at high DPI, suitable for Retina displays.
 "
 
+SyntaxInformation[RasterizeAsOutput] = {"ArgumentsPattern" -> {_}};
+
 RasterizeAsOutput[expr_] := assembleWithLabel[$outputCellLabel, fastRasterize[expr, "Output"]];
 
 SetUsage @ "
@@ -53,6 +55,8 @@ RasterizeAsInput[expr$] creates an Image of expr$, formatted textually as an \"I
 * RasterizeAsInput uses PrettyForm to automatically format the given input code.
 * The Image is produced at high DPI, suitable for Retina displays.
 "
+
+SyntaxInformation[RasterizeAsInput] = {"ArgumentsPattern" -> {_}};
 
 SetAttributes[{RasterizeAsInput, RasterizeAsInputOutputPair}, HoldFirst];
 RasterizeAsInput[expr_] := assembleWithLabel[$inputCellLabel, fastRasterize[Unevaluated @ expr, "Input"]];
@@ -70,5 +74,7 @@ and the corresponding resulting output expression.
 * RasterAsOutput[expr$] is used to create the Image of the result.
 * The Image is produced at high DPI, suitable for Retina displays.
 "
+
+SyntaxInformation[RasterizeAsInputOutputPair] = {"ArgumentsPattern" -> {_}};
 
 RasterizeAsInputOutputPair[expr_] := imageColumn[{RasterizeAsInput[expr], RasterizeAsOutput[expr]}];

--- a/Kernel/rasterization.m
+++ b/Kernel/rasterization.m
@@ -24,7 +24,7 @@ SetAttributes[MakeFormattedCodeBoxes, HoldFirst];
 MakeFormattedCodeBoxes[expr_, n_:60] := Block[
   {GeneralUtilities`Formatting`PackagePrivate`$prettyFormWidth = n,
    GeneralUtilities`PackageScope`$enableReflow = False},
-	MakeFormattedBoxes[expr] /. symbol_String /;
+  MakeFormattedBoxes[expr] /. symbol_String /;
     StringMatchQ[symbol, ("GeneralUtilities`" | "SetReplace`") ~~ Except["`"]..] :>
       StringExtract[symbol, "`" -> 2]
   (* MakeFormattedBoxes fully qualifies all symbols, we strip off these two since
@@ -83,7 +83,7 @@ rasterizeExpr[expr_, type_:"Output"] :=
 
 cellLabelToImage[text_] := With[
   {img = RasterizeCell @ Cell[text, "CellLabel", "CellLabelExpired"]},
-	ImagePad[img, {{80 - ImageDimensions[img][[1]], 15}, {0, 10}}, White]];
+  ImagePad[img, {{80 - ImageDimensions[img][[1]], 15}, {0, 10}}, White]];
 
 $outputCellLabel := $outputCellLabel = cellLabelToImage["Out[\:f759\:f363]="];
 $inputCellLabel := $inputCellLabel = cellLabelToImage["In[\:f759\:f363]:="];
@@ -154,13 +154,13 @@ image and copy a markdown-compatible <img> tag to the clipboard that displays th
 "
 
 RasterizePreviousCell[] := Scope[
-	prev1 = PreviousCell[]; prev2 = PreviousCell @ prev1;
-	prev1 = NotebookRead[prev1]; prev2 = NotebookRead[prev2];
-	If[Head[prev1] =!= Cell, Return[$Failed]];
-	If[cellType[prev1] === "Output" && cellType[prev2] === "Input",
-		RasterizeCell[{prev2, prev1}],
-		RasterizeCell[prev1]
-	]
+  prev1 = PreviousCell[]; prev2 = PreviousCell @ prev1;
+  prev1 = NotebookRead[prev1]; prev2 = NotebookRead[prev2];
+  If[Head[prev1] =!= Cell, Return[$Failed]];
+  If[cellType[prev1] === "Output" && cellType[prev2] === "Input",
+    RasterizeCell[{prev2, prev1}],
+    RasterizeCell[prev1]
+  ]
 ];
 
 SetUsage @ "

--- a/Kernel/rasterization.m
+++ b/Kernel/rasterization.m
@@ -49,7 +49,7 @@ RasterizeAsOutput[expr$] creates an Image of expr$, formatted graphically as an 
 
 SyntaxInformation[RasterizeAsOutput] = {"ArgumentsPattern" -> {_}};
 
-RasterizeAsOutput[expr_] := 
+RasterizeAsOutput[expr_] :=
   assembleWithLabel[$outputCellLabel, rasterizeExpr[expr, "Output"]];
 
 SetUsage @ "
@@ -81,7 +81,7 @@ and the corresponding resulting output expression.
 
 SyntaxInformation[RasterizeAsInputOutputPair] = {"ArgumentsPattern" -> {_}};
 
-RasterizeAsInputOutputPair[expr_] := 
+RasterizeAsInputOutputPair[expr_] :=
   imageColumn[{RasterizeAsInput[expr], RasterizeAsOutput[expr]}, Magnification -> 1/2];
 
 SetUsage @ "

--- a/Kernel/rasterization.m
+++ b/Kernel/rasterization.m
@@ -174,7 +174,7 @@ correctly render on e.g. GitHub but may not render in e.g. VSCode.
 * The resulting markdown is placed on the system clipboard, ready to be pasted into a file.
 "
 
-SyntaxInformation[ExportImageForEmbedding] = {"ArgumentsPattern" -> {_String, _Image}};
+SyntaxInformation[ExportImageForEmbedding] = {"ArgumentsPattern" -> {_, _}};
 
 ExportImageForEmbedding::nodot = "The name \"``\" should not contain a file extension, since one will be added automatically.";
 ExportImageForEmbedding::notcap = "The name \"``\" should start with a capital letter and not contain any spaces.";

--- a/Kernel/rasterization.m
+++ b/Kernel/rasterization.m
@@ -29,16 +29,16 @@ toCell[expr_, type_, isize_] := Cell[
   GraphicsBoxOptions -> {ImageSize -> isize}, Graphics3DBoxOptions -> {ImageSize -> isize}
 ];
 
-rasterizeExpr[expr_, type_:"Output"] := 
+rasterizeExpr[expr_, type_:"Output"] :=
   rasterizeCell @ toCell[Unevaluated @ expr, type, Small];
 
 cellLabelToImage[text_] := With[{img = rasterizeCell @ Cell[text, "CellLabel", "CellLabelExpired"]}, 
 	ImagePad[img, {{80 - ImageDimensions[img][[1]], 15}, {0, 10}}, White]];
-	
+
 $outputCellLabel := $outputCellLabel = cellLabelToImage["Out[\:f759\:f363]="];
 $inputCellLabel := $inputCellLabel = cellLabelToImage["In[\:f759\:f363]:="];
 
-assembleWithLabel[label_, cell_] := 
+assembleWithLabel[label_, cell_] :=
   ImageAssemble[{{label, cell}}, "Fit", Background -> White, Magnification -> 1/2];
 
 SetUsage @ "
@@ -62,11 +62,11 @@ RasterizeAsInput[expr$] creates an Image of expr$, formatted textually as an \"I
 SyntaxInformation[RasterizeAsInput] = {"ArgumentsPattern" -> {_}};
 
 SetAttributes[{RasterizeAsInput, RasterizeAsInputOutputPair}, HoldFirst];
-RasterizeAsInput[expr_] := 
+RasterizeAsInput[expr_] :=
   assembleWithLabel[$inputCellLabel, rasterizeExpr[Unevaluated @ expr, "Input"]];
 
 imageColumn[images_, opts___Rule] := With[
-  {width = Max[First /@ ImageDimensions /@ images]}, 
+  {width = Max[First /@ ImageDimensions /@ images]},
   ImageAssemble[{ImageCrop[#, {width, Full}, Left, Padding -> White]} & /@ images, opts]
 ];
 

--- a/Kernel/rasterization.m
+++ b/Kernel/rasterization.m
@@ -1,0 +1,76 @@
+Package["SetReplace`"]
+
+PackageImport["GeneralUtilities`"]
+
+PackageExport["RasterizeAsOutput"]
+PackageExport["RasterizeAsInput"]
+PackageExport["RasterizeAsInputOutputPair"]
+
+ClearAll[RasterizeAsOutput, RasterizeAsInput, RasterizeAsInputOutputPair]
+
+SetRelatedSymbolGroup[RasterizeAsOutput, RasterizeAsInput, RasterizeAsInputOutputPair]
+
+cellToExportPacket[cell_] := ExportPacket[cell,
+  "BitmapPacket", ColorSpace -> RGBColor, "AlphaChannel" -> False,
+  "DataCompression" -> True, ImageResolution -> 144
+];
+
+bitmapToImage[System`ConvertersDump`Bitmap[rawString_, {width_, height_, depth_}, ___]] := Scope[
+  bytes = NumericArray[Developer`RawUncompress @ rawString, "Byte"];
+  Internal`ArrayReshapeTo[bytes, {height, width, depth}];
+  Image[Image`ReverseNumericArray[bytes, False], Interleaving -> True, Magnification -> 0.5]
+]
+
+toCell[expr_, type_, isize_] := Cell[
+  BoxData[If[type === "Input", PrettyFormBoxes @ expr, ToBoxes[Unevaluated @ expr]]],
+  type, ShowCellBracket -> False, Background -> Automatic, CellMargins -> 0,
+  CellFrameMargins -> 0, CellContext -> "Global`", 
+  GraphicsBoxOptions -> {ImageSize -> isize}, Graphics3DBoxOptions -> {ImageSize -> isize}
+];
+
+rasterizeCell[cell_Cell] := 
+	bitmapToImage @ MathLink`CallFrontEnd @ cellToExportPacket @ cell;
+
+fastRasterize[expr_, type_:"Output", size_:Medium] := rasterizeCell @ toCell[Unevaluated @ expr, type, size];
+
+cellLabelToImage[text_] := With[{img = rasterizeCell @ Cell[text, "CellLabel", "CellLabelExpired"]}, 
+	ImagePad[img, {{80 - ImageDimensions[img][[1]], 15}, {0, 10}}, White]];
+	
+$outputCellLabel := $outputCellLabel = cellLabelToImage["Out[\:f759\:f363]="];
+$inputCellLabel := $inputCellLabel = cellLabelToImage["In[\:f759\:f363]:="];
+
+assembleWithLabel[label_, cell_] := ImageAssemble[{{label, cell}}, "Fit", Background -> White];
+
+SetUsage @ "
+RasterizeAsOutput[expr$] creates an Image of expr$, formatted graphically as an \"Output\" cell.
+* Graphics[$$], Graph[$$], etc. objects within expr$ are rendered in StandardForm.
+* The Image is produced at high DPI, suitable for Retina displays.
+"
+
+RasterizeAsOutput[expr_] := assembleWithLabel[$outputCellLabel, fastRasterize[expr, "Output"]];
+
+SetUsage @ "
+RasterizeAsInput[expr$] creates an Image of expr$, formatted textually as an \"Input\" cell.
+* RasterizeAsInput Holds expr$, preventing it from evaluating.
+* RasterizeAsInput uses PrettyForm to automatically format the given input code.
+* The Image is produced at high DPI, suitable for Retina displays.
+"
+
+SetAttributes[{RasterizeAsInput, RasterizeAsInputOutputPair}, HoldFirst];
+RasterizeAsInput[expr_] := assembleWithLabel[$inputCellLabel, fastRasterize[Unevaluated @ expr, "Input"]];
+
+imageColumn[images_] := With[
+  {width = Max[First /@ ImageDimensions /@ images]}, 
+  ImageAssemble[{ImageCrop[#, {width, Full}, Left, Padding -> White]}& /@ images]
+];
+
+SetUsage @ "
+RasterizeAsInputOutputPair[expr$] creates an Image of expr$ formatted as both an input, \
+and the corresponding resulting output expression.
+* RasterizeAsInputOutputPair Holds expr$, preventing it from evaluating.
+* RasterAsInput[expr$] is used to create the Image of the input.
+* RasterAsOutput[expr$] is used to create the Image of the result.
+* The Image is produced at high DPI, suitable for Retina displays.
+"
+
+RasterizeAsInputOutputPair[expr_] := imageColumn[{RasterizeAsInput[expr], RasterizeAsOutput[expr]}];

--- a/Kernel/rasterization.m
+++ b/Kernel/rasterization.m
@@ -25,7 +25,7 @@ bitmapToImage[System`ConvertersDump`Bitmap[rawString_, {width_, height_, depth_}
 toCell[expr_, type_, isize_] := Cell[
   BoxData[If[type === "Input", PrettyFormBoxes @ expr, ToBoxes[Unevaluated @ expr]]],
   type, ShowCellBracket -> False, Background -> Automatic, CellMargins -> 0,
-  CellFrameMargins -> 0, CellContext -> "Global`", 
+  CellFrameMargins -> 0, CellContext -> "Global`",
   GraphicsBoxOptions -> {ImageSize -> isize}, Graphics3DBoxOptions -> {ImageSize -> isize}
 ];
 
@@ -67,7 +67,7 @@ RasterizeAsInput[expr_] :=
 
 imageColumn[images_, opts___Rule] := With[
   {width = Max[First /@ ImageDimensions /@ images]}, 
-  ImageAssemble[{ImageCrop[#, {width, Full}, Left, Padding -> White]}& /@ images, opts]
+  ImageAssemble[{ImageCrop[#, {width, Full}, Left, Padding -> White]} & /@ images, opts]
 ];
 
 SetUsage @ "
@@ -116,4 +116,3 @@ ExportImageForEmbedding[name_String, image_Image, opts:OptionsPattern[]] := Scop
   If[$Notebooks, CopyToClipboard[markdown]];
   markdown
 ]
-  

--- a/Kernel/rasterization.m
+++ b/Kernel/rasterization.m
@@ -101,7 +101,7 @@ ExportImageForEmbedding::nodot = "The name \"``\" should not contain a file exte
 ExportImageForEmbedding::notcap = "The name \"``\" should start with a capital letter and not contain any spaces.";
 ExportImageForEmbedding::noexport = "The image could not be exported.";
 
-$ImagesDirectory = FileNameJoin[{FileNameDrop[$InputFileName, -2], "Documentation", "Images"}];
+$ImagesDirectory = FileNameJoin[{$SetReplaceBaseDirectory, "Documentation", "Images"}];
 $ImageMarkdownTemplate = StringTemplate["<img src=\"/Documentation/Images/``\" width=\"``\">"];
 
 ExportImageForEmbedding[name_String, image_Image, opts:OptionsPattern[]] := Scope[

--- a/Kernel/usageString.m
+++ b/Kernel/usageString.m
@@ -13,3 +13,6 @@ argString[arg_] :=
 
 usageString[str__] :=
   (StringTemplate[StringJoin[{str}]] /. {TemplateSlot[s_] :> argString[s]})[]
+
+PackageExport["$SetReplaceBaseDirectory"]
+(* this is actually set in Kernel/init.m, but needs to be exported from somewhere *)

--- a/Kernel/usageString.m
+++ b/Kernel/usageString.m
@@ -14,5 +14,5 @@ argString[arg_] :=
 usageString[str__] :=
   (StringTemplate[StringJoin[{str}]] /. {TemplateSlot[s_] :> argString[s]})[]
 
-PackageExport["$SetReplaceBaseDirectory"]
 (* this is actually set in Kernel/init.m, but needs to be exported from somewhere *)
+PackageExport["$SetReplaceBaseDirectory"]

--- a/Tests/Rasterization.wlt
+++ b/Tests/Rasterization.wlt
@@ -1,0 +1,48 @@
+<|
+  "Rasterization" -> <|
+    "init" -> (
+      $dummyImage = RandomImage[1, ImageSize -> {5,5}];
+      $dummyImagePath = FileNameJoin[{$SetReplaceBaseDirectory, "Documentation", "Images", "DummyImageForTestingPurposes.png"}];
+      If[FileExistsQ[$dummyImagePath], DeleteFile[$dummyImagePath]];
+    ),
+    "options" -> <|
+      "Parallel" -> False, (* <- because we need to write a file and then read it *)
+      "RequiresFrontEnd" -> True
+    |>,
+    "tests" -> {
+
+      (* test it actually produces an image *)
+      VerificationTest[ImageQ[RasterizeAsInput[Graphics[{}]]]],
+      VerificationTest[ImageQ[RasterizeAsOutput[Graphics[{}]]]],
+      VerificationTest[ImageQ[RasterizeAsInputOutputPair[Graphics[{}]]]],
+
+      (* test image size *)
+      VerificationTest[
+        ImageDimensions[RasterizeAsOutput[Graphics[{}, ImageSize -> {200, 200}]]] == {495, 400}
+      ],
+
+      (* test for grayscale *)
+      VerificationTest[
+        Equal @@ Transpose @ Flatten[ImageData[RasterizeAsOutput[""]], 1]
+      ],
+
+     (* test that ExportImageForEmbedding produces a markdown string result *)
+      VerificationTest[
+        StringQ @ ExportImageForEmbedding["DummyImageForTestingPurposes", $dummyImage]
+      ],
+
+      (* test that the previous test produced a right file *)
+      VerificationTest[
+        FileExistsQ[$dummyImagePath]
+      ],
+
+      (* test that the image was correct *)
+      VerificationTest[
+        ImageDistance[Import[$dummyImagePath], $dummyImage] < 0.01
+      ]
+    },
+    "cleanup" -> (
+      If[FileExistsQ[$dummyImagePath], DeleteFile[$dummyImagePath]]
+    )
+  |>
+|>

--- a/Tests/Rasterization.wlt
+++ b/Tests/Rasterization.wlt
@@ -11,7 +11,38 @@
     |>,
     "tests" -> {
 
-      (* test it actually produces an image *)
+      (* test that MakeFormattedCodeBoxes works on two simple cases *)
+      VerificationTest[
+        MakeFormattedCodeBoxes[Evaluate @ Range[5]] === RowBox[{"{", RowBox[{"1", ",", " ", "2", ",", " ", "3", ",", " ", "4", ",", " ", "5"}], "}"}]
+      ],
+
+      VerificationTest[
+        MakeFormattedCodeBoxes["hello \"world\""] === "\"hello \\\"world\\\"\""
+      ],
+
+      (* test it respects the character limit *)
+      VerificationTest[
+        MakeFormattedCodeBoxes[Evaluate@Range[5], 10] === RowBox[{"{",RowBox[{"\n","\t","1",",","\n","\t","2",",","\n","\t","3",",","\n","\t","4",",","\n","\t","5","\n",""}],"}"}]
+      ],
+
+      (* test it doesn't evaluate its contents *)
+      VerificationTest[
+        $z = 0;
+        MakeFormattedCodeBoxes[$z++];
+        $z == 0
+      ],
+
+      (* test it fully qualifies (most) symbols *)
+      VerificationTest[
+	      MakeFormattedCodeBoxes[Foo`Bar`Baz] === "Foo`Bar`Baz"
+      ],
+
+      (* test it doesn't fully qualify SetReplace` context *)
+      VerificationTest[
+	      MakeFormattedCodeBoxes[MakeFormattedCodeBoxes] === "MakeFormattedCodeBoxes"
+      ],
+
+      (* test the rasterization functions actually produce an Image *)
       VerificationTest[ImageQ[RasterizeAsInput[Graphics[{}]]]],
       VerificationTest[ImageQ[RasterizeAsOutput[Graphics[{}]]]],
       VerificationTest[ImageQ[RasterizeAsInputOutputPair[Graphics[{}]]]],

--- a/Tests/Rasterization.wlt
+++ b/Tests/Rasterization.wlt
@@ -43,25 +43,26 @@
       ],
 
       (* test the rasterization functions actually produce an Image *)
-      VerificationTest[ImageQ[RasterizeAsInput[Graphics[{}]]]],
-      VerificationTest[ImageQ[RasterizeAsOutput[Graphics[{}]]]],
-      VerificationTest[ImageQ[RasterizeAsInputOutputPair[Graphics[{}]]]],
+      VerificationTest[ImageQ[RasterizeExpression[Graphics[{}]]]],
+      VerificationTest[ImageQ[RasterizeExpressionAsInput[Graphics[{}]]]],
+      VerificationTest[ImageQ[RasterizeExpressionAsOutput[Graphics[{}]]]],
+      VerificationTest[ImageQ[RasterizeExpressionAsInputOutputPair[Graphics[{}]]]],
 
       (* test that RasterizeAsInput doesn't evaluate its argument *)
       VerificationTest[
         $z = 0;
-        RasterizeAsInput[$z++];
+        RasterizeExpressionAsInput[$z++];
         $z == 0
       ],
 
       (* test image size *)
       VerificationTest[
-        ImageDimensions[RasterizeAsOutput[Graphics[{}, ImageSize -> {200, 200}]]] == {495, 400}
+        ImageDimensions[RasterizeExpressionAsOutput[Graphics[{}, ImageSize -> {200, 200}]]] == {495, 400}
       ],
 
       (* test for grayscale *)
       VerificationTest[
-        Equal @@ Transpose @ Flatten[ImageData[RasterizeAsOutput[""]], 1]
+        Equal @@ Transpose @ Flatten[ImageData[RasterizeExpressionAsOutput[""]], 1]
       ],
 
      (* test that ExportImageForEmbedding produces a markdown string result *)

--- a/Tests/Rasterization.wlt
+++ b/Tests/Rasterization.wlt
@@ -16,6 +16,13 @@
       VerificationTest[ImageQ[RasterizeAsOutput[Graphics[{}]]]],
       VerificationTest[ImageQ[RasterizeAsInputOutputPair[Graphics[{}]]]],
 
+      (* test that RasterizeAsInput doesn't evaluate its argument *)
+      VerificationTest[
+        $z = 0;
+        RasterizeAsInput[$z++];
+        $z == 0
+      ],
+
       (* test image size *)
       VerificationTest[
         ImageDimensions[RasterizeAsOutput[Graphics[{}, ImageSize -> {200, 200}]]] == {495, 400}

--- a/test.wls
+++ b/test.wls
@@ -3,11 +3,30 @@
 (* Disable messages about outdated cloud. *)
 Off[CloudConnect::clver];
 
-<< SetReplace`;
+$redColor = "\033[0;31m";
+$greenColor = "\033[0;32m";
+$orangeColor = "\033[0;33m";
+$yellowColor = "\033[1;33m";
+$endColor = "\033[0m";
+
+$localSetReplaceEntryPoint = FileNameJoin[{FileNameDrop @ $InputFileName, "Kernel", "init.m"}];
+Get[$localSetReplaceEntryPoint];
+
 (* Launch kernels preemptively to avoid "Launching kernels..." interrupting test log *)
-CloseKernels[];
-LaunchKernels[];
-ParallelEvaluate[<< SetReplace`];
+
+$commandLineArgs = Rest[$ScriptCommandLine];
+
+(* make it possible to disable parallelization, which for very short tests saves quite a 
+lot of time. *)
+If[MemberQ[$commandLineArgs, "-np"],
+  $commandLineArgs = DeleteCases[$commandLineArgs, "-np"];
+  $allowParallelization = False;
+,
+  $allowParallelization = True;
+  CloseKernels[];
+  LaunchKernels[];
+  With[{path = $localSetReplaceEntryPoint}, ParallelEvaluate[Get[path]]]
+];
 
 Needs["GeneralUtilities`"];
 
@@ -15,8 +34,8 @@ $successQ = True;
 
 (* Get test files *)
 
-$testFiles = If[Length @ $ScriptCommandLine >= 2,
-  Replace[$ScriptCommandLine[[2 ;; ]], {
+$testFiles = If[Length @ $commandLineArgs >= 1,
+  Replace[$commandLineArgs, {
     args : {"-e", ___} :> Select[
       FileNames[FileNameJoin[{AbsoluteFileName["."], "Tests", "*.wlt"}]],
       !MatchQ[FileBaseName @ #, Alternatives @@ Rest[args]] &
@@ -32,9 +51,21 @@ If[!FileExistsQ[#],
 
 (* Read tests *)
 
+printFileLineError[FileLine[file_, line_] -> error_] := Print[file <> ":" <> IntegerString[line] <> "\t" <> error];
+
+importAsHeldExpression[file_] := Module[{exprs},
+  exprs = ToExpression[Import[file, "Text"], InputForm, Hold];
+  If[FailureQ[exprs], 
+    WriteString["stdout", $redColor <> "There were syntax errors in \"" <> file <> "\"" <> $endColor <> "\n"];
+    Scan[printFileLineError, FindSyntaxErrors[file]]; 
+    Exit[1]
+  ];
+  exprs
+];
+
 $testGroups = Join @@ (
   KeyMap[ReleaseHold, #] & /@
-    ReleaseHold @ Map[Hold, ToExpression[Import[#, "Text"], InputForm, Hold], {5}] & /@ $testFiles);
+    ReleaseHold @ Map[Hold, importAsHeldExpression[#], {5}] & /@ $testFiles);
 
 Attributes[test] = Attributes[constrainedTest] = {HoldAll};
 
@@ -54,7 +85,7 @@ removeHoldFormFromInputString[input_String] := StringReplace[
 ];
 
 $results = Association[KeyValueMap[Function[{testGroupName, testGroup}, Module[{
-    testList, testResults, testReport, options, parallelQ, runInit, failedTests},
+    testList, testResults, testReport, options, parallelQ, requiresFrontEnd, runInit, failedTests},
   (* Notify the user which test group we are running *)
   WriteString["stdout",
     testGroupName,
@@ -62,10 +93,16 @@ $results = Association[KeyValueMap[Function[{testGroupName, testGroup}, Module[{
 
   (* Read options *)
   options = Association[ReleaseHold[Lookup[testGroup, "options", <||>]]];
-  parallelQ = Lookup[options, "Parallel", True];
+  parallelQ = $allowParallelization && Lookup[options, "Parallel", True];
+  requiresFrontEnd = Lookup[options, "RequiresFrontEnd", False];
+
+  (* if a frontend is required, better to start it once than again and again in each
+  test *)
+  If[requiresFrontEnd, UsingFrontEnd, Identity][
 
   (* Run init, changing VerificationTest to test in all definitions *)
   runInit[] := ReleaseHold[testGroup["init"] /. VerificationTest -> constrainedTest];
+  runCleanup[] := ReleaseHold[testGroup["cleanup"] /. VerificationTest -> constrainedTest];
   runInit[];
   If[parallelQ, ParallelEvaluate[runInit[]]];
 
@@ -74,13 +111,12 @@ $results = Association[KeyValueMap[Function[{testGroupName, testGroup}, Module[{
 
   (* Run tests in parallel *)
   testResults = If[parallelQ, ParallelMap, Map][# /. test -> VerificationTest &, testList];
-  testReport = TestReport[testResults];
 
-  $redColor = "\033[0;31m";
-  $greenColor = "\033[0;32m";
-  $orangeColor = "\033[0;33m";
-  $yellowColor = "\033[1;33m";
-  $endColor = "\033[0m";
+  runCleanup[];
+
+  ];
+
+  testReport = TestReport[testResults];
 
   (* Print the summery (green if ok, red if failed) *)
   WriteString["stdout", If[testReport["AllTestsSucceeded"],


### PR DESCRIPTION
This change introduces rasterization functions to produce input, output, and input output pairs, including the little `In[*]`, `Out[*]` cell labels. These are produced at high DPI resolutions.

Here's a screenshot of the intended behavior:

![PixelSnap 2020-11-02 at 21 25 37@2x](https://user-images.githubusercontent.com/365157/97910121-f41c8b80-1d51-11eb-8ce6-cb3f0b7f0b18.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/506)
<!-- Reviewable:end -->
