### PR TITLE
Remove unreliable references

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -19,13 +19,7 @@ implicitly sends a message that *bugs* (aka insects) are someone bad and should 
 sentiment, as *bugs* :ant: :beetle: :spider: are living creatures who deserve moral consideration. Hence, let's leave "
 bugs" alone, and go *weed whacking*.
 
-The issues in this repository are only related to *SetReplace*, not the entire Wolfram Physics Project. If you have
-found an issue with a Wolfram Physics [bulletin](https://www.wolframphysics.org/bulletins/), or with anything else on
-the Wolfram Physics [website](https://www.wolframphysics.org), please report it using the tools available there. The
-bulletins that also appear as [research notes](/Research) in this repository are the only exceptions. The issues with
-these should be reported here.
-
-Similarly, the weeds in function repository functions should be reported on the function repository website rather than
+Note that the weeds in function repository functions should be reported on the function repository website rather than
 here.
 
 To report a weed, follow these steps:

--- a/README.md
+++ b/README.md
@@ -224,15 +224,9 @@ the one this package implements.
 A slightly different version of this system was first introduced in *Stephen Wolfram*'
 s [A New Kind Of Science](https://www.wolframscience.com/nks/chap-9--fundamental-physics/).
 
-You can find many more details about our physics results in *Stephen Wolfram*'
-s [Technical Introduction](https://www.wolframphysics.org/technical-introduction/), and *Jonathan Gorard*'s papers
-on [Relativity](https://www.wolframcloud.com/obj/wolframphysics/Documents/some-relativistic-and-gravitational-properties-of-the-wolfram-model.pdf)
-and [Quantum Mechanics](https://www.wolframcloud.com/obj/wolframphysics/Documents/some-quantum-mechanical-properties-of-the-wolfram-model.pdf)
-. And there is much more on [wolframphysics.org](https://www.wolframphysics.org).
-
 # Acknowledgements
 
-In additional to commit authors and reviewers, *Stephen Wolfram* has contributed to the API design of most functions,
+In additional to commit authors and reviewers, *Stephen Wolfram* has contributed to the API design of some functions,
 and *Jeremy Davis* has contributed to the visual style
 of [`HypergraphPlot`](Documentation/SymbolsAndFunctions/HypergraphPlot.md)
 , [`RulePlot`](Documentation/SymbolsAndFunctions/RulePlotOfWolframModel.md)

--- a/Research/LocalMultiwaySystem/LocalMultiwaySystem.md
+++ b/Research/LocalMultiwaySystem/LocalMultiwaySystem.md
@@ -25,8 +25,7 @@ is, in itself, interesting to investigate.
 Another approach is to consider the so-called multiway systems, which evaluate all possible ways to resolve such
 overlaps between matches. This is the approach that is discussed in this note.
 
-The original type of the multiway system that was first considered in the
-[Wolfram Physics Project](https://www.wolframphysics.org) is what we will call the
+One type of the multiway system is what we will call the
 [*global* multiway system](https://resources.wolframcloud.com/FunctionRepository/resources/MultiwaySystem), which will
 be discussed in more detail in the next section. Here we propose a new kind of multiway system, called a *local*
 multiway system. The prime difference is that it allows one to consider the branching of only parts of space (subgraphs


### PR DESCRIPTION
## Changes

* Removes references to unreliable sources such as [wolframphysics.org](https://www.wolframphysics.org) which has known errors that have not been fixed for a substantial amount of time.
* Also removes the note about reporting Wolfram Physics issues elsewhere as without the link to [wolframphysics.org](https://www.wolframphysics.org) on the main repo page, it is no longer necessary.

## Comments

* `WolframPhysicsProjectStyleData` will be renamed to `SetReplaceStyleData` in a separate PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/607)
<!-- Reviewable:end -->
