### PR TITLE
CI job: macOS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,6 +103,35 @@ jobs:
       - store_test_results:
           path: TestResults
 
+  macos:
+    macos:
+      xcode: 12.2.0
+
+    steps:
+      - checkout
+
+      - run:
+          name: Install CMake
+          command: |
+            cmakeURL=$(\
+              curl -s https://api.github.com/repos/Kitware/CMake/releases/latest \
+              | grep 'browser_download_url' \
+              | cut -d\" -f4 \
+              | grep Darwin-x86_64.tar.gz)
+            curl -L --output cmake-Darwin-x86_64.tar.gz $cmakeURL
+            tar xf cmake-Darwin-x86_64.tar.gz
+            cmakeDir=$(ls | grep cmake-*-Darwin-x86_64)
+            mkdir -p /usr/local/bin /usr/local/share
+            cp -r $cmakeDir/CMake.app/Contents/bin/* /usr/local/bin/
+            cp -r $cmakeDir/CMake.app/Contents/share/* /usr/local/share/
+
+      - run:
+          name: Build
+          command: scripts/buildLibraryResources.sh
+
+      - store_artifacts:
+          path: ./LibraryResources/
+
   windows:
     executor:
       name: win/default
@@ -142,4 +171,5 @@ workflows:
       - wolfram-language
       - cpp
       - cpp-32
+      - macos
       - windows


### PR DESCRIPTION
## Changes
* Closes #371.
* Adds macOS builds to the Circle CI workflow using the new `buildLibraryResources.sh` script.

## Comments
* CI will fail until #561 is merged, the passing build with #561 cherry-picked is [here](https://app.circleci.com/pipelines/github/maxitg/SetReplace/1426/workflows/67aff070-9e47-4215-9c55-481371310c38/jobs/2004/steps).
* I tried using [Homebrew](https://brew.sh) to install CMake which is much cleaner, but installing Homebrew itself takes [over 2 mins](https://app.circleci.com/pipelines/github/maxitg/SetReplace/1423/workflows/73be1fa3-6e55-4c9d-87eb-afa49748f282/jobs/2000/steps), so I had to revert to manual installation like on Windows.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/562)
<!-- Reviewable:end -->
