### PR TITLE
Alpine Linux 64 CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,9 +52,8 @@ jobs:
       - run:
           name: Install Required Tools
           command: |
-            apk add --no-cache bash git g++ make cmake clang python2
-            wget https://raw.githubusercontent.com/cpplint/cpplint/develop/cpplint.py
-            install -Dm755 cpplint.py /usr/bin/cpplint
+            apk add --no-cache bash git g++ make cmake clang py-pip
+            pip install cpplint
 
       - run:
           name: Lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,10 +41,20 @@ jobs:
           command: ./performanceTest.wls master @HEAD 2
   cpp:
     docker:
-      - image: maxitg/set-replace-cpp-ci
+      - image: alpine:3.12.1
+        auth:
+          username: maxitg
+          password: $DOCKERHUB_PASSWORD
 
     steps:
       - checkout
+
+      - run:
+          name: Install Required Tools
+          command: |
+            apk add --no-cache bash git g++ make cmake clang python2
+            wget https://raw.githubusercontent.com/google/styleguide/gh-pages/cpplint/cpplint.py
+            install -Dm755 cpplint.py /usr/bin/cpplint
 
       - run:
           name: Lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
           name: Install Required Tools
           command: |
             apk add --no-cache bash git g++ make cmake clang python2
-            wget https://raw.githubusercontent.com/google/styleguide/gh-pages/cpplint/cpplint.py
+            wget https://raw.githubusercontent.com/cpplint/cpplint/develop/cpplint.py
             install -Dm755 cpplint.py /usr/bin/cpplint
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,6 +73,36 @@ jobs:
       - store_test_results:
           path: TestResults
 
+  cpp-32:
+    docker:
+      - image: i386/alpine:3.12.1
+        auth:
+          username: maxitg
+          password: $DOCKERHUB_PASSWORD
+
+    steps:
+      - checkout
+
+      - run:
+          name: Install Required Tools
+          command: apk add --no-cache bash git g++ make cmake
+
+      - run:
+          name: Build
+          command: |
+            mkdir build
+            cd build
+            cmake .. -DSET_REPLACE_BUILD_TESTING=ON \
+                     -DSET_REPLACE_ENABLE_ALLWARNINGS=ON
+            cmake --build .
+
+      - run:
+          name: Test
+          command: ./libSetReplaceTest.sh
+
+      - store_test_results:
+          path: TestResults
+
   windows:
     executor:
       name: win/default
@@ -111,4 +141,5 @@ workflows:
     jobs:
       - wolfram-language
       - cpp
+      - cpp-32
       - windows

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,7 +116,7 @@ if(SET_REPLACE_BUILD_TESTING)
   FetchContent_Declare(
     googletest
     GIT_REPOSITORY https://github.com/google/googletest.git
-    GIT_TAG v1.8.x
+    GIT_TAG v1.10.x
   )
 
   set(CMAKE_POLICY_DEFAULT_CMP0048 NEW) # google test raises warning about it

--- a/libSetReplace/Event.cpp
+++ b/libSetReplace/Event.cpp
@@ -1,7 +1,9 @@
 #include "Event.hpp"
 
 #include <algorithm>
+#include <memory>
 #include <unordered_map>
+#include <vector>
 
 namespace SetReplace {
 class CausalGraph::Implementation {

--- a/libSetReplace/Parallelism.cpp
+++ b/libSetReplace/Parallelism.cpp
@@ -1,6 +1,7 @@
 #include "Parallelism.hpp"
 
 #include <algorithm>
+#include <memory>
 #include <mutex>
 #include <stdexcept>
 #include <thread>

--- a/libSetReplace/test/Parallelism_tests.cpp
+++ b/libSetReplace/test/Parallelism_tests.cpp
@@ -2,6 +2,7 @@
 
 #include <forward_list>
 #include <thread>
+#include <utility>
 #include <vector>
 
 #include "Parallelism.hpp"

--- a/libSetReplace/test/profile_tests.cpp
+++ b/libSetReplace/test/profile_tests.cpp
@@ -1,5 +1,8 @@
 #include <gtest/gtest.h>
 
+#include <utility>
+#include <vector>
+
 #include "Set.hpp"
 
 namespace SetReplace {


### PR DESCRIPTION
## Changes
* Changes C++ CI image to use public alpine image rather than custom public one specifically for this repo.

## Comments
* For some reason, cpplint is broken on previous CI image and was not catching errors. I fixed them in this PR. See [this failed build](https://app.circleci.com/pipelines/github/maxitg/SetReplace/1434/workflows/6db31200-a23a-44e3-8ace-b0fb28b7f2c5/jobs/2037).
* Using this image makes it easier to install new tools on CI image for instance. There is no longer a need to edit a Dockerfile, build the image, then push anymore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/565)
<!-- Reviewable:end -->
