### PR TITLE
Parallel WL Tests on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,8 +45,9 @@ jobs:
           command: |
             ./.circleci/test.sh $(circleci tests glob "Tests/*.wlt" \
               | circleci tests split --split-by=timings \
+              | sed "s/\.wlt//" \
               | sed "s/Tests\///" \
-              | sed "s/performance//")
+              | sed "/performance/d")
 
       - run:
           name: Performance Test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,11 @@ jobs:
 
       - run:
           name: Performance Test
-          command: ./performanceTest.wls master @HEAD 2
+          command: |
+            if [ $CIRCLE_NODE_INDEX -eq 0 ]
+            then
+              ./performanceTest.wls master @HEAD 2
+            fi
 
   cpp-test:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,11 +43,22 @@ jobs:
       - run:
           name: Test
           command: |
-            ./.circleci/test.sh $(circleci tests glob "Tests/*.wlt" \
-              | circleci tests split --split-by=filesize \
-              | sed "s/\.wlt//" \
-              | sed "s/Tests\///" \
-              | sed "/performance/d")
+            if [ $CIRCLE_NODE_INDEX -eq 2 ]
+            then
+              testsToRun=matching
+            elif [ $CIRCLE_NODE_INDEX -eq 3 ]
+            then
+              testsToRun=WolframModel
+            else
+              testsToRun=$(circleci tests glob "Tests/*.wlt" \
+                | sed "/Tests\/performance.wlt/d" \
+                | sed "/Tests\/matching.wlt/d" \
+                | sed "/Tests\/WolframModel.wlt/d" \
+                | circleci tests split --total=2 --split-by=filesize \
+                | sed "s/\.wlt//" \
+                | sed "s/Tests\///")
+            fi
+            ./.circleci/test.sh $testsToRun
 
       - run:
           name: Performance Test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ jobs:
         auth:
           username: maxitg
           password: $DOCKERHUB_PASSWORD
+    parallelism: 4
 
     steps:
       - checkout
@@ -41,7 +42,11 @@ jobs:
 
       - run:
           name: Test
-          command: ./.circleci/test.sh
+          command: |
+            ./.circleci/test.sh $(circleci tests glob "Tests/*.wlt" \
+              | circleci tests split --split-by=timings \
+              | sed "s/Tests\///" \
+              | sed "s/performance//")
 
       - run:
           name: Performance Test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
           name: Test
           command: |
             ./.circleci/test.sh $(circleci tests glob "Tests/*.wlt" \
-              | circleci tests split --split-by=timings \
+              | circleci tests split --split-by=filesize \
               | sed "s/\.wlt//" \
               | sed "s/Tests\///" \
               | sed "/performance/d")

--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -2,5 +2,5 @@
 set -eo pipefail
 
 rm -f exit_status.txt
-STATUS_FILE=1 ./test.wls -lip -e performance
+STATUS_FILE=1 ./test.wls -lip "$@"
 [[ -f exit_status.txt && $(<exit_status.txt) == "0" ]]


### PR DESCRIPTION
## Changes
* Adds 4x parallelism to WL tests on CI
* Closes #448 

## Comments
Currently, we do not have WL [test metadata](https://circleci.com/docs/2.0/collect-test-data/) compatible with CircleCI. Therefore, we can't use CircleCI's built-in [split-by timing](https://circleci.com/docs/2.0/parallelism-faster-jobs/#splitting-by-timing-data) to distribute tests efficiently. This PR simply runs `matching` and `WolframModel` (which take the most time by far) each in separate executors, and splits the rest among the last two. 

In order to optimize this further, we could:
1. Distribute tests from `matching` and `WolframModel` into separate files.
2. Implement JUnit XML or Cucumber JSON test result reports for WL and enable `split-by timing`.

## Examples
Parallel executors:
![image](https://user-images.githubusercontent.com/26678747/102551793-1b26e680-408e-11eb-8301-79c441f71da0.png)

Test time is reduced by ~10 minutes (over ~2x reduction):
![image](https://user-images.githubusercontent.com/26678747/102552754-b7052200-408f-11eb-97d1-7cba3b151416.png)

compared to master:
![image](https://user-images.githubusercontent.com/26678747/102552708-9fc63480-408f-11eb-87ef-592c572eb111.png)


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/578)
<!-- Reviewable:end -->
