### PR TITLE
Fix Xcode warnings

### DIFF
--- a/SetReplace.xcodeproj/project.pbxproj
+++ b/SetReplace.xcodeproj/project.pbxproj
@@ -252,7 +252,7 @@
 				DEVELOPMENT_TEAM = "";
 				HEADER_SEARCH_PATHS = "build/_deps/googletest-src/googletest/include";
 				LIBRARY_SEARCH_PATHS = "build/_deps/googletest-build/googlemock/gtest";
-				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_LDFLAGS = (
 					"-lgtest",
 					"-lgtest_main",
@@ -270,7 +270,7 @@
 				DEVELOPMENT_TEAM = "";
 				HEADER_SEARCH_PATHS = "build/_deps/googletest-src/googletest/include";
 				LIBRARY_SEARCH_PATHS = "build/_deps/googletest-build/googlemock/gtest";
-				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_LDFLAGS = (
 					"-lgtest",
 					"-lgtest_main",
@@ -406,7 +406,7 @@
 					/Applications/Mathematica.app/Contents/SystemFiles/IncludeFiles/C,
 				);
 				LIBRARY_SEARCH_PATHS = "";
-				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 			};
@@ -426,7 +426,7 @@
 					/Applications/Mathematica.app/Contents/SystemFiles/IncludeFiles/C,
 				);
 				LIBRARY_SEARCH_PATHS = "";
-				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 			};

--- a/libSetReplace/Match.cpp
+++ b/libSetReplace/Match.cpp
@@ -221,7 +221,7 @@ class Matcher::Implementation {
       const uint64_t& numThreadsToUse = token->numThreads();
 
       auto addMatchesForRuleRange = [=](RuleID start) {
-        for (RuleID i = start; i < static_cast<int>(rules_.size()); i += numThreadsToUse) {
+        for (RuleID i = start; i < static_cast<RuleID>(rules_.size()); i += numThreadsToUse) {
           addMatchesForRule(expressionIDs, i, shouldAbort);
         }
       };
@@ -237,7 +237,7 @@ class Matcher::Implementation {
         }
       } else {
         // Single-threaded path
-        for (RuleID i = 0; i < static_cast<int>(rules_.size()); ++i) {
+        for (RuleID i = 0; i < static_cast<RuleID>(rules_.size()); ++i) {
           addMatchesForRule(expressionIDs, i, shouldAbort);
         }
       }

--- a/libSetReplace/Match.cpp
+++ b/libSetReplace/Match.cpp
@@ -220,8 +220,8 @@ class Matcher::Implementation {
       const auto token = Parallelism::acquire(Parallelism::HardwareType::StdCpu, rules_.size());
       const uint64_t& numThreadsToUse = token->numThreads();
 
-      auto addMatchesForRuleRange = [=](uint64_t start) {
-        for (uint64_t i = start; i < static_cast<uint64_t>(rules_.size()); i += numThreadsToUse) {
+      auto addMatchesForRuleRange = [=](RuleID start) {
+        for (RuleID i = start; i < static_cast<int>(rules_.size()); i += numThreadsToUse) {
           addMatchesForRule(expressionIDs, i, shouldAbort);
         }
       };
@@ -237,7 +237,7 @@ class Matcher::Implementation {
         }
       } else {
         // Single-threaded path
-        for (size_t i = 0; i < rules_.size(); ++i) {
+        for (RuleID i = 0; i < static_cast<int>(rules_.size()); ++i) {
           addMatchesForRule(expressionIDs, i, shouldAbort);
         }
       }

--- a/libSetReplace/Parallelism.cpp
+++ b/libSetReplace/Parallelism.cpp
@@ -41,7 +41,7 @@ class Parallelism<HardwareType::StdCpu> : private ParallelismBase {
     threadsInUse_ -= numThreadsToReturn;
   }
 
-  void overrideNumHardwareThreads(const int64_t& numThreads) { numHardwareThreads_ = numThreads; }
+  void overrideNumHardwareThreads(const unsigned& numThreads) { numHardwareThreads_ = numThreads; }
 };
 
 Parallelism<HardwareType::StdCpu> cpuParallelism;
@@ -88,7 +88,7 @@ bool isAvailable(const HardwareType& type) {
 }
 
 namespace Testing {
-void overrideNumHardwareThreads(const HardwareType& type, const int64_t& numThreads) {
+void overrideNumHardwareThreads(const HardwareType& type, const unsigned& numThreads) {
   if (type == HardwareType::StdCpu) {
     cpuParallelism.overrideNumHardwareThreads(numThreads);
   } else {

--- a/libSetReplace/Parallelism.hpp
+++ b/libSetReplace/Parallelism.hpp
@@ -44,7 +44,7 @@ bool isAvailable(const HardwareType& type);
 
 #ifdef LIBSETREPLACE_BUILD_TESTING
 namespace Testing {
-void overrideNumHardwareThreads(const HardwareType& type, const int64_t& numThreads);
+void overrideNumHardwareThreads(const HardwareType& type, const unsigned& numThreads);
 }
 #endif
 }  // namespace SetReplace::Parallelism


### PR DESCRIPTION
## Changes
* Fixes warnings generated when compiling with Xcode:
  * There was some implicit type conversion.
  * The macOS deployment target is updated to 11.0 (Big Sur).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/545)
<!-- Reviewable:end -->
