### PR TITLE
Linter: Enforce line width

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
       - run:
           name: Install Required Tools
           command: |
-            apk add --no-cache bash git g++ make cmake clang py-pip
+            apk add --no-cache bash git g++ make cmake clang py-pip ncurses
             pip install cpplint
 
       - run:

--- a/lint.sh
+++ b/lint.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+setReplaceRoot=$(cd $(dirname $0) && pwd)
+cd "$setReplaceRoot"
 sourceFiles="libSetReplace/*pp libSetReplace/test/*pp"
 
 red="\\\033[0;31m"
@@ -46,6 +48,10 @@ if [ $exitStatus -eq 1 ]; then
 fi
 
 if ! cpplint --quiet --extensions=hpp,cpp $sourceFiles; then
+  exitStatus=1
+fi
+
+if ! ./scripts/checkLineWidth.sh; then
   exitStatus=1
 fi
 

--- a/scripts/checkLineWidth.sh
+++ b/scripts/checkLineWidth.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+setReplaceRoot=$(dirname $(cd $(dirname $0) && pwd))
+cd "$setReplaceRoot"
+
+lsfilesOptions=(
+  --cached
+  --others                   # untracked files
+  --exclude-standard         # exclude .gitignore
+  '*'
+  ':(exclude)*.png'
+  ':(exclude)*.md'           # Markdown files do not yet follow the line width limit
+  ':(exclude)*.xcodeproj/*'  # Xcode manages these automatically
+  ':(exclude)*.?pp'          # Handled by clang-format
+  ':(exclude)*.h'
+)
+
+filesToCheckIncludingDeleted=$(git ls-files "${lsfilesOptions[@]}")
+deletedFiles=$(git ls-files --deleted)
+
+if [ -n "$deletedFiles" ]; then
+  filesToCheck=$(echo "$filesToCheckIncludingDeleted" \
+                 | grep --invert-match --word-regexp --fixed-strings "$deletedFiles")
+else
+  filesToCheck="$filesToCheckIncludingDeleted"
+fi
+
+widthLimit=120
+
+# If colors are printed using escape sequences, they stop working if the script is called from another script
+# If the terminal is not explicitly specified, CI fails with $TERM unspecified error.
+terminal=xterm-256color
+bold=$(tput -T$terminal bold)
+yellow=$(tput -T$terminal setaf 3)
+green=$(tput -T$terminal setaf 2)
+endColor=$(tput -T$terminal sgr0)
+
+exitCode=0
+for file in $filesToCheck; do
+  lineWidths=($(awk '{ print length }' $file))
+  for lineIndex in "${!lineWidths[@]}"; do
+    lineWidth=${lineWidths[$lineIndex]}
+    if (( $lineWidth > $widthLimit )); then
+      oneIndexedLineIndex=$(( $lineIndex + 1 ))
+      formattedFilename="${bold}$setReplaceRoot/${yellow}$file:$oneIndexedLineIndex${endColor}"
+      formattedErrorMessage="${bold}: line length ${lineWidth} exceeds the maximum of $widthLimit${endColor}"
+      echo "${formattedFilename}${formattedErrorMessage}"
+      echo "$(sed "${oneIndexedLineIndex}q;d" $file)"
+      echo "$(head -c 120 < /dev/zero | tr '\0' ' ')${green}^${endColor}"
+      exitCode=1
+    fi
+  done
+done
+
+exit $exitCode


### PR DESCRIPTION
## Changes
* Implements part of #522.
* Adds a script that checks that lines in all files are within the length of 120 chars.
* Calls that script from `./lint.sh` so that it is run by CI and git hooks.

## Comments
* For some reason, using ordinary escape sequences for colors does not work if the script is called from another script: [example](https://app.circleci.com/pipelines/github/maxitg/SetReplace/1465/workflows/d94e9c25-151c-4204-86d0-c3711e4ac924/jobs/2188). I'm using `tput` from `ncurses` as a workaround.
* Markdown files are not enforced because the limit is not respected there at all. A lot of work will need to be done to fix that first.
* CI will fail until existing errors are not fixed. They will be fixed in another PR which will need to be merged first.

## Examples
* Here is an example of error messages: [example](https://app.circleci.com/pipelines/github/maxitg/SetReplace/1469/workflows/8d3b5476-75b6-407e-a5bf-16799a5a3989/jobs/2207).