### PR TITLE
Create function AcyclicGraphTake and tests for it

### DIFF
--- a/Documentation/SymbolsAndFunctions/UtilityFunctions/AcyclicGraphTake.md
+++ b/Documentation/SymbolsAndFunctions/UtilityFunctions/AcyclicGraphTake.md
@@ -1,0 +1,10 @@
+###### [Symbols and Functions](/README.md#symbols-and-functions) > Utility Functions >
+
+# AcyclicGraphTake
+
+**`AcyclicGraphTake`** gives the subgraph of a graph between two vertices.
+
+```wl
+In[]:= AcyclicGraphTake[DirectedGraph[CycleGraph[10], "Acyclic"], {1, 4}]
+Out[]= Graph[1 -> 2, 2 -> 3, 3 -> 4]
+```

--- a/Kernel/AcyclicGraphTake.m
+++ b/Kernel/AcyclicGraphTake.m
@@ -1,0 +1,44 @@
+Package["SetReplace`"]
+
+PackageImport["GeneralUtilities`"]
+
+PackageExport["AcyclicGraphTake"]
+
+(* SyntaxInformation *)
+SyntaxInformation[AcyclicGraphTake] =
+  {"ArgumentsPattern" -> {_, _}};
+
+(* Argument count *)
+AcyclicGraphTake[args___] := 0 /;
+  !Developer`CheckArgumentCount[AcyclicGraphTake[args], 2, 2] && False;
+
+(* main *)
+expr : AcyclicGraphTake[graph_, vertices_] := ModuleScope[
+  res = Catch[acyclicGraphTake[HoldForm @ expr, graph, vertices]];
+  res /; res =!= $Failed
+];
+
+(* Normal form *)
+acyclicGraphTake[_, graph_ ? (AcyclicGraphQ[#] && DirectedGraphQ[#] &), {startVertex_, endVertex_}] /;
+    VertexQ[graph, startVertex] && VertexQ[graph, endVertex] := ModuleScope[
+  Subgraph[graph, Intersection[
+    VertexInComponent[graph, endVertex], VertexOutComponent[graph, startVertex]]]
+]
+
+(* Incorrect arguments messages *)
+AcyclicGraphTake::invalidGraph = "The argument at position `1` in `2` should be a directed, acyclic graph.";
+acyclicGraphTake[expr_, graph_ ? (Not @* (AcyclicGraphQ[#] && DirectedGraphQ[#] &)), _] :=
+  (Message[AcyclicGraphTake::invalidGraph, 1, HoldForm @ expr];
+  Throw[$Failed]);
+
+AcyclicGraphTake::invalidVertexList = "The argument at position `1` in `2` should be a list of two vertices.";
+acyclicGraphTake[expr_, _, Except[{_, _}]] :=
+  (Message[AcyclicGraphTake::invalidVertexList, 2, HoldForm @ expr];
+  Throw[$Failed]);
+
+AcyclicGraphTake::invalidVertex = "The argument `1` is not a valid vertex in `2`.";
+acyclicGraphTake[expr_, graph_Graph, {startVertex_, endVertex_}] /;
+    (Not @ (VertexQ[graph, startVertex] && VertexQ[graph, endVertex])) :=
+  (Message[AcyclicGraphTake::invalidVertex, If[VertexQ[graph, startVertex], endVertex, startVertex], HoldForm @ expr];
+  Throw[$Failed]);
+  

--- a/Tests/AcyclicGraphTake.wlt
+++ b/Tests/AcyclicGraphTake.wlt
@@ -5,9 +5,16 @@
       Global`testUnevaluated[args___] := SetReplace`PackageScope`testUnevaluated[VerificationTest, args];
     ),
     "tests" -> {
-      
+
+      (* Verification tests *)
       VerificationTest[
-          AcyclicGraphTake[CycleGraph[10,]]
+        Sort[EdgeList[AcyclicGraphTake[Graph[{1 -> 2, 2 -> 3, 2 -> 4, 3 -> 4, 4 -> 5, 5 -> 6}], {2, 5}]]],
+        Sort[EdgeList[Graph[{2 -> 3, 2 -> 4, 3 -> 4, 4 -> 5}]]]
+      ]
+
+      VerificationTest[
+        Sort[EdgeList[AcyclicGraphTake[Graph[{1 -> 1, 1 -> 2, 2 -> 3, 4 -> 5}], {1, 3}]]],
+        Sort[EdgeList[Graph[{1 -> 1, 1 -> 2, 2 -> 3}]]]
       ]
 
 

--- a/Tests/AcyclicGraphTake.wlt
+++ b/Tests/AcyclicGraphTake.wlt
@@ -1,0 +1,61 @@
+<|
+  "AcyclicGraphTake" -> <|
+    "init" -> (
+      Attributes[Global`testUnevaluated] = {HoldAll};
+      Global`testUnevaluated[args___] := SetReplace`PackageScope`testUnevaluated[VerificationTest, args];
+    ),
+    "tests" -> {
+      
+      VerificationTest[
+          AcyclicGraphTake[CycleGraph[10,]]
+      ]
+
+
+      (* unevaluated *)
+
+      (* argument count *)
+      testUnevaluated[
+        AcyclicGraphTake[],
+        {AcyclicGraphTake::argr}
+      ],
+
+      testUnevaluated[
+        AcyclicGraphTake[x],
+        {AcyclicGraphTake::argr}
+      ],
+
+      (* first argument: graph *)
+      testUnevaluated[
+        AcyclicGraphTake[x, ],
+        {AcyclicGraphTake::invalidGraph}
+      ],
+
+      testUnevaluated[
+        AcyclicGraphTake[DirectedGraph[RandomGraph[{5, 5}]], x],
+        {AcyclicGraphTake::invalidGraph}
+      ],
+
+      (* second argument: vertex list *)
+      testUnevaluated[
+        AcyclicGraphTake[DirectedGraph[RandomGraph[{5, 5}], "Acyclic"], x],
+        {AcyclicGraphTake::invalidVertexList}
+      ],
+
+      testUnevaluated[
+        AcyclicGraphTake[DirectedGraph[RandomGraph[{5, 5}], "Acyclic"], {x, y, z}],
+        {AcyclicGraphTake::invalidVertexList}
+      ],
+
+      testUnevaluated[
+        AcyclicGraphTake[DirectedGraph[RandomGraph[{5, 5}], "Acyclic"], {6, 1}],
+        {AcyclicGraphTake::invalidVertex}
+      ],
+
+       testUnevaluated[
+        AcyclicGraphTake[DirectedGraph[RandomGraph[{5, 5}], "Acyclic"], {1, 6}],
+        {AcyclicGraphTake::invalidVertex}
+      ]
+    }
+  |>
+|>
+      


### PR DESCRIPTION
## Changes
Introduced function AcyclicGraphTake, which accepts a directed, acyclic graph as well as a list of two vertices in that graph, returning the intersection of the out-component of the first vertex in the list with the in-component of the second vertex in the list.

## Comments

* Still need to write the documentation and verification tests.
* Have created tests for when the function is unevaluated, but need help in writing the verification tests because the function should return a `Graph`.
* The `testUnevaluated` tests in which I am generating a random graph return a failure when actually the error message is the one to be expected. I think this has to do with the fact that the resulting full expression of the error message is returned literally and not as a `Graph` itself and so `SameQ` doesn't work.

<img width="960" alt="2021-01-20" src="https://user-images.githubusercontent.com/70669841/105274943-a820fc00-5b74-11eb-99c5-d1e8ad1211b8.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/600)
<!-- Reviewable:end -->
