### PR TITLE
Fix early exit from clang-format in ./lint.sh

### DIFF
--- a/lint.sh
+++ b/lint.sh
@@ -36,12 +36,12 @@ done
 exitStatus=0
 
 for file in $sourceFiles; do
-  diff=$(diff -U0 --label "$file" "$file" --label formatted <(clang-format "$file"))
+  diff=$(diff -U0 --label "$file" "$file" --label formatted <(clang-format "$file") || :)
   if [ $formatInPlace -eq 1 ]; then
     clang-format -i "$file"
   fi
   if [[ -n "$diff" ]]; then
-    printf -- "%s" "$(printf "%s" "$diff\n\n" | sed "s|^-|$red-|g" | sed "s|^+|$green+|g" | sed "s|$|$endColor|g")"
+    echo -e "$(echo -e "$diff\n\n" | sed "s|^-|$red-|g" | sed "s|^+|$green+|g" | sed "s|$|$endColor|g")"
     exitStatus=1
   fi
 done


### PR DESCRIPTION
## Changes
This PR fixes two related issues:
* `./lint.sh` would silently exit (with exit code 1) if `clang-format` found formatting errors. This was caused `set -eo pipefail` which terminated the script after the first failure. Fixed with ` || :`
* Changed `printf`'s to `echo -e` because `printf` caused colors to stop working.

## Examples
* Add a formatting error (for example, add a trailing space to `libSetReplace/Parallelism.hpp:37`).
* Run `./lint.sh`:

<img width="682" alt="Screen Shot 2020-12-17 at 12 10 22" src="https://user-images.githubusercontent.com/1479325/102526123-d8024e80-4060-11eb-8df3-62f57abdf281.png">

* As one can see, colors are now produced, the errors from `cpplint` are still generated, and the non-zero exit code is returned.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/577)
<!-- Reviewable:end -->
