### PR TITLE
Change non-standard types to int

### DIFF
--- a/libSetReplace/Match.cpp
+++ b/libSetReplace/Match.cpp
@@ -217,8 +217,8 @@ class Matcher::Implementation {
 
     {
       // Only create threads if there is more than one rule
-      const auto token = Parallelism::acquire(Parallelism::HardwareType::StdCpu, rules_.size());
-      const uint64_t& numThreadsToUse = token->numThreads();
+      const auto token = Parallelism::acquire(Parallelism::HardwareType::StdCpu, static_cast<int>(rules_.size()));
+      const int& numThreadsToUse = token->numThreads();
 
       auto addMatchesForRuleRange = [=](RuleID start) {
         for (RuleID i = start; i < static_cast<RuleID>(rules_.size()); i += numThreadsToUse) {
@@ -229,7 +229,7 @@ class Matcher::Implementation {
       if (numThreadsToUse > 0) {
         // Multi-threaded path
         std::vector<std::thread> threads(numThreadsToUse);
-        for (uint64_t i = 0; i < numThreadsToUse; ++i) {
+        for (int i = 0; i < numThreadsToUse; ++i) {
           threads[i] = std::thread(addMatchesForRuleRange, i);
         }
         for (auto& thread : threads) {

--- a/libSetReplace/Parallelism.cpp
+++ b/libSetReplace/Parallelism.cpp
@@ -22,7 +22,7 @@ class Parallelism;
 template <>
 class Parallelism<HardwareType::StdCpu> : private ParallelismBase {
  public:
-  Parallelism() noexcept : ParallelismBase(std::thread::hardware_concurrency()) {}
+  Parallelism() noexcept : ParallelismBase(static_cast<int>(std::thread::hardware_concurrency())) {}
 
   [[nodiscard]] bool isAvailable() const { return numHardwareThreads_ >= 2; }
 

--- a/libSetReplace/Parallelism.cpp
+++ b/libSetReplace/Parallelism.cpp
@@ -8,11 +8,11 @@
 namespace SetReplace::Parallelism {
 namespace {
 struct ParallelismBase {
-  explicit ParallelismBase(unsigned numHardwareThreads) noexcept
+  explicit ParallelismBase(int numHardwareThreads) noexcept
       : numHardwareThreads_(numHardwareThreads), threadsInUse_(0) {}
 
-  unsigned numHardwareThreads_;
-  unsigned threadsInUse_;
+  int numHardwareThreads_;
+  int threadsInUse_;
   std::mutex reservationMutex_;
 };
 
@@ -26,9 +26,9 @@ class Parallelism<HardwareType::StdCpu> : private ParallelismBase {
 
   [[nodiscard]] bool isAvailable() const { return numHardwareThreads_ >= 2; }
 
-  [[nodiscard]] int64_t numThreadsAvailable() const { return isAvailable() ? numHardwareThreads_ - threadsInUse_ : 0; }
+  [[nodiscard]] int numThreadsAvailable() const { return isAvailable() ? numHardwareThreads_ - threadsInUse_ : 0; }
 
-  [[nodiscard]] int64_t acquireThreads(const int64_t& requestedNumThreads) {
+  [[nodiscard]] int acquireThreads(const int& requestedNumThreads) {
     std::lock_guard lock(reservationMutex_);
     auto numThreadsToReserve = std::min(requestedNumThreads, numThreadsAvailable());
     if (numThreadsToReserve <= 1) numThreadsToReserve = 0;
@@ -36,12 +36,12 @@ class Parallelism<HardwareType::StdCpu> : private ParallelismBase {
     return numThreadsToReserve;
   }
 
-  void releaseThreads(const int64_t& numThreadsToReturn) {
+  void releaseThreads(const int& numThreadsToReturn) {
     std::lock_guard lock(reservationMutex_);
     threadsInUse_ -= numThreadsToReturn;
   }
 
-  void overrideNumHardwareThreads(const unsigned& numThreads) { numHardwareThreads_ = numThreads; }
+  void overrideNumHardwareThreads(const int& numThreads) { numHardwareThreads_ = numThreads; }
 };
 
 Parallelism<HardwareType::StdCpu> cpuParallelism;
@@ -49,7 +49,7 @@ Parallelism<HardwareType::StdCpu> cpuParallelism;
 /** @brief Reserves at most requestedNumThreads of the given hardware type and returns the number of threads
  * successfully reserved.
  */
-int64_t acquireThreads(const HardwareType& type, const int64_t& requestedNumThreads) {
+int acquireThreads(const HardwareType& type, const int& requestedNumThreads) {
   if (requestedNumThreads <= 1) return 0;
   if (type == HardwareType::StdCpu) return cpuParallelism.acquireThreads(requestedNumThreads);
   throw std::runtime_error("Invalid Parallelism::HardwareType");
@@ -57,7 +57,7 @@ int64_t acquireThreads(const HardwareType& type, const int64_t& requestedNumThre
 
 /** @brief Releases ownership of numThreadsToReturn of the given hardware type.
  */
-void releaseThreads(const HardwareType& type, const int64_t& numThreadsToReturn) {
+void releaseThreads(const HardwareType& type, const int& numThreadsToReturn) {
   if (type == HardwareType::StdCpu) return cpuParallelism.releaseThreads(numThreadsToReturn);
   throw std::runtime_error("Invalid Parallelism::HardwareType");
 }
@@ -65,22 +65,22 @@ void releaseThreads(const HardwareType& type, const int64_t& numThreadsToReturn)
 
 class ThreadAcquisitionToken::Implementation {
  public:
-  Implementation(const HardwareType& type, const int64_t& requestedNumThreads)
+  Implementation(const HardwareType& type, const int& requestedNumThreads)
       : hardwareType_(type), threads_(acquireThreads(hardwareType_, requestedNumThreads)) {}
 
-  [[nodiscard]] constexpr const int64_t& numThreads() const noexcept { return threads_; }
+  [[nodiscard]] constexpr const int& numThreads() const noexcept { return threads_; }
 
   ~Implementation() { releaseThreads(hardwareType_, threads_); }
 
  private:
   const HardwareType hardwareType_;
-  const int64_t threads_;
+  const int threads_;
 };
 
-ThreadAcquisitionToken::ThreadAcquisitionToken(const HardwareType& type, const int64_t& requestedNumThreads)
+ThreadAcquisitionToken::ThreadAcquisitionToken(const HardwareType& type, const int& requestedNumThreads)
     : implementation_(std::make_shared<Implementation>(type, requestedNumThreads)) {}
 
-int64_t ThreadAcquisitionToken::numThreads() const noexcept { return implementation_->numThreads(); }
+int ThreadAcquisitionToken::numThreads() const noexcept { return implementation_->numThreads(); }
 
 bool isAvailable(const HardwareType& type) {
   if (type == HardwareType::StdCpu) return cpuParallelism.isAvailable();
@@ -88,7 +88,7 @@ bool isAvailable(const HardwareType& type) {
 }
 
 namespace Testing {
-void overrideNumHardwareThreads(const HardwareType& type, const unsigned& numThreads) {
+void overrideNumHardwareThreads(const HardwareType& type, const int& numThreads) {
   if (type == HardwareType::StdCpu) {
     cpuParallelism.overrideNumHardwareThreads(numThreads);
   } else {

--- a/libSetReplace/Parallelism.hpp
+++ b/libSetReplace/Parallelism.hpp
@@ -1,7 +1,6 @@
 #ifndef LIBSETREPLACE_PARALLELISM_HPP_
 #define LIBSETREPLACE_PARALLELISM_HPP_
 
-#include <cstdint>
 #include <memory>
 
 namespace SetReplace::Parallelism {

--- a/libSetReplace/Parallelism.hpp
+++ b/libSetReplace/Parallelism.hpp
@@ -19,11 +19,11 @@ enum class HardwareType {
  */
 class ThreadAcquisitionToken {
  public:
-  ThreadAcquisitionToken(const HardwareType& type, const int64_t& requestedNumThreads);
+  ThreadAcquisitionToken(const HardwareType& type, const int& requestedNumThreads);
 
   /** @brief Returns the number of threads successfully reserved.
    */
-  [[nodiscard]] int64_t numThreads() const noexcept;
+  [[nodiscard]] int numThreads() const noexcept;
 
  private:
   class Implementation;
@@ -34,7 +34,7 @@ using ThreadAcquisitionTokenPtr = std::shared_ptr<const ThreadAcquisitionToken>;
 
 /** @brief Returns a RAII token for reserving the given number of threads for the given hardware type.
  */
-inline ThreadAcquisitionTokenPtr acquire(const HardwareType& type, const int64_t& requestedNumThreads) {
+inline ThreadAcquisitionTokenPtr acquire(const HardwareType& type, const int& requestedNumThreads) {
   return std::make_shared<ThreadAcquisitionTokenPtr::element_type>(type, requestedNumThreads);
 }
 
@@ -44,7 +44,7 @@ bool isAvailable(const HardwareType& type);
 
 #ifdef LIBSETREPLACE_BUILD_TESTING
 namespace Testing {
-void overrideNumHardwareThreads(const HardwareType& type, const unsigned& numThreads);
+void overrideNumHardwareThreads(const HardwareType& type, const int& numThreads);
 }
 #endif
 }  // namespace SetReplace::Parallelism


### PR DESCRIPTION
## Changes
* Changes non-standard integer types used in `Parallelism.*pp` to `int`.
* This is consistent with the [Google Style](https://google.github.io/styleguide/cppguide.html#Integer_Types).
* It also [prevents](https://app.circleci.com/pipelines/github/maxitg/SetReplace/1355/workflows/7e8d28dc-3948-43ed-b1a8-b640fcba875a/jobs/1801) compile warnings [generated](https://app.circleci.com/pipelines/github/maxitg/SetReplace/1354/workflows/6d9eb567-fe8c-48ec-95aa-c5f4301a827c/jobs/1800) by Visual Studio.

## Comments
* Since the variables changed are related to the numbers of threads, they can never exceed the `int` range.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/554)
<!-- Reviewable:end -->
