### PR TITLE
Load GeneralUtilities in Kernel/init.m, and add back some simple macro sugar

### DIFF
--- a/Kernel/globals.m
+++ b/Kernel/globals.m
@@ -1,0 +1,12 @@
+Package["SetReplace`"]
+
+PackageImport["GeneralUtilities`"]
+
+(* Note: this is actually set in Kernel/init.m, but it needs to be exported from a new-style package so that
+the new-style package loader understands that this is a global symbol *)
+PackageExport["$SetReplaceRootDirectory"]
+
+SetUsage @ "
+$SetReplaceRootDirectory contains the path of the root of the SetReplace package that was loaded. \
+This corresponds to the directory that containts the Kernel/ directory.
+"

--- a/Kernel/init.m
+++ b/Kernel/init.m
@@ -2,9 +2,31 @@ Unprotect["SetReplace`*"];
 
 ClearAll @@ (# <> "*" & /@ Contexts["SetReplace`*"]);
 
+(* Make sure that we don't effect $ContextPath by getting GU, and that we are isolated from
+any user contexts *)
+BeginPackage["SetReplace`"];
+
+(* This is useful for various purposes, like loading libraries from the 'same place' as the
+paclet, and also knowing *where* the loaded code even came from. *)
+$SetReplaceRootDirectory = FileNameDrop[$InputFileName, -2];
+
+Needs["GeneralUtilities`"];
+
+(* ensure private symbols we use below don't show up on Global, etc *)
+Begin["SetReplace`Private`"]
+
 Block[
-  {GeneralUtilities`Control`PackagePrivate`$DesugaringRules = {}},
-  Get[FileNameJoin[{FileNameDrop[$InputFileName], "usageString.m"}]];
+  (* Temporarily overrule some of the more exotic features of the macro system.
+  TODO: Fix this upstream when GU is open sourced. *)
+  {GeneralUtilities`Control`PackagePrivate`$DesugaringRules = {
+    HoldPattern[$Unreachable] :> Unreachable[$LHSHead],
+    HoldPattern[ReturnFailed[msg_String, args___]] :> ReturnFailed[MessageName[$LHSHead, msg], args],
+    HoldPattern[ReturnFailure[msg_String, args___]] :> ReturnFailure[MessageName[$LHSHead, msg], args]
+  }},
+  Get[FileNameJoin[{$SetReplaceRootDirectory, "Kernel", "usageString.m"}]];
 ];
+
+End[];
+EndPackage[];
 
 SetAttributes[#, {Protected, ReadProtected}] & /@ Evaluate @ Names @ "SetReplace`*";

--- a/Kernel/init.m
+++ b/Kernel/init.m
@@ -2,7 +2,7 @@ Unprotect["SetReplace`*"];
 
 ClearAll @@ (# <> "*" & /@ Contexts["SetReplace`*"]);
 
-(* Make sure that we don't effect $ContextPath by getting GU, and that we are isolated from
+(* Make sure that we don't affect $ContextPath by getting GU, and that we are isolated from
 any user contexts *)
 BeginPackage["SetReplace`"];
 

--- a/Tests/buildData.wlt
+++ b/Tests/buildData.wlt
@@ -1,4 +1,12 @@
 <|
+  "$SetReplaceRootDirectory" -> <|
+    "tests" -> {
+      VerificationTest[
+        FileExistsQ @ $SetReplaceRootDirectory
+      ]
+    }
+  |>,
+
   "$SetReplaceGitSHA" -> <|
     "tests" -> {
       (* These two tests will fail if the paclet was built from a dirty repo, i.e. there were uncommitted changes.


### PR DESCRIPTION
## Changes

* Fixes #508.
* Use `BeginPackage` and `Begin` to do proper context isolation to make loading GU safer, which we now do.
* Also include some useful sugar that isn't funky syntax which the previous override of `$DesugaringRules` unintentionally removed -- I will use this in a lot of code I write, including a pending PR (that will be resurrected soon!).
* Define the package global `$SetReplaceBaseDirectory`, which other PRs will end up using in various places.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/520)
<!-- Reviewable:end -->
