### PR TITLE
Allows using HEAD in performanceTest.wls and fixes it on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ jobs:
           command: |
             if [ $CIRCLE_NODE_INDEX -eq 0 ]
             then
-              ./performanceTest.wls master @HEAD 2
+              ./performanceTest.wls master HEAD 2
             fi
 
   cpp-test:

--- a/performanceTest.wls
+++ b/performanceTest.wls
@@ -102,7 +102,7 @@ Check[
   speedupDelta[old_, new_] := (old - new) / old;
 
   $gitRepo = GitOpen[$SetReplaceRoot];
-  $currentSHA = GitSHA[$gitRepo, $gitRepo["HEAD"]];
+  $currentSHA = GitSHA[$gitRepo, "HEAD"];
   $cleanQ = AllTrue[# === {} &] @ GitStatus[$gitRepo];
 
   If[!$cleanQ,
@@ -110,11 +110,13 @@ Check[
     Exit[1];
   ];
 
-  dereferenceHead["HEAD"] := $currentSHA;
-  dereferenceHead[arg_] := arg;
+  argumentReferenceToSHA[ref_] := Replace[GitSHA[$gitRepo, ref], $Failed :> (
+    Print["Reference ", ref, " is not recognized."];
+    Exit[1];
+  )];
 
-  $oldSHA = If[Length @ $ScriptCommandLine >= 2, dereferenceHead @ $ScriptCommandLine[[2]], "master"];
-  $newSHA = If[Length @ $ScriptCommandLine >= 3, dereferenceHead @ $ScriptCommandLine[[3]], $currentSHA];
+  $oldSHA = If[Length @ $ScriptCommandLine >= 2, argumentReferenceToSHA @ $ScriptCommandLine[[2]], "master"];
+  $newSHA = If[Length @ $ScriptCommandLine >= 3, argumentReferenceToSHA @ $ScriptCommandLine[[3]], $currentSHA];
 
   $symbolicRef = RunProcess[{"git", "symbolic-ref", "--short", "HEAD"}];
   $originalRef = If[$symbolicRef["ExitCode"] === 0, StringExtract[$symbolicRef["StandardOutput"], 1], $currentSHA];

--- a/performanceTest.wls
+++ b/performanceTest.wls
@@ -110,8 +110,11 @@ Check[
     Exit[1];
   ];
 
-  $oldSHA = If[Length @ $ScriptCommandLine >= 2, $ScriptCommandLine[[2]], "master"];
-  $newSHA = If[Length @ $ScriptCommandLine >= 3, $ScriptCommandLine[[3]], $currentSHA];
+  dereferenceHead["HEAD"] := $currentSHA;
+  dereferenceHead[arg_] := arg;
+
+  $oldSHA = If[Length @ $ScriptCommandLine >= 2, dereferenceHead @ $ScriptCommandLine[[2]], "master"];
+  $newSHA = If[Length @ $ScriptCommandLine >= 3, dereferenceHead @ $ScriptCommandLine[[3]], $currentSHA];
 
   $symbolicRef = RunProcess[{"git", "symbolic-ref", "--short", "HEAD"}];
   $originalRef = If[$symbolicRef["ExitCode"] === 0, StringExtract[$symbolicRef["StandardOutput"], 1], $currentSHA];

--- a/performanceTest.wls
+++ b/performanceTest.wls
@@ -113,7 +113,7 @@ Check[
   argumentReferenceToSHA[ref_] := ModuleScope[
     revParseOutput = RunProcess[{"git", "rev-parse", ref}];
     If[revParseOutput["ExitCode"] === 0,
-      revParseOutput["StandardOutput"]
+      StringExtract[revParseOutput["StandardOutput"], 1] (* remove \n at the end *)
     ,
       Print["Reference ", ref, " is not recognized."];
       Exit[1];

--- a/performanceTest.wls
+++ b/performanceTest.wls
@@ -110,10 +110,15 @@ Check[
     Exit[1];
   ];
 
-  argumentReferenceToSHA[ref_] := Replace[GitSHA[$gitRepo, ref], $Failed :> (
-    Print["Reference ", ref, " is not recognized."];
-    Exit[1];
-  )];
+  argumentReferenceToSHA[ref_] := ModuleScope[
+    revParseOutput = RunProcess[{"git", "rev-parse", ref}];
+    If[revParseOutput["ExitCode"] === 0,
+      revParseOutput["StandardOutput"]
+    ,
+      Print["Reference ", ref, " is not recognized."];
+      Exit[1];
+    ]
+  ];
 
   $oldSHA = If[Length @ $ScriptCommandLine >= 2, argumentReferenceToSHA @ $ScriptCommandLine[[2]], "master"];
   $newSHA = If[Length @ $ScriptCommandLine >= 3, argumentReferenceToSHA @ $ScriptCommandLine[[3]], $currentSHA];


### PR DESCRIPTION
## Changes

* Closes #573.
* Allows using `HEAD` as an argument to `./performanceTest.wls`.
* Fixes CI to use `HEAD` instead of (an incorrect) `@HEAD`.

## Comments

* `./performanceTest.wls` was broken on CI because it fails with `HEAD` and silently fails with `@HEAD` by running the tests on the same branch again (so the performance report is always at zero).

## Examples

* Test `HEAD` against `master`:

```console
$ ./performanceTest.wls master HEAD 2
Testing master

Testing 286a74794bb15a89addc2c697a7d66124b10de0e

Single-input rule                       -5.5 ± 0.6 %
Medium rule                             -1.2 ± 2.7 %
Sequential rule                         -0.2 ± 0.6 %
Large rule                              -1.9 ± 1.2 %
Exponential-match-count rule            -1. ± 4. %
CA emulator                             0. ± 10. %
```

* Test a previous commit vs. its predecessor:

```console
$ ./performanceTest.wls @~2 @^ 2
Testing 4122bf6ede4d58207923360009e096eb04239409

Testing 3e71dee78255a937f3bb67b5dc25322d03cfb763

Single-input rule                       -43.2 ± 2.0 %
Medium rule                             -32.0 ± 1.5 %
Sequential rule                         -25.3 ± 1.0 %
Large rule                              -21.5 ± 3.0 %
Exponential-match-count rule            -17.4 ± 1.8 %
CA emulator                             -2. ± 9. %
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/595)
<!-- Reviewable:end -->
