### PR TITLE
Anonymous Namespaces

### DIFF
--- a/libSetReplace/Match.cpp
+++ b/libSetReplace/Match.cpp
@@ -19,6 +19,7 @@
 #include "Parallelism.hpp"
 
 namespace SetReplace {
+namespace {
 class MatchComparator {
  private:
   const Matcher::OrderingSpec orderingSpec_;
@@ -131,6 +132,7 @@ class MatchEquality {
            mismatchedIterators.second == b->inputExpressions.end();
   }
 };
+}  // namespace
 
 class Matcher::Implementation {
  private:

--- a/libSetReplace/SetReplace.cpp
+++ b/libSetReplace/SetReplace.cpp
@@ -11,6 +11,13 @@
 
 #include "Set.hpp"
 
+namespace SetReplace {
+namespace {
+// These are global variables that keep all sets returned to Wolfram Language until they are destroyed.
+// Pointers are not returned directly for security reasons.
+using SetID = int64_t;
+std::unordered_map<SetID, Set> sets_;
+
 mint getData(const mint* data, const mint& length, const mint& index) {
   if (index >= length || index < 0) {
     throw LIBRARY_FUNCTION_ERROR;
@@ -18,12 +25,6 @@ mint getData(const mint* data, const mint& length, const mint& index) {
     return data[index];
   }
 }
-
-namespace SetReplace {
-// These are global variables that keep all sets returned to Wolfram Language until they are destroyed.
-// Pointers are not returned directly for security reasons.
-using SetID = int64_t;
-std::unordered_map<SetID, Set> sets_;
 
 std::vector<AtomsVector> getNextSet(const mint& tensorLength, const mint* tensorData, mint* startReadIndex) {
   const auto getDataFunc = [&tensorData, &tensorLength, startReadIndex]() -> mint {
@@ -369,6 +370,7 @@ int terminationReason([[maybe_unused]] WolframLibraryData, mint argc, MArgument*
 
   return LIBRARY_NO_ERROR;
 }
+}  // namespace
 }  // namespace SetReplace
 
 EXTERN_C mint WolframLibrary_getVersion() { return WolframLibraryVersion; }


### PR DESCRIPTION
## Changes
* Adds some anonymous namespaces to force internal linkage

## Examples
Library size is reduced:

`compareLibSize.sh`
```bash
#!/usr/bin/env bash

sizes=()

function getSize() {
  rm -rf BuiltPaclets LibraryResources
  git checkout "$1"
  ./build.wls
  ./install.wls
  sizes+=("$(du -s LibraryResources | awk '{print $1;}')")
}

for tag in "$1" "$2"; do
  getSize "$tag" &>/dev/null
done

echo -e "First: "${sizes[0]}"\nSecond: "${sizes[1]}"\nChange: $(printf "%s%%\n" "$(bc <<< "100 * "${sizes[1]}" / "${sizes[0]}"")")"
```

```bash
$ ./compareLibSize.sh master optimization/AnonymousNamespace
First: 243030
Second: 227678
Change: 93%
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/587)
<!-- Reviewable:end -->
