### PR TITLE
Linter pre-push hook

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,14 @@ jobs:
 
       - run:
           name: Lint
-          command: ./lint.sh
+          command: |
+            set +eo pipefail
+            ./lint.sh
+            if [ $? -ne 0 ]
+            then
+              echo "Please run scripts/install_git_hooks.sh to detect linting issues before git push."
+              exit 1
+            fi
 
       - run:
           name: Build

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -511,6 +511,9 @@ To run these automatically, call `./lint.sh`. This will print a formatting diff 
 If there are no errors found, it will exit with no output.
 To edit the code in place with the fixed formatting use `./lint.sh -i`.
 
+We recommend installing a git hook that runs `./lint.sh` automatically before each push.
+You can do that by running `scripts/install_git_hooks.sh`.
+
 If `cpplint` flags a portion of your code, please make sure it is adhering to the proper code style. If it is a false
 positive or if there is no reasonable way to avoid the flag, you may put `// NOLINT` at the end of the line if there is
 space, or `// NOLINTNEXTLINE` on a new line above if there is no space. For any usages of `// NOLINT` or

--- a/lint.sh
+++ b/lint.sh
@@ -41,6 +41,10 @@ for file in $sourceFiles; do
   fi
 done
 
+if [ $exitStatus -eq 1 ]; then
+  echo "Found formatting errors. Run ./lint.sh -i to automatically fix by applying the printed patch."
+fi
+
 if ! cpplint --quiet --extensions=hpp,cpp $sourceFiles; then
   exitStatus=1
 fi

--- a/scripts/git_hooks/pre-push
+++ b/scripts/git_hooks/pre-push
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+./lint.sh
+
+if [ $? -ne 0 ]
+then
+  echo "Linter errors need to be fixed before pushing."
+  exit 1
+fi
+
+exit 0

--- a/scripts/install_git_hooks.sh
+++ b/scripts/install_git_hooks.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Adapted from https://stackoverflow.com/a/3464399
+
+hookNames="pre-push"
+repoRoot=$(git rev-parse --show-toplevel)
+hookDir=$repoRoot/.git/hooks
+
+for hook in $hookNames
+do
+  # If the hook already exists and is not a symlink, move it out of the way
+  if [[ -e $hookDir/$hook && ! -h $hookDir/$hook ]]
+  then
+    echo "Moving an existing hook $hookDir/$hook to $hookDir/$hook.local"
+    mv $hookDir/$hook $hookDir/$hook.local
+  fi
+  # create the symlink, overwriting the file if it exists
+  echo "Symlinking $repoRoot/scripts/git_hooks/$hook to $hookDir/$hook"
+  ln -s -f $repoRoot/scripts/git_hooks/$hook $hookDir/$hook
+done


### PR DESCRIPTION
## Changes
* Closes #521.
* Implements a pre-push git hook that runs `./lint.sh` so that the linting issues can be fixed quickly before going to GitHub and CI.
* The hook can be installed by running `scripts/install_git_hooks.sh`.
* Adds a message to `./lint.sh` advising how to fix formatting errors.
* If `./lint.sh` fails on CI, it will now print a message advising to install the git hook.

## Comments
* Note that the hooks live in the `.git/hooks` directory which is not version controlled. Each user has to install them manually. I assume this is done for security reasons so that users don't run the code they don't expect to run.

## Examples
* First, install the hook:
  ```sh
  > scripts/install_git_hooks.sh
  Symlinking /Users/maxitg/git/SetReplace/scripts/git_hooks/pre-push to
    /Users/maxitg/git/SetReplace/.git/hooks/pre-push
  ```
* Next, introduce a formatting/linting issue.
* Now, try to `commit` and `push`:
  ```sh
  > git add .
  > git commit -m "Linting issue."
  [linterHook d331a39] Linting issue.
  1 file changed, 1 insertion(+), 1 deletion(-)
  > git push -u origin linterHook
  --- libSetReplace/Set.cpp
  +++ formatted
  @@ -32 +32 @@
  -    std::unordered_map<Atom, int64_t> atomDegrees_;
  +  std::unordered_map<Atom, int64_t> atomDegrees_;
  
  Found formatting errors. Run ./lint.sh -i to automatically fix by applying the printed patch.
  Linter errors need to be fixed before pushing.
  error: failed to push some refs to 'git@github.com:maxitg/SetReplace.git'
  ```
* As you can see, the linter refuses to push the change due to the linting issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/539)
<!-- Reviewable:end -->
