### PR TITLE
Changing section name "# Style" to "# Code Style".

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -591,7 +591,7 @@ All four scripts use functionality defined in the [DevUtils](/DevUtils) package.
 Note that the `pack.wls` script will auto-generate the paclet version number based on the number of commits to master
 from the checkpoint defined in [version.wl](/scripts/version.wl).
 
-## Style
+## Code Style
 
 ### Wolfram Language
 


### PR DESCRIPTION
## Changes

* The "code style" links in the contributing page were not working: there was a "# Style" section but no "# Code Style".

## Comments

* The section might be intenionally be named "Style", in which case I should change "#code-style" to "#style".

## Examples
![codestyle](https://user-images.githubusercontent.com/40190339/104216241-ca45ac00-5407-11eb-9aa4-c019b9c42807.gif)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/593)
<!-- Reviewable:end -->
