### PR TITLE
Standardize Shebangs

### DIFF
--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 rm -f exit_status.txt
 STATUS_FILE=1 ./test.wls -lip -e performance

--- a/libSetReplaceTest.sh
+++ b/libSetReplaceTest.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ $(uname) = "Darwin" ]
 then

--- a/lint.sh
+++ b/lint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 sourceFiles="libSetReplace/*pp libSetReplace/test/*pp"
 

--- a/scripts/git_hooks/pre-push
+++ b/scripts/git_hooks/pre-push
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 ./lint.sh
 

--- a/scripts/install_git_hooks.sh
+++ b/scripts/install_git_hooks.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Adapted from https://stackoverflow.com/a/3464399
 
 hookNames=$(find scripts/git_hooks -type f -exec basename {} \; | tr '\n' ' ')


### PR DESCRIPTION
## Changes
* Changes all shebangs to use `/usr/bin/env *`.

## Comments
See [here](https://en.wikipedia.org/w/index.php?title=Shebang_(Unix)#Portability) for shebang portability.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/564)
<!-- Reviewable:end -->
