### PR TITLE
CI: Fix CMake install script to use the new universal archive

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,10 +134,10 @@ jobs:
               curl -s https://api.github.com/repos/Kitware/CMake/releases/latest \
               | grep 'browser_download_url' \
               | cut -d\" -f4 \
-              | grep Darwin-x86_64.tar.gz)
-            curl -L --output cmake-Darwin-x86_64.tar.gz $cmakeURL
-            tar xf cmake-Darwin-x86_64.tar.gz
-            cmakeDir=$(ls | grep cmake-*-Darwin-x86_64)
+              | grep macos-universal.tar.gz)
+            curl -L --output cmake-macos-universal.tar.gz $cmakeURL
+            tar xf cmake-macos-universal.tar.gz
+            cmakeDir=$(ls | grep cmake-*-macos-universal)
             mkdir -p /usr/local/bin /usr/local/share
             cp -r $cmakeDir/CMake.app/Contents/bin/* /usr/local/bin/
             cp -r $cmakeDir/CMake.app/Contents/share/* /usr/local/share/


### PR DESCRIPTION
## Changes
* Due to the ongoing change of Macs from x86 to ARM architecture, the archives with CMake releases are now named `-universal` instead of `-Darwin-x86_64`. As a result, macOS CI fails because it cannot find the macOS CMake in the most recent release.
* This fixes the name to search for.

## Comments
* Perhaps, we should be using a specific version to prevent this from happening in the future. However, the architecture changes like this are rare, and it does save time to not have to update CMake manually, so perhaps we can leave it like this until/if the next issue arises.

## Examples
* [CI job](https://app.circleci.com/pipelines/github/maxitg/SetReplace/1501/workflows/52549d15-c635-4143-8650-667c088f390b/jobs/2363) now succeeds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/576)
<!-- Reviewable:end -->
