### PR TITLE
CI job: Windows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,7 @@ jobs:
               | grep win64-x64.zip)
             curl -L --output cmake-win64-x64.zip $cmakeURL
             unzip -q cmake-win64-x64.zip
-            cmakeDir=$(find cmake-*-win64-x64 -d 0)
+            cmakeDir=$(find "cmake-*-win64-x64" -d 0)
             echo "export PATH=\"$(pwd)/$cmakeDir/bin:$PATH\"" >> $BASH_ENV
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,7 @@ jobs:
               | grep win64-x64.zip)
             curl -L --output cmake-win64-x64.zip $cmakeURL
             unzip -q cmake-win64-x64.zip
-            cmakeDir=$(find "cmake-*-win64-x64" -d 0)
+            cmakeDir=$(dir -1 | findstr -i cmake-*-win64-x64)
             echo "export PATH=\"$(pwd)/$cmakeDir/bin:$PATH\"" >> $BASH_ENV
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,10 +81,15 @@ jobs:
       - run:
           name: Install CMake
           command: |
-            curl -L --output cmake-3.19.1-win64-x64.zip \
-                    https://github.com/Kitware/CMake/releases/download/v3.19.1/cmake-3.19.1-win64-x64.zip
-            unzip -q cmake-3.19.1-win64-x64.zip
-            echo "export PATH=\"$(pwd)/cmake-3.19.1-win64-x64/bin:$PATH\"" >> $BASH_ENV
+            cmakeURL=$(\
+              curl -s https://api.github.com/repos/Kitware/CMake/releases/latest \
+              | grep 'browser_download_url' \
+              | cut -d\" -f4 \
+              | grep win64-x64.zip)
+            curl -L --output cmake-win64-x64.zip $cmakeURL
+            unzip -q cmake-win64-x64.zip
+            cmakeDir=$(find cmake-*-win64-x64 -d 0)
+            echo "export PATH=\"$(pwd)/$cmakeDir/bin:$PATH\"" >> $BASH_ENV
 
       - run:
           name: Build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,8 @@
-version: 2
+version: 2.1
+
+orbs:
+  win: circleci/windows@2.2.0
+
 jobs:
   wolfram-language:
     docker:
@@ -66,9 +70,37 @@ jobs:
           name: Test
           command: ./libSetReplaceTest.sh
 
+  windows:
+    executor:
+      name: win/default
+      shell: bash.exe
+
+    steps:
+      - checkout
+
+      - run:
+          name: Install CMake
+          command: |
+            curl -L --output cmake-3.19.1-win64-x64.zip \
+                    https://github.com/Kitware/CMake/releases/download/v3.19.1/cmake-3.19.1-win64-x64.zip
+            unzip -q cmake-3.19.1-win64-x64.zip
+            echo "export PATH=\"$(pwd)/cmake-3.19.1-win64-x64/bin:$PATH\"" >> $BASH_ENV
+
+      - run:
+          name: Build
+          command: |
+            mkdir build
+            cd build
+            cmake .. -DSET_REPLACE_ENABLE_ALLWARNINGS=ON -DBUILD_SHARED_LIBS=ON
+            cmake --build . --config Release
+
+      - store_artifacts:
+          path: ./build/Release/
+
 workflows:
   version: 2
   build-and-test:
     jobs:
       - wolfram-language
       - cpp
+      - windows


### PR DESCRIPTION
## Changes
* Closes the Windows part of #371.
* Adds a CI build job on Windows.

## Comments
* We have 25k monthly credits on Circle CI which should be plenty for building only (but won't be enough for full testing).
* The job uses CMake and builds a shared library (which we will need in the paclet).
* It already creates a DLL artifact which can be manually put directly into the paclet.
* Of course, the goal is to create the entire paclet, but before doing that, we need to create a metadata file (`libSetReplaceBuildInfo.json`), which will require computing the hash of the source code in bash.

## Examples
* Check the [CI build](https://app.circleci.com/pipelines/github/maxitg/SetReplace/1376/workflows/87374f0c-bb51-4b76-950d-2d8aa5ea61f4/jobs/1843), and, if you have Windows, try out the DLL file it generated in the Artifacts tab.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/558)
<!-- Reviewable:end -->
