### PR TITLE
Managed Expressions

### DIFF
--- a/Kernel/setSubstitutionSystem$cpp.m
+++ b/Kernel/setSubstitutionSystem$cpp.m
@@ -38,10 +38,12 @@ $libraryFunctions = {
         Integer, (* event selection function *)
         {Integer, 1}, (* ordering function index, forward / reverse, function, forward / reverse, ... *)
         Integer, (* event deduplication *)
-        Integer}, (* random seed *)
-      Integer], (* set ptr *)
+        Integer, (* random seed *)
+        Integer}, (* set ptr *)
+      "Void"],
     $Failed],
 
+  (* Expressions are automatically managed, so this is only here for optional manual resource release. *)
   $cpp$setDelete = If[$libraryFile =!= $Failed,
     LibraryFunctionLoad[
       $libraryFile,
@@ -212,33 +214,36 @@ setSubstitutionSystem$cpp[
       globalIndex,
       localIndices[[K]]],
     {K, Length[canonicalRules]}];
-  setPtr = $cpp$setCreate[
+  managedLibraryExpression = CreateManagedLibraryExpression["SetReplace", managedSet];
+  setID = ManagedLibraryExpressionID[managedLibraryExpression, "SetReplace"];
+  $cpp$setCreate[
     encodeNestedLists[List @@@ mappedRules],
     eventSelectionCodes[eventSelectionFunction, Length[canonicalRules]],
     encodeNestedLists[mappedSet],
     systemTypeCode[eventSelectionFunction],
     Catenate[Replace[eventOrderingFunction, $orderingFunctionCodes, {2}]],
     Replace[eventDeduplication, $eventDeduplicationCodes],
-    RandomInteger[{0, $maxUInt32}]];
+    RandomInteger[{0, $maxUInt32}],
+    setID
+  ];
   TimeConstrained[
     CheckAbort[
       $cpp$setReplace[
-        setPtr,
+        setID,
         stepSpec /@ {
             $maxEvents, $maxGenerationsLocal, $maxFinalVertices, $maxFinalVertexDegree, $maxFinalExpressions} /.
           {Infinity | (_ ? MissingQ) -> $maxInt64}],
       If[!returnOnAbortQ, Abort[], terminationReason = $Aborted]],
     timeConstraint,
     If[!returnOnAbortQ, Return[$Aborted], terminationReason = $timeConstraint]];
-  numericAtomLists = decodeAtomLists[$cpp$setExpressions[setPtr]];
-  events = decodeEvents[$cpp$setEvents[setPtr]];
+  numericAtomLists = decodeAtomLists[$cpp$setExpressions[setID]];
+  events = decodeEvents[$cpp$setEvents[setID]];
   maxCompleteGeneration = CheckAbort[
-    Replace[$cpp$maxCompleteGeneration[setPtr], LibraryFunctionError[___] -> Missing["Unknown", $Aborted]],
+    Replace[$cpp$maxCompleteGeneration[setID], LibraryFunctionError[___] -> Missing["Unknown", $Aborted]],
     If[!returnOnAbortQ, Abort[], terminationReason = $Aborted; Missing["Unknown", $Aborted]]];
-  terminationReason = Replace[$terminationReasonCodes[$cpp$terminationReason[setPtr]], {
+  terminationReason = Replace[$terminationReasonCodes[$cpp$terminationReason[setID]], {
     $Aborted -> terminationReason,
     $notTerminated -> $timeConstraint}];
-  $cpp$setDelete[setPtr];
   resultAtoms = Union[Catenate[numericAtomLists]];
   inversePartialGlobalMap = Association[Reverse /@ Normal @ globalIndex];
   inverseGlobalMap = Association @ Thread[resultAtoms

--- a/Kernel/setSubstitutionSystem$cpp.m
+++ b/Kernel/setSubstitutionSystem$cpp.m
@@ -208,14 +208,14 @@ setSubstitutionSystem$cpp[
   setHandle = CreateManagedLibraryExpression["SetReplace", managedSet];
   setID = ManagedLibraryExpressionID[setHandle, "SetReplace"];
   $cpp$setInitialize[
+    setID,
     encodeNestedLists[List @@@ mappedRules],
     eventSelectionCodes[eventSelectionFunction, Length[canonicalRules]],
     encodeNestedLists[mappedSet],
     systemTypeCode[eventSelectionFunction],
     Catenate[Replace[eventOrderingFunction, $orderingFunctionCodes, {2}]],
     Replace[eventDeduplication, $eventDeduplicationCodes],
-    RandomInteger[{0, $maxUInt32}],
-    setID
+    RandomInteger[{0, $maxUInt32}]
   ];
   TimeConstrained[
     CheckAbort[

--- a/Kernel/setSubstitutionSystem$cpp.m
+++ b/Kernel/setSubstitutionSystem$cpp.m
@@ -32,23 +32,14 @@ $libraryFunctions = {
     LibraryFunctionLoad[
       $libraryFile,
       "setCreate",
-      {{Integer, 1}, (* rules *)
+      {Integer, (* set ID *)
+        {Integer, 1}, (* rules *)
         {Integer, 1}, (* event selection functions for rules *)
         {Integer, 1}, (* initial set *)
         Integer, (* event selection function *)
         {Integer, 1}, (* ordering function index, forward / reverse, function, forward / reverse, ... *)
         Integer, (* event deduplication *)
-        Integer, (* random seed *)
-        Integer}, (* set ID *)
-      "Void"],
-    $Failed],
-
-  (* Expressions are automatically managed, so this is only here for optional manual resource release. *)
-  $cpp$setDelete = If[$libraryFile =!= $Failed,
-    LibraryFunctionLoad[
-      $libraryFile,
-      "setDelete",
-      {Integer}, (* set ID *)
+        Integer}, (* random seed *)
       "Void"],
     $Failed],
 

--- a/Kernel/setSubstitutionSystem$cpp.m
+++ b/Kernel/setSubstitutionSystem$cpp.m
@@ -28,10 +28,10 @@ If[!StringQ[$libraryFile] || !FileExistsQ[$libraryFile],
 
 (* Load libSetReplace functions *)
 $libraryFunctions = {
-  $cpp$setCreate = If[$libraryFile =!= $Failed,
+  $cpp$setInitialize = If[$libraryFile =!= $Failed,
     LibraryFunctionLoad[
       $libraryFile,
-      "setCreate",
+      "setInitialize",
       {Integer, (* set ID *)
         {Integer, 1}, (* rules *)
         {Integer, 1}, (* event selection functions for rules *)
@@ -207,7 +207,7 @@ setSubstitutionSystem$cpp[
     {K, Length[canonicalRules]}];
   setHandle = CreateManagedLibraryExpression["SetReplace", managedSet];
   setID = ManagedLibraryExpressionID[setHandle, "SetReplace"];
-  $cpp$setCreate[
+  $cpp$setInitialize[
     encodeNestedLists[List @@@ mappedRules],
     eventSelectionCodes[eventSelectionFunction, Length[canonicalRules]],
     encodeNestedLists[mappedSet],

--- a/Kernel/setSubstitutionSystem$cpp.m
+++ b/Kernel/setSubstitutionSystem$cpp.m
@@ -39,7 +39,7 @@ $libraryFunctions = {
         {Integer, 1}, (* ordering function index, forward / reverse, function, forward / reverse, ... *)
         Integer, (* event deduplication *)
         Integer, (* random seed *)
-        Integer}, (* set ptr *)
+        Integer}, (* set ID *)
       "Void"],
     $Failed],
 
@@ -48,7 +48,7 @@ $libraryFunctions = {
     LibraryFunctionLoad[
       $libraryFile,
       "setDelete",
-      {Integer}, (* set ptr *)
+      {Integer}, (* set ID *)
       "Void"],
     $Failed],
 
@@ -56,7 +56,7 @@ $libraryFunctions = {
     LibraryFunctionLoad[
       $libraryFile,
       "setReplace",
-      {Integer, (* set ptr *)
+      {Integer, (* set ID *)
         {Integer, 1}}, (* {events, generations, atoms, max expressions per atom, expressions} *)
       "Void"],
     $Failed],
@@ -65,7 +65,7 @@ $libraryFunctions = {
     LibraryFunctionLoad[
       $libraryFile,
       "setExpressions",
-      {Integer}, (* set ptr *)
+      {Integer}, (* set ID *)
       {Integer, 1}], (* expressions *)
     $Failed],
 
@@ -73,7 +73,7 @@ $libraryFunctions = {
     LibraryFunctionLoad[
       $libraryFile,
       "setEvents",
-      {Integer}, (* set ptr *)
+      {Integer}, (* set ID *)
       {Integer, 1}], (* expressions *)
     $Failed],
 
@@ -81,7 +81,7 @@ $libraryFunctions = {
     LibraryFunctionLoad[
       $libraryFile,
       "maxCompleteGeneration",
-      {Integer}, (* set ptr *)
+      {Integer}, (* set ID *)
       Integer], (* generation *)
     $Failed],
 
@@ -89,7 +89,7 @@ $libraryFunctions = {
     LibraryFunctionLoad[
       $libraryFile,
       "terminationReason",
-      {Integer}, (* set ptr *)
+      {Integer}, (* set ID *)
       Integer], (* reason *)
     $Failed]
 };

--- a/Kernel/setSubstitutionSystem$cpp.m
+++ b/Kernel/setSubstitutionSystem$cpp.m
@@ -214,8 +214,8 @@ setSubstitutionSystem$cpp[
       globalIndex,
       localIndices[[K]]],
     {K, Length[canonicalRules]}];
-  managedLibraryExpression = CreateManagedLibraryExpression["SetReplace", managedSet];
-  setID = ManagedLibraryExpressionID[managedLibraryExpression, "SetReplace"];
+  setHandle = CreateManagedLibraryExpression["SetReplace", managedSet];
+  setID = ManagedLibraryExpressionID[setHandle, "SetReplace"];
   $cpp$setCreate[
     encodeNestedLists[List @@@ mappedRules],
     eventSelectionCodes[eventSelectionFunction, Length[canonicalRules]],

--- a/libSetReplace/SetReplace.cpp
+++ b/libSetReplace/SetReplace.cpp
@@ -21,7 +21,7 @@ mint getData(const mint* data, const mint& length, const mint& index) {
 }
 
 namespace SetReplace {
-// These are global variables that keep all sets returned to Wolfram Language until they are destroyed.
+// These are global variables that keep all sets returned to Wolfram Language until they are no longer referenced.
 // Pointers are not returned directly for security reasons.
 using SetID = mint;
 // We use a pointer here because map key insertion (setManageInstance) is separate from map value insertion (setCreate).

--- a/libSetReplace/SetReplace.cpp
+++ b/libSetReplace/SetReplace.cpp
@@ -375,11 +375,11 @@ int terminationReason([[maybe_unused]] WolframLibraryData, mint argc, MArgument*
 
 EXTERN_C mint WolframLibrary_getVersion() { return WolframLibraryVersion; }
 
-EXTERN_C int WolframLibrary_initialize([[maybe_unused]] WolframLibraryData libData) {
+EXTERN_C int WolframLibrary_initialize(WolframLibraryData libData) {
   return (*libData->registerLibraryExpressionManager)("SetReplace", SetReplace::setManageInstance);
 }
 
-EXTERN_C void WolframLibrary_uninitialize([[maybe_unused]] WolframLibraryData libData) {
+EXTERN_C void WolframLibrary_uninitialize(WolframLibraryData libData) {
   (*libData->unregisterLibraryExpressionManager)("SetReplace");
 }
 

--- a/libSetReplace/SetReplace.cpp
+++ b/libSetReplace/SetReplace.cpp
@@ -232,8 +232,8 @@ int setInitialize(WolframLibraryData libData, mint argc, const MArgument* argv, 
   Matcher::EventDeduplication eventDeduplication;
   unsigned int randomSeed;
   try {
-    thisSetID = MArgument_getInteger(argv[1]);
-    rules = getRules(libData, MArgument_getMTensor(argv[0]), MArgument_getMTensor(argv[2]));
+    thisSetID = MArgument_getInteger(argv[0]);
+    rules = getRules(libData, MArgument_getMTensor(argv[1]), MArgument_getMTensor(argv[2]));
     initialExpressions = getSet(libData, MArgument_getMTensor(argv[3]));
     systemType = static_cast<Set::SystemType>(MArgument_getInteger(argv[4]));
     orderingSpec = getOrderingSpec(libData, MArgument_getMTensor(argv[5]));

--- a/libSetReplace/SetReplace.cpp
+++ b/libSetReplace/SetReplace.cpp
@@ -219,26 +219,26 @@ MTensor putEvents(const std::vector<Event>& events, WolframLibraryData libData) 
   return output;
 }
 
-int setCreate(WolframLibraryData libData, mint argc, const MArgument* argv, [[maybe_unused]] MArgument result) {
+int setInitialize(WolframLibraryData libData, mint argc, const MArgument* argv, [[maybe_unused]] MArgument result) {
   if (argc != 8) {
     return LIBRARY_FUNCTION_ERROR;
   }
 
+  SetID thisSetID;
   std::vector<Rule> rules;
   std::vector<AtomsVector> initialExpressions;
   Set::SystemType systemType;
   Matcher::OrderingSpec orderingSpec;
   Matcher::EventDeduplication eventDeduplication;
   unsigned int randomSeed;
-  SetID thisSetID;
   try {
-    rules = getRules(libData, MArgument_getMTensor(argv[0]), MArgument_getMTensor(argv[1]));
-    initialExpressions = getSet(libData, MArgument_getMTensor(argv[2]));
-    systemType = static_cast<Set::SystemType>(MArgument_getInteger(argv[3]));
-    orderingSpec = getOrderingSpec(libData, MArgument_getMTensor(argv[4]));
-    eventDeduplication = static_cast<Matcher::EventDeduplication>(MArgument_getInteger(argv[5]));
-    randomSeed = static_cast<unsigned int>(MArgument_getInteger(argv[6]));
-    thisSetID = MArgument_getInteger(argv[7]);
+    thisSetID = MArgument_getInteger(argv[1]);
+    rules = getRules(libData, MArgument_getMTensor(argv[0]), MArgument_getMTensor(argv[2]));
+    initialExpressions = getSet(libData, MArgument_getMTensor(argv[3]));
+    systemType = static_cast<Set::SystemType>(MArgument_getInteger(argv[4]));
+    orderingSpec = getOrderingSpec(libData, MArgument_getMTensor(argv[5]));
+    eventDeduplication = static_cast<Matcher::EventDeduplication>(MArgument_getInteger(argv[6]));
+    randomSeed = static_cast<unsigned int>(MArgument_getInteger(argv[7]));
   } catch (...) {
     return LIBRARY_FUNCTION_ERROR;
   }
@@ -251,17 +251,6 @@ int setCreate(WolframLibraryData libData, mint argc, const MArgument* argv, [[ma
   }
 
   return LIBRARY_NO_ERROR;
-}
-
-int setDelete([[maybe_unused]] WolframLibraryData libData,
-              mint argc,
-              MArgument* argv,
-              [[maybe_unused]] MArgument result) {
-  if (argc != 1) {
-    return LIBRARY_FUNCTION_ERROR;
-  }
-
-  return libData->releaseManagedLibraryExpression("SetReplace", MArgument_getInteger(argv[0]));
 }
 
 std::function<bool()> shouldAbort(WolframLibraryData libData) {
@@ -385,12 +374,8 @@ EXTERN_C void WolframLibrary_uninitialize(WolframLibraryData libData) {
   (*libData->unregisterLibraryExpressionManager)("SetReplace");
 }
 
-EXTERN_C int setCreate(WolframLibraryData libData, mint argc, MArgument* argv, MArgument result) {
-  return SetReplace::setCreate(libData, argc, argv, result);
-}
-
-EXTERN_C int setDelete(WolframLibraryData libData, mint argc, MArgument* argv, MArgument result) {
-  return SetReplace::setDelete(libData, argc, argv, result);
+EXTERN_C int setInitialize(WolframLibraryData libData, mint argc, MArgument* argv, MArgument result) {
+  return SetReplace::setInitialize(libData, argc, argv, result);
 }
 
 EXTERN_C int setReplace(WolframLibraryData libData, mint argc, MArgument* argv, MArgument result) {

--- a/libSetReplace/SetReplace.cpp
+++ b/libSetReplace/SetReplace.cpp
@@ -17,8 +17,8 @@ namespace {
 // These are global variables that keep all sets returned to Wolfram Language until they are no longer referenced.
 // Pointers are not returned directly for security reasons.
 using SetID = mint;
-// We use a pointer here because map key insertion (setManageInstance) is separate from map value insertion (setCreate).
-// Until the value is inserted, the set is nullptr.
+// We use a pointer here because map key insertion (setManageInstance) is separate from map value insertion
+// (setInitialize). Until the value is inserted, the set is nullptr.
 std::unordered_map<SetID, std::unique_ptr<Set>> sets_;
 
 /** @brief Either acquires or a releases a set, depending on the mode.

--- a/libSetReplace/SetReplace.cpp
+++ b/libSetReplace/SetReplace.cpp
@@ -1,5 +1,11 @@
 #include "SetReplace.hpp"
 
+// NOLINTNEXTLINE(build/c++11)
+#include <chrono>  // <chrono> is banned in Chromium, so cpplint flags it https://stackoverflow.com/a/33653404/905496
+#include <limits>
+#include <memory>
+#include <random>
+#include <string>
 #include <unordered_map>
 #include <utility>
 #include <vector>

--- a/libSetReplace/SetReplace.cpp
+++ b/libSetReplace/SetReplace.cpp
@@ -1,10 +1,5 @@
 #include "SetReplace.hpp"
 
-// NOLINTNEXTLINE(build/c++11)
-#include <chrono>  // <chrono> is banned in Chromium, so cpplint flags it https://stackoverflow.com/a/33653404/905496
-#include <limits>
-#include <random>
-#include <string>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -22,8 +17,16 @@ mint getData(const mint* data, const mint& length, const mint& index) {
 namespace SetReplace {
 // These are global variables that keep all sets returned to Wolfram Language until they are destroyed.
 // Pointers are not returned directly for security reasons.
-using SetID = int64_t;
-std::unordered_map<SetID, Set> sets_;
+using SetID = mint;
+std::unordered_map<SetID, std::unique_ptr<Set>> sets_;
+
+void setManageInstance([[maybe_unused]] WolframLibraryData libData, mbool mode, mint id) {
+  if (mode == 0) {
+    sets_.emplace(id, nullptr);
+  } else {
+    sets_.erase(id);
+  }
+}
 
 std::vector<AtomsVector> getNextSet(const mint& tensorLength, const mint* tensorData, mint* startReadIndex) {
   const auto getDataFunc = [&tensorData, &tensorLength, startReadIndex]() -> mint {
@@ -205,8 +208,8 @@ MTensor putEvents(const std::vector<Event>& events, WolframLibraryData libData) 
   return output;
 }
 
-int setCreate(WolframLibraryData libData, mint argc, const MArgument* argv, MArgument result) {
-  if (argc != 7) {
+int setCreate(WolframLibraryData libData, mint argc, const MArgument* argv, [[maybe_unused]] MArgument result) {
+  if (argc != 8) {
     return LIBRARY_FUNCTION_ERROR;
   }
 
@@ -216,6 +219,7 @@ int setCreate(WolframLibraryData libData, mint argc, const MArgument* argv, MArg
   Matcher::OrderingSpec orderingSpec;
   Matcher::EventDeduplication eventDeduplication;
   unsigned int randomSeed;
+  SetID thisSetID;
   try {
     rules = getRules(libData, MArgument_getMTensor(argv[0]), MArgument_getMTensor(argv[1]));
     initialExpressions = getSet(libData, MArgument_getMTensor(argv[2]));
@@ -223,23 +227,18 @@ int setCreate(WolframLibraryData libData, mint argc, const MArgument* argv, MArg
     orderingSpec = getOrderingSpec(libData, MArgument_getMTensor(argv[4]));
     eventDeduplication = static_cast<Matcher::EventDeduplication>(MArgument_getInteger(argv[5]));
     randomSeed = static_cast<unsigned int>(MArgument_getInteger(argv[6]));
+    thisSetID = MArgument_getInteger(argv[7]);
   } catch (...) {
     return LIBRARY_FUNCTION_ERROR;
   }
 
-  SetID thisSetID;
-  do {
-    std::mt19937_64 randomGenerator(std::chrono::system_clock::now().time_since_epoch().count());
-    std::uniform_int_distribution<SetID> distribution(0, std::numeric_limits<SetID>::max());
-    thisSetID = distribution(randomGenerator);
-  } while (sets_.count(thisSetID) > 0);
   try {
-    sets_.insert({thisSetID, Set(rules, initialExpressions, systemType, orderingSpec, eventDeduplication, randomSeed)});
+    sets_[thisSetID] =
+        std::make_unique<Set>(rules, initialExpressions, systemType, orderingSpec, eventDeduplication, randomSeed);
   } catch (...) {
     return LIBRARY_FUNCTION_ERROR;
   }
 
-  MArgument_setInteger(result, thisSetID);
   return LIBRARY_NO_ERROR;
 }
 
@@ -250,15 +249,8 @@ int setDelete([[maybe_unused]] WolframLibraryData libData,
   if (argc != 1) {
     return LIBRARY_FUNCTION_ERROR;
   }
-  const SetID setToDelete = MArgument_getInteger(argv[0]);
 
-  const auto setToDeleteIterator = sets_.find(setToDelete);
-  if (setToDeleteIterator != sets_.end()) {
-    sets_.erase(setToDeleteIterator);
-  } else {
-    return LIBRARY_FUNCTION_ERROR;
-  }
-  return LIBRARY_NO_ERROR;
+  return libData->releaseManagedLibraryExpression("SetReplace", MArgument_getInteger(argv[0]));
 }
 
 std::function<bool()> shouldAbort(WolframLibraryData libData) {
@@ -268,7 +260,7 @@ std::function<bool()> shouldAbort(WolframLibraryData libData) {
 Set& setFromID(const SetID id) {
   const auto setIDIterator = sets_.find(id);
   if (setIDIterator != sets_.end()) {
-    return setIDIterator->second;
+    return *setIDIterator->second;
   } else {
     throw LIBRARY_FUNCTION_ERROR;
   }
@@ -373,9 +365,13 @@ int terminationReason([[maybe_unused]] WolframLibraryData, mint argc, MArgument*
 
 EXTERN_C mint WolframLibrary_getVersion() { return WolframLibraryVersion; }
 
-EXTERN_C int WolframLibrary_initialize([[maybe_unused]] WolframLibraryData libData) { return 0; }
+EXTERN_C int WolframLibrary_initialize([[maybe_unused]] WolframLibraryData libData) {
+  return (*libData->registerLibraryExpressionManager)("SetReplace", SetReplace::setManageInstance);
+}
 
-EXTERN_C void WolframLibrary_uninitialize([[maybe_unused]] WolframLibraryData libData) { return; }
+EXTERN_C void WolframLibrary_uninitialize([[maybe_unused]] WolframLibraryData libData) {
+  (*libData->unregisterLibraryExpressionManager)("SetReplace");
+}
 
 EXTERN_C int setCreate(WolframLibraryData libData, mint argc, MArgument* argv, MArgument result) {
   return SetReplace::setCreate(libData, argc, argv, result);

--- a/libSetReplace/SetReplace.cpp
+++ b/libSetReplace/SetReplace.cpp
@@ -18,8 +18,12 @@ namespace SetReplace {
 // These are global variables that keep all sets returned to Wolfram Language until they are destroyed.
 // Pointers are not returned directly for security reasons.
 using SetID = mint;
+// We use a pointer here because map key insertion (setManageInstance) is separate from map value insertion (setCreate).
+// Until the value is inserted, the set is nullptr.
 std::unordered_map<SetID, std::unique_ptr<Set>> sets_;
 
+/** @brief Either acquires or a releases a set, depending on the mode.
+ */
 void setManageInstance([[maybe_unused]] WolframLibraryData libData, mbool mode, mint id) {
   if (mode == 0) {
     sets_.emplace(id, nullptr);

--- a/libSetReplace/SetReplace.hpp
+++ b/libSetReplace/SetReplace.hpp
@@ -12,12 +12,11 @@ EXTERN_C DLLEXPORT int WolframLibrary_initialize(WolframLibraryData libData);
 EXTERN_C DLLEXPORT void WolframLibrary_uninitialize(WolframLibraryData libData);
 
 /** @brief Creates a new set object.
- * @return Pointer to the newly created set in memory.
- * @note Memory is not managed, the set needs to be destroyed manually.
  */
 EXTERN_C DLLEXPORT int setCreate(WolframLibraryData libData, mint argc, MArgument* argv, MArgument result);
 
-/** @brief Destroys a set given a pointer.
+/** @brief Destroys a set given an ID.
+ * @note This is optional, as memory is managed.
  */
 EXTERN_C DLLEXPORT int setDelete(WolframLibraryData libData, mint argc, MArgument* argv, MArgument result);
 

--- a/libSetReplace/SetReplace.hpp
+++ b/libSetReplace/SetReplace.hpp
@@ -13,12 +13,7 @@ EXTERN_C DLLEXPORT void WolframLibrary_uninitialize(WolframLibraryData libData);
 
 /** @brief Creates a new set object.
  */
-EXTERN_C DLLEXPORT int setCreate(WolframLibraryData libData, mint argc, MArgument* argv, MArgument result);
-
-/** @brief Destroys a set given an ID.
- * @note This is optional, as memory is managed.
- */
-EXTERN_C DLLEXPORT int setDelete(WolframLibraryData libData, mint argc, MArgument* argv, MArgument result);
+EXTERN_C DLLEXPORT int setInitialize(WolframLibraryData libData, mint argc, MArgument* argv, MArgument result);
 
 /** @brief Performs a specified number of replacements, but does not return anything.
  */


### PR DESCRIPTION
## Changes
* Implements [managed expressions](https://reference.wolfram.com/language/LibraryLink/tutorial/InteractionWithWolframLanguage.html#353220453)
* Closes #574 

## Examples
To verify release is actually working (and not just releasing at program exit):
```c++
void setManageInstance([[maybe_unused]] WolframLibraryData libData, mbool mode, mint id) {
  std::string time = std::to_string(std::time(nullptr));
  if (mode == 0) {
    sets_.emplace(id, nullptr);
    std::system((std::string("echo \"create ") + time + "\" >> /tmp/sr").c_str());
  } else {
    sets_.erase(id);
    std::system((std::string("echo \"delete ") + time + "\" >> /tmp/sr").c_str());
  }
}
```
```bash
$ ./test.wls eventDeduplication && cat /tmp/sr
create 1609878542
delete 1609878542
create 1609878542
delete 1609878542
create 1609878542
delete 1609878542
...
create 1609878566
delete 1609878566
create 1609878566
delete 1609878566
create 1609878566
delete 1609878566
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/588)
<!-- Reviewable:end -->
