### PR TITLE
Googletest: Computable results

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,9 @@ jobs:
           name: Test
           command: ./libSetReplaceTest.sh
 
+      - store_test_results:
+          path: TestResults
+
 workflows:
   version: 2
   build-and-test:

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,10 @@ BuiltPaclets/
 
 build/
 
+# Test result XMLs
+
+TestResults/
+
 # Test results
 
 exit_status.txt

--- a/libSetReplaceTest.sh
+++ b/libSetReplaceTest.sh
@@ -22,6 +22,13 @@ then
   exit 1
 fi
 
+libSetReplaceTestsDir=TestResults/libSetReplace
+
+if [ ! -d "$libSetReplaceTestsDir" ]
+then
+  mkdir TestResults
+fi
+
 exitStatus=0
 isFirstTest=1
 for testBinary in $testBinaries
@@ -31,8 +38,9 @@ do
     echo
   fi
   isFirstTest=0
-  echo "$(basename $testBinary)..."
-  if ! eval $testBinary
+  testBasename=$(basename $testBinary)
+  echo "$testBasename..."
+  if ! eval $testBinary --gtest_output=xml:$libSetReplaceTestsDir/$testBasename.xml
   then
     exitStatus=1
   fi

--- a/libSetReplaceTest.sh
+++ b/libSetReplaceTest.sh
@@ -24,10 +24,7 @@ fi
 
 libSetReplaceTestsDir=TestResults/libSetReplace
 
-if [ ! -d "$libSetReplaceTestsDir" ]
-then
-  mkdir TestResults
-fi
+mkdir -p TestResults
 
 exitStatus=0
 isFirstTest=1


### PR DESCRIPTION
## Changes
* Stores results of *libSetReplace* tests in the new `TestResults` directory as JUnit XMLs.
* This allows Circle CI to pick up these results and display them in a nice way.

## Comments
* The same can be done for Wolfram Language as well. We will need to produce the XMLs manually, but we can infer the format from the files generated by Googletest.

## Examples
* This is what it looks like when tests [pass](https://app.circleci.com/pipelines/github/maxitg/SetReplace/1379/workflows/31d17a1c-11c5-4d37-9b85-c165b2482a3e/jobs/1849/tests).
* And this is when they [fail](https://app.circleci.com/pipelines/github/maxitg/SetReplace/1378/workflows/2bb65399-5864-4d71-b73a-2d8fff8f919a/jobs/1847/tests).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/559)
<!-- Reviewable:end -->
