### PR TITLE
Use a temporary build directory

### DIFF
--- a/build.wls
+++ b/build.wls
@@ -9,6 +9,7 @@ Check[
 $success = True;
 
 Check[
+  Print["Temporary build directory is ", $buildDirectory];
   $builtLibSetReplaceHash = builtLibSetReplaceHash[];
   $libSetReplaceSourceHash = libSetReplaceSourceHash[];
   If[$builtLibSetReplaceHash =!= $libSetReplaceSourceHash,
@@ -27,7 +28,7 @@ Check[
   $context = renameContext[Automatic, $version];
   updateBuildData[];
   packPaclet[$context];,
-
+  Print["Message occurred during build."];
   Exit[1];
 ];
 

--- a/scripts/buildInit.wl
+++ b/scripts/buildInit.wl
@@ -2,6 +2,8 @@ Needs["CCompilerDriver`"];
 Needs["PacletManager`"];
 Needs["GeneralUtilities`"];
 
+$setReplaceTemporaryDirectory = FileNameJoin[{$TemporaryDirectory, "SetReplace"}];
+
 $internalBuildQ = AntProperty["build_target"] === "internal";
 
 If[PacletFind["GitLink", "Internal" -> All] === {},
@@ -14,7 +16,8 @@ Needs["GitLink`"];
 $repoRoot = FileNameJoin[{DirectoryName[$InputFileName], ".."}];
 $buildDirectory = If[$internalBuildQ,
   FileNameJoin[{AntProperty["files_directory"], AntProperty["component"]}],
-  FileNameJoin[{$repoRoot, "Build"}]];
+  FileNameJoin[{$setReplaceTemporaryDirectory, "Build"}]
+];
 
 tryEnvironment[var_, default_] := If[# === $Failed, default, #] & @ Environment[var];
 
@@ -62,7 +65,7 @@ libSetReplaceSourceHash[] := ModuleScope[
   Hash[{sourceFiles, fileHashes}, "SHA", "HexString"]
 ]
 
-$builtLibSetReplaceHashFilename = FileNameJoin[{AbsoluteFileName[$repoRoot], ".builtLibSetReplaceHash"}];
+$builtLibSetReplaceHashFilename = FileNameJoin[{$setReplaceTemporaryDirectory, "builtLibSetReplaceHash"}];
 
 saveBuiltLibSetReplaceHash[hash_String] := Export[$builtLibSetReplaceHashFilename, hash, "Text"]
 


### PR DESCRIPTION
Use a temporary build directory, rather than the /Build subdir of the root dir. This is friendlier to IDEs, find-in-files, etc. This will have to be rebased if #518 lands to update the temporary directory used *there* as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/519)
<!-- Reviewable:end -->
