### PR TITLE
Ignore Mathematica notebooks

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -90,7 +90,7 @@ If sharing variables among multiple tests, use [`With`](https://reference.wolfra
 
 You should also modify the [README](/README.md) or the corresponding files in the Documentation directory if you are implementing new functionality, or causing any outputs there to change.
 
-**Never put notebooks (.nb files) in the repository**, as they, even though text files, are not human readable, cannot be reviewed line-by-line, and are guaranteed to cause conflicts, which would be almost impossible to resolve.
+**Never put notebooks (.nb files) in the repository**, as they, even though text files, are not human readable, cannot be reviewed line-by-line, and are guaranteed to cause conflicts, which would be almost impossible to resolve. In fact, `.nb` files are listed in the `.gitignore` file precisely so that you cannot accidentally add them.
 
 ### Opening a pull request
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,19 @@
+# Mathematica notebooks
+
+*.nb
+
+# Sublime text
+
+*.sublime-workspace
+
+# VS Code
+
+*.code-workspace
+
+# Files specifically requesting to be ignored
+
+ignoreme.*
+
 # Xcode
 
 xcuserdata/


### PR DESCRIPTION
## Changes
This change adds notebook files to the `.gitignore` list, for two reasons:
1. To make it much harder to deliberately or accidentally add notebooks to commits.
2. To make it friendlier to have a couple of "local notebooks" that are simply invisible to Git. (I use this for various purposes).

I've also added VSCode and Sublime workspace files, as well as files that contain the magic string "ignoreme.", which comes in handy when you want to 'stash' a single new file away easily without messing with git. 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/530)
<!-- Reviewable:end -->
