### PR TITLE
CI: Build LibraryResources without Wolfram Language

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,14 +126,10 @@ jobs:
 
       - run:
           name: Build
-          command: |
-            mkdir build
-            cd build
-            cmake .. -DSET_REPLACE_ENABLE_ALLWARNINGS=ON -DBUILD_SHARED_LIBS=ON
-            cmake --build . --config Release
+          command: scripts/buildLibraryResources.sh
 
       - store_artifacts:
-          path: ./build/Release/
+          path: ./LibraryResources/
 
 workflows:
   version: 2

--- a/scripts/buildLibraryResources.sh
+++ b/scripts/buildLibraryResources.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eo pipefail
 
 setReplaceRoot=$(dirname $(cd $(dirname $0) && pwd))

--- a/scripts/buildLibraryResources.sh
+++ b/scripts/buildLibraryResources.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+set -eo pipefail
+
+setReplaceRoot=$(dirname $(cd $(dirname $0) && pwd))
+cd $setReplaceRoot
+
+# Compute the source hash
+
+sourceFiles="libSetReplace/*pp CMakeLists.txt cmake/* scripts/buildLibraryResources.sh"
+
+if command -v shasum &> /dev/null
+then
+  echo "Using SHA tool: $(which shasum)"
+  sha=$((shasum -a 256 $sourceFiles && uname -sm) | shasum -a 256 | cut -d\  -f1)
+elif [[ "$OSTYPE" == "msys" && $(command -v certutil) ]]  # there is another certutil in macOS
+then
+  echo "Using SHA tool: $(which certutil)"
+  echo $(for fileToHash in $sourceFiles
+  do
+    echo $(certutil -hashfile $fileToHash SHA256 | findstr -v "hash") $fileToHash
+  done
+  uname -sm) > $TEMP/libSetReplaceFilesToHash
+  sha=$(certutil -hashfile $TEMP/libSetReplaceFilesToHash SHA256 | findstr -v "hash")
+else
+  echo "Could not find SHA utility"
+  exit 1
+fi
+
+shortSHA=$(echo $sha | cut -c 1-13)
+echo "libSetReplace sources hash: $shortSHA"
+
+# Build the library
+
+mkdir -p build
+cd build
+cmake .. -DSET_REPLACE_ENABLE_ALLWARNINGS=ON -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Release
+cmake --build . --config Release  # Needed for multi-config generators
+cd ..
+
+# Set the platform-specific names
+
+if [ "$(uname -sm)" = "Darwin x86_64" ]
+then
+  libraryResourcesDirName=MacOSX-x86-64
+  libraryExtension=dylib
+elif [ "$(uname -sm)" = "Linux x86_64" ]
+then
+  libraryResourcesDirName=Linux-x86-64
+  libraryExtension=so
+elif [[ "$OSTYPE" == "msys" && "$(uname -m)" == "x86_64" ]]  # Windows
+then
+  libraryResourcesDirName=Windows-x86-64
+  libraryExtension=dll
+else
+  echo "Operating system unsupported"
+  exit 1
+fi
+
+libraryDir=LibraryResources/$libraryResourcesDirName
+echo "LibraryResources directory: $setReplaceRoot/$libraryDir"
+echo "Library extension: $libraryExtension"
+
+# Find the compiled library
+
+compiledLibrary=build/libSetReplace.$libraryExtension
+if [ ! -f $compiledLibrary ]
+then
+  compiledLibrary=build/Release/SetReplace.$libraryExtension
+fi
+
+if [ ! -f $compiledLibrary ]
+then
+  echo "Could not find compiled library"
+  exit 1
+fi
+
+echo "Found compiled library at $setReplaceRoot/$compiledLibrary"
+
+# Copy the library to LibraryResources
+
+mkdir -p $libraryDir
+libraryDestination=$libraryDir/libSetReplace-$shortSHA.$libraryExtension
+echo "Copying the library to $setReplaceRoot/$libraryDestination"
+cp $compiledLibrary $libraryDestination
+
+metadataDestination=$libraryDir/libSetReplaceBuildInfo.json
+echo "Writing metadata to $setReplaceRoot/$metadataDestination"
+echo "\
+{
+  \"LibraryFileName\": \"libSetReplace-$shortSHA.$libraryExtension\",
+  \"LibraryBuildTime\": $(date -u "+[%Y, %m, %d, %H, %M, %S]"),
+  \"LibrarySourceHash\": \"$shortSHA\"
+}" > $metadataDestination
+
+cat $metadataDestination
+echo "Build done"

--- a/scripts/buildLibraryResources.sh
+++ b/scripts/buildLibraryResources.sh
@@ -88,7 +88,7 @@ echo "Writing metadata to $setReplaceRoot/$metadataDestination"
 echo "\
 {
   \"LibraryFileName\": \"libSetReplace-$shortSHA.$libraryExtension\",
-  \"LibraryBuildTime\": $(date -u "+[%Y, %m, %d, %H, %M, %S]"),
+  \"LibraryBuildTime\": $(date -u "+[%-Y, %-m, %-d, %-H, %-M, %-S]"),
   \"LibrarySourceHash\": \"$shortSHA\"
 }" > $metadataDestination
 


### PR DESCRIPTION
## Changes
* Useful for #552.
* Implements `buildLibraryResources.sh` script that builds correctly-formatted `LibraryResources` directory without using Wolfram Language including hashing the source files.
* Works on Linux, Mac, and Windows.

## Comments
* Note that the hashes will not be the same as if produced by `./build.wls`. That is intentional since the hashes also include the sources of the build scripts.
* The hashes are not consistent between platforms as well because they contain `uname -sm` (similar to `./build.wls`).
* There is no `shasum` on Windows CI, so I'm using `certutil` instead, which is a bit hacky, but it works.
* Only 64-bit OS is supported because the intention is to only build the paclet for 64-bit OSs (like we did previously).

## Examples
* On Mac:
```
> ./scripts/buildLibraryResources.sh
Using SHA tool: /usr/bin/shasum
libSetReplace sources hash: aafd8d2a383a3
-- The CXX compiler identification is AppleClang 12.0.0.12000032
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- SetReplace version: 0.3.0
-- SetReplace using CMAKE_CXX_STANDARD: 17
-- CMAKE_BUILD_TYPE: Release
-- SET_REPLACE_BUILD_TESTING: OFF
-- SET_REPLACE_COMPILE_OPTIONS: -Wall;-Wextra;-Werror;-pedantic;-Wcast-align;-Wcast-qual;-Wctor-dtor-privacy;-Wdisabled-optimization;-Wformat=2;-Winit-self;-Wmissing-include-dirs;-Wold-style-cast;-Woverloaded-virtual;-Wredundant-decls;-Wshadow;-Wsign-promo;-Wswitch-default;-Wundef;-Wno-unused
-- SET_REPLACE_LIBRARIES: SetReplace
-- Configuring done
-- Generating done
-- Build files have been written to: /Users/maxitg/git/SetReplace/build
Scanning dependencies of target SetReplace
[ 14%] Building CXX object CMakeFiles/SetReplace.dir/libSetReplace/Event.cpp.o
[ 28%] Building CXX object CMakeFiles/SetReplace.dir/libSetReplace/Expression.cpp.o
[ 42%] Building CXX object CMakeFiles/SetReplace.dir/libSetReplace/Match.cpp.o
[ 57%] Building CXX object CMakeFiles/SetReplace.dir/libSetReplace/Set.cpp.o
[ 71%] Building CXX object CMakeFiles/SetReplace.dir/libSetReplace/Parallelism.cpp.o
[ 85%] Building CXX object CMakeFiles/SetReplace.dir/libSetReplace/SetReplace.cpp.o
[100%] Linking CXX shared library libSetReplace.dylib
[100%] Built target SetReplace
LibraryResources directory: /Users/maxitg/git/SetReplace/LibraryResources/MacOSX-x86-64
Library extension: dylib
Found compiled library at /Users/maxitg/git/SetReplace/build/libSetReplace.dylib
Copying the library to /Users/maxitg/git/SetReplace/LibraryResources/MacOSX-x86-64/libSetReplace-aafd8d2a383a3.dylib
Writing metadata to /Users/maxitg/git/SetReplace/LibraryResources/MacOSX-x86-64/libSetReplaceBuildInfo.json
{
  "LibraryFileName": "libSetReplace-aafd8d2a383a3.dylib",
  "LibraryBuildTime": [2020, 12, 09, 22, 08, 11],
  "LibrarySourceHash": "aafd8d2a383a3"
}
Build done
```

* On Linux:
```
> ./scripts/buildLibraryResources.sh
Using SHA tool: /usr/bin/shasum
libSetReplace sources hash: e6c4d44036d49
-- The CXX compiler identification is GNU 9.3.0
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- SetReplace version: 0.3.0
-- SetReplace using CMAKE_CXX_STANDARD: 17
-- CMAKE_BUILD_TYPE: Release
-- SET_REPLACE_BUILD_TESTING: OFF
-- SET_REPLACE_COMPILE_OPTIONS: -Wall;-Wextra;-Werror;-pedantic;-Wcast-align;-Wcast-qual;-Wctor-dtor-privacy;-Wdisabled-optimization;-Wformat=2;-Winit-self;-Wmissing-include-dirs;-Wold-style-cast;-Woverloaded-virtual;-Wredundant-decls;-Wshadow;-Wsign-promo;-Wswitch-default;-Wundef;-Wno-unused
-- SET_REPLACE_LIBRARIES: SetReplace
-- Configuring done
-- Generating done
-- Build files have been written to: /SetReplace/build
Scanning dependencies of target SetReplace
[ 14%] Building CXX object CMakeFiles/SetReplace.dir/libSetReplace/Event.cpp.o
[ 28%] Building CXX object CMakeFiles/SetReplace.dir/libSetReplace/Expression.cpp.o
[ 42%] Building CXX object CMakeFiles/SetReplace.dir/libSetReplace/Match.cpp.o
[ 57%] Building CXX object CMakeFiles/SetReplace.dir/libSetReplace/Set.cpp.o
[ 71%] Building CXX object CMakeFiles/SetReplace.dir/libSetReplace/Parallelism.cpp.o
[ 85%] Building CXX object CMakeFiles/SetReplace.dir/libSetReplace/SetReplace.cpp.o
[100%] Linking CXX shared library libSetReplace.so
[100%] Built target SetReplace
LibraryResources directory: /SetReplace/LibraryResources/Linux-x86-64
Library extension: so
Found compiled library at /SetReplace/build/libSetReplace.so
Copying the library to /SetReplace/LibraryResources/Linux-x86-64/libSetReplace-e6c4d44036d49.so
Writing metadata to /SetReplace/LibraryResources/Linux-x86-64/libSetReplaceBuildInfo.json
{
  "LibraryFileName": "libSetReplace-e6c4d44036d49.so",
  "LibraryBuildTime": [2020, 12, 09, 22, 10, 01],
  "LibrarySourceHash": "e6c4d44036d49"
}
Build done
```

* On Windows: see [CI output](https://app.circleci.com/pipelines/github/maxitg/SetReplace/1422/workflows/398b47a7-c8c2-4306-9cc9-fac3b00bf622/jobs/1994).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/561)
<!-- Reviewable:end -->
