### PR TITLE
Add CMake build directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,10 @@ LibraryResources/
 
 BuiltPaclets/
 
+# CMake build directory
+
+build/
+
 # Test results
 
 exit_status.txt


### PR DESCRIPTION
## Changes
* Adds the `build` directory used by default for CMake building purposes to `.gitignore`.

## Comments
* It's not required to use this specific directory, but that's what `./libSetReplaceTest.sh` suggests to use.
* I believe it was not an issue previously because the temporary WL `Build` directory was in `.gitignore`, and `.gitignore` does not appear to be case sensitive.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/544)
<!-- Reviewable:end -->
