### PR TITLE
Confluence and Causal Invariance: Mention classical sequential growth models

### DIFF
--- a/Research/ConfluenceAndCausalInvariance/ConfluenceAndCausalInvariance.md
+++ b/Research/ConfluenceAndCausalInvariance/ConfluenceAndCausalInvariance.md
@@ -247,7 +247,7 @@ Out[] = False
 It would be interesting to investigate the systems exhibiting these properties in different combinations.
 For example, systems that don't exhibit [multiway branching](/Research/LocalMultiwaySystem/LocalMultiwaySystem.md) at
 all do satisfy both of these conditions.
-One can also consider systems in which causal graph isomorphism is equivalent to states isomorphism by construction,
+One can also consider systems in which causal graphs isomorphism is equivalent to states isomorphism by construction,
 for example, [classical sequential growth models of causal sets](https://arxiv.org/abs/gr-qc/9904062).
 It might be possible to generalize this to include more classes of systems.
 We could also enumerate ([#57](https://github.com/maxitg/SetReplace/issues/57)) simple rules and determine how many of

--- a/Research/ConfluenceAndCausalInvariance/ConfluenceAndCausalInvariance.md
+++ b/Research/ConfluenceAndCausalInvariance/ConfluenceAndCausalInvariance.md
@@ -247,6 +247,8 @@ Out[] = False
 It would be interesting to investigate the systems exhibiting these properties in different combinations.
 For example, systems that don't exhibit [multiway branching](/Research/LocalMultiwaySystem/LocalMultiwaySystem.md) at
 all do satisfy both of these conditions.
+One can also consider systems in which causal graph isomorphism is equivalent to states isomorphism by construction,
+for example, [classical sequential growth models of causal sets](https://arxiv.org/abs/gr-qc/9904062).
 It might be possible to generalize this to include more classes of systems.
 We could also enumerate ([#57](https://github.com/maxitg/SetReplace/issues/57)) simple rules and determine how many of
 them exhibit just one of these properties, both or neither.

--- a/Research/ConfluenceAndCausalInvariance/ConfluenceAndCausalInvariance.md
+++ b/Research/ConfluenceAndCausalInvariance/ConfluenceAndCausalInvariance.md
@@ -247,8 +247,9 @@ Out[] = False
 It would be interesting to investigate the systems exhibiting these properties in different combinations.
 For example, systems that don't exhibit [multiway branching](/Research/LocalMultiwaySystem/LocalMultiwaySystem.md) at
 all do satisfy both of these conditions.
-One can also consider systems in which causal graphs isomorphism is equivalent to states isomorphism by construction,
-for example, [classical sequential growth models of causal sets](https://arxiv.org/abs/gr-qc/9904062).
+One can also consider systems in which causal-graphs isomorphism is equivalent to states isomorphism by
+construction&mdash;for example,
+[classical sequential growth models of causal sets](https://arxiv.org/abs/gr-qc/9904062).
 It might be possible to generalize this to include more classes of systems.
 We could also enumerate ([#57](https://github.com/maxitg/SetReplace/issues/57)) simple rules and determine how many of
 them exhibit just one of these properties, both or neither.


### PR DESCRIPTION
## Changes
* Mentions classical sequential growth models for causal sets in Confluence and Causal Invariance note as examples of models where confluence is equivalent to causal invariance by construction.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/527)
<!-- Reviewable:end -->
