### PR TITLE
Fix CMake download on CI to version 3.18.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,14 +152,10 @@ jobs:
       - run:
           name: Install CMake
           command: |
-            cmakeURL=$(\
-              curl -s https://api.github.com/repos/Kitware/CMake/releases/latest \
-              | grep 'browser_download_url' \
-              | cut -d\" -f4 \
-              | grep macos-universal.tar.gz)
-            curl -L --output cmake-macos-universal.tar.gz $cmakeURL
-            tar xf cmake-macos-universal.tar.gz
-            cmakeDir=$(ls | grep cmake-*-macos-universal)
+            cmakeURL="https://github.com/Kitware/CMake/releases/download/v3.18.6/cmake-3.18.6-Darwin-x86_64.tar.gz"
+            curl -L --output cmake.tar.gz $cmakeURL
+            tar xf cmake.tar.gz
+            cmakeDir=$(ls | grep cmake-*)
             mkdir -p /usr/local/bin /usr/local/share
             cp -r $cmakeDir/CMake.app/Contents/bin/* /usr/local/bin/
             cp -r $cmakeDir/CMake.app/Contents/share/* /usr/local/share/
@@ -187,14 +183,10 @@ jobs:
       - run:
           name: Install CMake
           command: |
-            cmakeURL=$(\
-              curl -s https://api.github.com/repos/Kitware/CMake/releases/latest \
-              | grep 'browser_download_url' \
-              | cut -d\" -f4 \
-              | grep win64-x64.zip)
-            curl -L --output cmake-win64-x64.zip $cmakeURL
-            unzip -q cmake-win64-x64.zip
-            cmakeDir=$(dir -1 | findstr -i cmake-*-win64-x64)
+            cmakeURL="https://github.com/Kitware/CMake/releases/download/v3.18.6/cmake-3.18.6-win64-x64.zip"
+            curl -L --output cmake.zip $cmakeURL
+            unzip -q cmake.zip
+            cmakeDir=$(dir -1 | findstr -i cmake-*)
             echo "export PATH=\"$(pwd)/$cmakeDir/bin:$PATH\"" >> $BASH_ENV
 
       - run:


### PR DESCRIPTION
## Changes

* macOS and Windows CI was failing again to download CMake due to the change of name from `*macos-universal*` to `*Darwin*`.
* Since this is likely to happen again (they need to support ARM Macs), I'm fixing the version to 3.18.6 to prevent the CI from failing now and in the future.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/614)
<!-- Reviewable:end -->
