### PR TITLE
Save build artifacts in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,9 +14,15 @@ jobs:
           name: Build
           command: ./build.wls
 
+      - store_artifacts:
+          path: ./LibraryResources/
+
       - run:
           name: Install
           command: ./install.wls
+
+      - store_artifacts:
+          path: ./BuiltPaclets/
 
       - run:
           name: Reinstall


### PR DESCRIPTION
## Changes
* Circle CI now saves the built libraries (including the metadata JSON) and the paclet file as artifacts.

## Comments
* Note that the paclet file only has the Linux library. We will need to either cross-compile or run jobs on Mac and Windows to get a multi-platform paclet file, which is the goal.
* If we can achieve that, we will no longer need to rely on internal Wolfram infrastructure for building (which is inaccessible to external developers).

## Examples
* Here they are: https://app.circleci.com/pipelines/github/maxitg/SetReplace/1292/workflows/bea84003-2279-43e9-8b84-87d013e6d532/jobs/1683/artifacts

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/540)
<!-- Reviewable:end -->
