### PR TITLE
Cache libSetReplace build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ Build/
 # Built paclets
 
 *.paclet
+.builtLibSetReplaceHash

--- a/build.wls
+++ b/build.wls
@@ -1,8 +1,7 @@
 #!/usr/bin/env wolframscript
 
 Check[
-  Get[FileNameJoin[{DirectoryName[$InputFileName], "scripts", "buildInit.wl"}]];
-  deleteBuildDirectory[];,
+  Get[FileNameJoin[{DirectoryName[$InputFileName], "scripts", "buildInit.wl"}]];,
 
   Exit[1];
 ];
@@ -10,7 +9,14 @@ Check[
 $success = True;
 
 Check[
-  buildLibSetReplace[];,
+  $builtLibSetReplaceHash = builtLibSetReplaceHash[];
+  $libSetReplaceSourceHash = libSetReplaceSourceHash[];
+  If[$builtLibSetReplaceHash =!= $libSetReplaceSourceHash,
+    buildLibSetReplace[];
+    saveBuiltLibSetReplaceHash[$libSetReplaceSourceHash];,
+
+    Print["Using cached libSetReplace: ", $builtLibSetReplaceHash];
+  ],
 
   $success = False;
 ];
@@ -20,8 +26,7 @@ Check[
   $version = updateVersion[];
   $context = renameContext[Automatic, $version];
   updateBuildData[];
-  packPaclet[$context];
-  deleteBuildDirectory[];,
+  packPaclet[$context];,
 
   Exit[1];
 ];

--- a/scripts/buildInit.wl
+++ b/scripts/buildInit.wl
@@ -54,13 +54,32 @@ buildLibSetReplace[] := With[{
   ];
 ];
 
-deleteBuildDirectory[] /; !$internalBuildQ :=
-  If[FileExistsQ[$buildDirectory], DeleteDirectory[$buildDirectory, DeleteContents -> True]];
+libSetReplaceSourceHash[] := ModuleScope[
+  sourceFiles = Join[
+    FileNames[__ ~~ "." ~~ _ ~~ "pp", FileNameJoin[{$repoRoot, "libSetReplace"}]], (* C++ sources except for tests *)
+    FileNameJoin[{$repoRoot, #}] & /@ {"scripts/buildInit.wl", "build.wls"}]; (* compilation options might change *)
+  fileHashes = FileHash[#, "SHA", "HexString"] & /@ sourceFiles;
+  Hash[{sourceFiles, fileHashes}, "SHA", "HexString"]
+]
+
+$builtLibSetReplaceHashFilename = FileNameJoin[{AbsoluteFileName[$repoRoot], ".builtLibSetReplaceHash"}];
+
+saveBuiltLibSetReplaceHash[hash_String] := Export[$builtLibSetReplaceHashFilename, hash, "Text"]
+
+builtLibSetReplaceHash[] := If[FileExistsQ[$builtLibSetReplaceHashFilename],
+  Import[$builtLibSetReplaceHashFilename, "Text"],
+  Hash[{{}, {}}, "SHA", "HexString"]
+]
 
 copyWLSourceToBuildDirectory[] /; !$internalBuildQ := With[{
     files = Append[Import[FileNameJoin[{$repoRoot, "Kernel"}]], FileNameJoin[{"..", "PacletInfo.m"}]]},
-  If[!FileExistsQ[#], CreateDirectory[#]] & /@ {$buildDirectory, FileNameJoin[{$buildDirectory, "Kernel"}]};
-  CopyFile[FileNameJoin[{$repoRoot, "Kernel", #}], FileNameJoin[{$buildDirectory, "Kernel", #}]] & /@ files;
+  If[!FileExistsQ[$buildDirectory], CreateDirectory[$buildDirectory]];
+  $buildKernelDirectory = FileNameJoin[{$buildDirectory, "Kernel"}];
+  If[FileExistsQ[$buildKernelDirectory], DeleteDirectory[$buildKernelDirectory, DeleteContents -> True]];
+  CreateDirectory[$buildKernelDirectory];
+  CopyFile[FileNameJoin[{$repoRoot, "Kernel", #}],
+           FileNameJoin[{$buildDirectory, "Kernel", #}],
+           OverwriteTarget -> True] & /@ files;
 ];
 
 fileStringReplace[file_, rules_] := Export[file, StringReplace[Import[file, "Text"], rules], "Text"]


### PR DESCRIPTION
## Changes
* `Build` directory is no longer deleted after the build is done.
* *libSetReplace* compiled library is now cached so that if the build script is called without any changes to the C++ code, it does not rebuild it making it significantly faster.

## Comments
* The hash is stored in `.builtLibSetReplaceHash`. Note that it has to be outside of the `Build` directory so that it does not get copied to the paclet itself.
* It seems just starting `wolframscript` already takes multiple seconds, which is now the bottleneck. Not sure if anything can be done about that:
```sh
> time wolframscript -c 2+2
4
wolframscript -c 2+2  1.96s user 0.17s system 96% cpu 2.208 total
```

## Examples
* Run the build script:
```sh
> time ./build.wls 
Build done.
./build.wls  12.06s user 0.66s system 107% cpu 11.842 total
```
* Change some code in the `Kernel` directory, and rebuild. The build is now much faster:
```sh
>  time ./build.wls 
Using cached libSetReplace: 9aa32dd9bc7dd507d3f4353f59002457f4962465
Build done.
./build.wls  4.62s user 0.38s system 118% cpu 4.234 total
```
* Now, change some C++ code, and rebuild. The library is rebuilt:
```sh
> time ./build.wls         
Build done.
./build.wls  21.36s user 1.33s system 102% cpu 22.218 total
```
* One can check that the hash has now changed by rebuilding again:
```sh
> time ./build.wls
Using cached libSetReplace: 7dbb035c47e964e2b36bf21c2b77ccede4f59140
Build done.
./build.wls  3.39s user 0.27s system 129% cpu 2.833 total
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/514)
<!-- Reviewable:end -->
