### PR TITLE
CI: Build multi-platform paclet

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
   win: circleci/windows@2.2.0
 
 jobs:
-  wolfram-language:
+  wolfram-language-paclet-test:
     docker:
       - image: maxitg/set-replace-wl-ci:12.1.1
         auth:
@@ -20,6 +20,13 @@ jobs:
 
       - store_artifacts:
           path: ./LibraryResources/
+
+      - attach_workspace:
+          at: /tmp/workspace
+
+      - run:
+          name: Copy libraries from other platforms
+          command: cp -r /tmp/workspace/* ./LibraryResources/
 
       - run:
           name: Install
@@ -39,7 +46,8 @@ jobs:
       - run:
           name: Performance Test
           command: ./performanceTest.wls master @HEAD 2
-  cpp:
+
+  cpp-test:
     docker:
       - image: alpine:3.12.1
         auth:
@@ -82,7 +90,7 @@ jobs:
       - store_test_results:
           path: TestResults
 
-  cpp-32:
+  cpp-32-test:
     docker:
       - image: i386/alpine:3.12.1
         auth:
@@ -112,7 +120,7 @@ jobs:
       - store_test_results:
           path: TestResults
 
-  macos:
+  macos-build:
     macos:
       xcode: 12.2.0
 
@@ -138,10 +146,15 @@ jobs:
           name: Build
           command: scripts/buildLibraryResources.sh
 
+      - persist_to_workspace:
+          root: LibraryResources
+          paths:
+            - MacOSX-x86-64
+
       - store_artifacts:
           path: ./LibraryResources/
 
-  windows:
+  windows-build:
     executor:
       name: win/default
       shell: bash.exe
@@ -166,6 +179,11 @@ jobs:
           name: Build
           command: scripts/buildLibraryResources.sh
 
+      - persist_to_workspace:
+          root: LibraryResources
+          paths:
+            - Windows-x86-64
+
       - store_artifacts:
           path: ./LibraryResources/
 
@@ -173,8 +191,11 @@ workflows:
   version: 2
   build-and-test:
     jobs:
-      - wolfram-language
-      - cpp
-      - cpp-32
-      - macos
-      - windows
+      - macos-build
+      - windows-build
+      - cpp-test
+      - cpp-32-test
+      - wolfram-language-paclet-test:
+          requires:
+            - macos-build
+            - windows-build

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -154,11 +154,11 @@ The `test.wls` script accepts various arguments. Running `./test.wls testfile`, 
 
 We have a CI that automatically runs tests for all commits on all branches (kudos to [Circle CI](https://circleci.com) for providing free resources for this project). You need collaborator access to run the CI. If you don't have such access yet, the reviewer will run it for you.
 
-We use a private docker image `maxitg/set-replace:ci` running *Ubuntu* and *Wolfram Engine*, which [runs](https://app.circleci.com/pipelines/github/maxitg/SetReplace/408/workflows/8577ff51-2f5a-4517-992c-b20c76dcf170/jobs/444) [build](/build.wls), [install](/install.wls) and [test](/test.wls) scripts.
+We have a workflow ([example](https://app.circleci.com/pipelines/github/maxitg/SetReplace/1452/workflows/75b2a72b-c36e-43e2-bb51-2ff0e690e64c)) that builds a paclet (in wolfram-language-paclet-test) with libraries for Linux (also in wolfram-language-paclet-test), Mac (macos-build) and Windows (windows-build) and runs both C++ (cpp-test and cpp-32-test) and Wolfram Language (wolfram-language-paclet-test) tests.
 
-Your code must successfully pass all tests to be mergeable to master.
+Your code must successfully complete all builds and pass all tests to be mergeable to master.
 
-We also have a setup within Wolfram Research that allows us to build the paclet containing compiled binary libraries for all platforms, which we use for releases, but it's only available to developers working in the company. If you need such paclet for a version that is not a current release, please contact [@maxitg](https://github.com/maxitg).
+The paclets built by the wolfram-language-paclet-test job are the same as we use for releases.
 
 In addition to correctness tests, we have a performance testing tool, which is currently in the early stage of development, and only allows testing of the performance of the evolution. To use it, run in the repository root:
 
@@ -386,7 +386,7 @@ Note that it's essential to test not only the functionality but also the behavio
 
 The tests should be deterministic so that they can be easily reproduced. If the test cases are randomly generated, this can be achieved by setting [`SeedRandom`](https://reference.wolfram.com/language/ref/SeedRandom.html).
 
-If you want to implement performance tests, leave considerable leeway for the performance target, as the performance of CI servers may be different from what you might expect, and could fluctuate from run to run, which could result in randomly failing CI.
+If you want to implement performance tests, put them in the [`./performanceTest.wls` script](/performanceTest.wls) instead of the [Tests directory](/Tests).
 
 ### Documentation
 
@@ -410,8 +410,6 @@ The four main scripts of *SetReplace* are:
 All four scripts use functionality defined in the [DevUtils](/DevUtils) package.
 
 Note that the `pack.wls` script will auto-generate the paclet version number based on the number of commits to master from the checkpoint defined in [version.wl](/scripts/version.wl).
-
-The code in the [scripts](/scripts) folder is only used for building *SetReplace* on the internal Wolfram Research systems and should not be modified by external developers as CI has no way of testing it.
 
 ## Code style
 


### PR DESCRIPTION
## Changes
* Closes #552.
* Renames CI jobs to explicitly say if they do building or testing.
* Copies the libraries from macos-build and windows-build, and puts them into the paclet created in wolfram-language-paclet-test before testing.
* As a result, the paclet-artifact from wolfram-language-paclet-test now contains libraries for all platforms.
* Also updates contributing guide accordingly to describe the new workflow and remove references to the internal build process.

## Examples
* Here is [the workflow](https://app.circleci.com/pipelines/github/maxitg/SetReplace/1454/workflows/91394b90-7214-439f-95f7-3e4aa617784b).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/568)
<!-- Reviewable:end -->
