### PR TITLE
set -eo pipefail in all bash scripts

### DIFF
--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -eo pipefail
 
 rm -f exit_status.txt
 STATUS_FILE=1 ./test.wls -lip -e performance

--- a/libSetReplaceTest.sh
+++ b/libSetReplaceTest.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -eo pipefail
 
 if [ $(uname) = "Darwin" ]
 then

--- a/lint.sh
+++ b/lint.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -eo pipefail
 
 sourceFiles="libSetReplace/*pp libSetReplace/test/*pp"
 

--- a/scripts/install_git_hooks.sh
+++ b/scripts/install_git_hooks.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # Adapted from https://stackoverflow.com/a/3464399
+set -eo pipefail
 
 hookNames=$(find scripts/git_hooks -type f -exec basename {} \; | tr '\n' ' ')
 


### PR DESCRIPTION
## Changes
* Resolves #567.
* CI could silently fail in a lint step because `set +eo pipefail` in the CI script used to display an extra message in case of failure was not counteracted by `set -eo pipefail` in the lint script itself. (CI automatically sets `set -eo pipefail` to scripts if not manually disabled).
* This PR adds `set -eo pipefail` to all scripts to prevent this kind of weeds from happening.

## Examples
* See an example of a fail build [here](https://app.circleci.com/pipelines/github/maxitg/SetReplace/1457/workflows/48d322b2-0c86-4d0f-8d6c-695894d0cc9b/jobs/2144). Note that the hint about the hooks is still being printed at the end.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/570)
<!-- Reviewable:end -->
