### PR TITLE
Fix CMake Warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,7 +116,7 @@ if(SET_REPLACE_BUILD_TESTING)
   FetchContent_Declare(
     googletest
     GIT_REPOSITORY https://github.com/google/googletest.git
-    GIT_TAG v1.8.x
+    GIT_TAG v1.10.x
   )
 
   set(CMAKE_POLICY_DEFAULT_CMP0048 NEW) # google test raises warning about it


### PR DESCRIPTION
## Changes
* Fixes a GTest deprecation warning, due to an out of date version.

## Examples
Before fix:
```
$ cmake .. -DSET_REPLACE_ENABLE_ALLWARNINGS=ON -DBUILD_SHARED_LIBS=ON
-- SetReplace version: 0.3.0
-- SetReplace using CMAKE_CXX_STANDARD: 17
-- CMAKE_BUILD_TYPE: Release
-- SET_REPLACE_BUILD_TESTING: ON
-- SET_REPLACE_COMPILE_OPTIONS: -Wall;-Wextra;-Werror;-pedantic;-Wcast-align;-Wcast-qual;-Wctor-dtor-privacy;-Wdisabled-optimization;-Wformat=2;-Winit-self;-Wmissing-include-dirs;-Wold-style-cast;-Woverloaded-virtual;-Wredundant-decls;-Wshadow;-Wsign-promo;-Wswitch-default;-Wundef;-Wno-unused
CMake Deprecation Warning at build/_deps/googletest-src/CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 2.8.12 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.


CMake Deprecation Warning at build/_deps/googletest-src/googlemock/CMakeLists.txt:42 (cmake_minimum_required):
  Compatibility with CMake < 2.8.12 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.


CMake Deprecation Warning at build/_deps/googletest-src/googletest/CMakeLists.txt:49 (cmake_minimum_required):
  Compatibility with CMake < 2.8.12 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.


-- SET_REPLACE_LIBRARIES: SetReplace
-- Configuring done
-- Generating done
-- Build files have been written to: /home/antony/repos/SetReplace/build
```

Post fix:
```
$ cmake .. -DSET_REPLACE_ENABLE_ALLWARNINGS=ON -DBUILD_SHARED_LIBS=ON
-- The CXX compiler identification is GNU 10.2.0
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- SetReplace version: 0.3.0
-- Setting build type to 'Release' as none was specified.
-- SetReplace using CMAKE_CXX_STANDARD: 17
-- CMAKE_BUILD_TYPE: Release
-- SET_REPLACE_BUILD_TESTING: OFF
-- SET_REPLACE_COMPILE_OPTIONS: -Wall;-Wextra;-Werror;-pedantic;-Wcast-align;-Wcast-qual;-Wctor-dtor-privacy;-Wdisabled-optimization;-Wformat=2;-Winit-self;-Wmissing-include-dirs;-Wold-style-cast;-Woverloaded-virtual;-Wredundant-decls;-Wshadow;-Wsign-promo;-Wswitch-default;-Wundef;-Wno-unused
-- SET_REPLACE_LIBRARIES: SetReplace
-- Configuring done
-- Generating done
-- Build files have been written to: /home/antony/repos/SetReplace/build
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/563)
<!-- Reviewable:end -->
