### PR TITLE
Prevent empty lists being treated as options

### DIFF
--- a/Kernel/WolframModelEvolutionObject.m
+++ b/Kernel/WolframModelEvolutionObject.m
@@ -283,11 +283,14 @@ $propertyOptions = <|
   "FinalStatePlot" -> Options[HypergraphPlot]
 |>;
 
+(* Prevent {}, {{}}, {{}, {}}, etc. being treated as options *)
+$nonEmptyOptionsPattern = OptionsPattern[] ? (AllTrue[{##}, Length[Flatten[{#}, Infinity]] > 0 &] &);
+
 propertyEvaluate[True, includeBoundaryEventsPattern][
     obj : WolframModelEvolutionObject[_ ? evolutionDataQ],
     caller_,
     property : Alternatives @@ Keys[$propertyOptions],
-    o : OptionsPattern[]] := (
+    o : $nonEmptyOptionsPattern] := (
   Message[
     caller::optx,
     First[Last[Complement[{o}, FilterRules[{o}, Options[$propertyOptions[property]]]]]],
@@ -458,7 +461,7 @@ propertyEvaluate[True, boundary : includeBoundaryEventsPattern][
     obj : WolframModelEvolutionObject[_ ? evolutionDataQ],
     caller_,
     property : "FinalStatePlot",
-    o : OptionsPattern[] /; (Complement[{o}, FilterRules[{o}, Options[HypergraphPlot]]] == {})] :=
+    o : $nonEmptyOptionsPattern /; (Complement[{o}, FilterRules[{o}, Options[HypergraphPlot]]] == {})] :=
   Check[
     Quiet[
       Check[
@@ -529,7 +532,7 @@ propertyEvaluate[True, boundary : includeBoundaryEventsPattern][
     obj : WolframModelEvolutionObject[_ ? evolutionDataQ],
     caller_,
     property : "StatesPlotsList",
-    o : OptionsPattern[] /; (Complement[{o}, FilterRules[{o}, Options[HypergraphPlot]]] == {})] :=
+    o : $nonEmptyOptionsPattern /; (Complement[{o}, FilterRules[{o}, Options[HypergraphPlot]]] == {})] :=
   Check[
     Quiet[
       Map[
@@ -549,7 +552,7 @@ propertyEvaluate[True, boundary : includeBoundaryEventsPattern][
       obj : WolframModelEvolutionObject[_ ? evolutionDataQ],
       caller_,
       property : "EventsStatesPlotsList",
-      o : OptionsPattern[] /; (Complement[{o}, FilterRules[{o}, Options[HypergraphPlot]]] == {})] := ModuleScope[
+      o : $nonEmptyOptionsPattern /; (Complement[{o}, FilterRules[{o}, Options[HypergraphPlot]]] == {})] := ModuleScope[
   events = propertyEvaluate[True, boundary][obj, caller, "AllEventsList"][[All, 2]];
   stateIndices = FoldList[
     Function[{currentState, newEvent}, Module[{alreadyDeletedExpressions},
@@ -684,7 +687,7 @@ propertyEvaluate[True, boundary : includeBoundaryEventsPattern][
       obj : WolframModelEvolutionObject[data_ ? evolutionDataQ],
       caller_,
       property : "ExpressionsEventsGraph",
-      o : OptionsPattern[]] /;
+      o : $nonEmptyOptionsPattern] /;
         (Complement[{o}, FilterRules[{o}, $propertyOptions[property]]] == {}) := ModuleScope[
   {eventsToOutputs, expressionsToDestroyers} = eventsExpressionsRelations[obj, caller, boundary];
   {labeledEvents, labeledOutputs, labeledExpressions, labeledDestroyers} =
@@ -757,7 +760,7 @@ propertyEvaluate[True, boundary : includeBoundaryEventsPattern][
       obj : WolframModelEvolutionObject[data_ ? evolutionDataQ],
       caller_,
       property : "CausalGraph",
-      o : OptionsPattern[]] /;
+      o : $nonEmptyOptionsPattern] /;
         (Complement[{o}, FilterRules[{o}, $propertyOptions[property]]] == {}) := ModuleScope[
   {eventsToOutputs, expressionsToDestroyers} = eventsExpressionsRelations[obj, caller, boundary];
   eventsToEvents = Catenate /@ Map[expressionsToDestroyers, eventsToOutputs, {2}];
@@ -786,7 +789,7 @@ propertyEvaluate[True, includeBoundaryEvents : includeBoundaryEventsPattern][
     evolution : WolframModelEvolutionObject[data_ ? evolutionDataQ],
     caller_,
     property : "LayeredCausalGraph",
-    o : OptionsPattern[]] /;
+    o : $nonEmptyOptionsPattern] /;
       (Complement[{o}, FilterRules[{o}, $propertyOptions[property]]] == {}) :=
   Graph[
     propertyEvaluate[True, includeBoundaryEvents][evolution, caller, "CausalGraph", ##] & @@
@@ -950,17 +953,18 @@ $masterOptions = {
   "IncludeBoundaryEvents" -> None
 };
 
-WolframModelEvolutionObject[
-    data_ ? evolutionDataQ][
-    property__ ? (Not[MatchQ[#, OptionsPattern[]]] &),
-    opts : OptionsPattern[]] := ModuleScope[
+WolframModelEvolutionObject[data_ ? evolutionDataQ][args__] := ModuleScope[
+  {property, opts} = Replace[
+    {args},
+    {property__, opts : Longest[$nonEmptyOptionsPattern]} :>
+      {{property}, {opts}}];
   result = Catch[
     (propertyEvaluate @@
-        (OptionValue[Join[{opts}, $masterOptions], #] & /@ {"IncludePartialGenerations", "IncludeBoundaryEvents"}))[
+        (OptionValue[Join[opts, $masterOptions], #] & /@ {"IncludePartialGenerations", "IncludeBoundaryEvents"}))[
       WolframModelEvolutionObject[data],
       WolframModelEvolutionObject,
-      property,
-      ##] & @@ Flatten[FilterRules[{opts}, Except[$masterOptions]]]];
+      Sequence @@ property,
+      ##] & @@ Flatten[FilterRules[opts, Except[$masterOptions]]]];
   result /; result =!= $Failed
 ]
 
@@ -973,8 +977,8 @@ WolframModelEvolutionObject[
 WolframModelEvolutionObject[args___] := 0 /;
   !Developer`CheckArgumentCount[WolframModelEvolutionObject[args], 1, 1] && False
 
-WolframModelEvolutionObject[data_][opts : OptionsPattern[]] := 0 /;
-  Message[WolframModelEvolutionObject::argm, Defer[WolframModelEvolutionObject[data][opts]], 0, 1]
+WolframModelEvolutionObject[data_][] := 0 /;
+  Message[WolframModelEvolutionObject::argm, Defer[WolframModelEvolutionObject[data][]], 0, 1]
 
 (* Association has correct fields *)
 

--- a/Tests/WolframModelEvolutionObject.wlt
+++ b/Tests/WolframModelEvolutionObject.wlt
@@ -68,7 +68,7 @@
           pathGraph17,
           4]["$opt$" -> 3],
         WolframModelEvolutionObject[___]["$opt$" -> 3],
-        {WolframModelEvolutionObject::argm},
+        {WolframModelEvolutionObject::unknownProperty},
         SameTest -> MatchQ
       ],
 
@@ -130,6 +130,40 @@
         WolframModelEvolutionObject[___]["SetAfterEvent"],
         {WolframModelEvolutionObject::pargx},
         SameTest -> MatchQ
+      ],
+
+      VerificationTest[
+        WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4][##2],
+        WolframModelEvolutionObject[___][##2],
+        {MessageName[WolframModelEvolutionObject, #]},
+        SameTest -> MatchQ
+      ] & @@@ {
+        {"pargx", "FinalState", {}, {}},
+        {"pargx", "FinalState", {{}, {}}},
+        {"nonopt", "CausalGraph", {}},
+        {"nonopt", "CausalGraph", {}, {}},
+        {"nonopt", "CausalGraph", {{}, {}}},
+        {"nonopt", "CausalGraph", {}, EdgeStyle -> Red},
+        {"nonopt", "CausalGraph", {}, {EdgeStyle -> Red}},
+        {"nonopt", "CausalGraph", {EdgeStyle -> Red}, {}},
+        {"nonopt", "CausalGraph", EdgeStyle -> Red, {}},
+        {"nonopt", "CausalGraph", {}, EdgeStyle -> Red, {}},
+        {"unknownProperty", "$opt$" -> 3},
+        {"unknownProperty", "$opt$" -> 3, {}}
+      },
+
+      VerificationTest[
+        GraphQ[WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 3]["CausalGraph", {{}, EdgeStyle -> Red}]]
+      ],
+
+      (* Check options are being picked up even if they are in a list *)
+      VerificationTest[
+        VertexList[WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 2][
+          "CausalGraph", {{"IncludeBoundaryEvents" -> "Initial"}, EdgeStyle -> Red}]],
+        Range[0, 4]
       ],
 
       (* Incorrect step arguments *)


### PR DESCRIPTION
## Changes
* Closes #551.
* Prevents empty lists being treated as options in `WolframModelEvolutionObject` properties.

## Comments
* Especially useful for potential properties where `{}` might be a valid optional argument like #528.

## Examples
* Empty lists are no longer allowed:

```wl
In[] := WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}]["FinalState", {}]
```

<img width="690.6" src="https://user-images.githubusercontent.com/1479325/101420619-32105080-38b8-11eb-839c-4f6ac648694a.png">

* Cherry-picking this into #528 now yields the expected result for passing an empty list as an argument:

```wl
In[] := WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}]["FeatureAssociation", {}]
Out[] = <||>
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/553)
<!-- Reviewable:end -->
