### PR TITLE
Fix broken links in Feature* functions

### DIFF
--- a/Documentation/SymbolsAndFunctions/WolframModelAndWolframModelEvolutionObject/Properties/FeatureAssociation.md
+++ b/Documentation/SymbolsAndFunctions/WolframModelAndWolframModelEvolutionObject/Properties/FeatureAssociation.md
@@ -2,16 +2,19 @@
 
 # Feature Association
 
-**`"FeatureAssociation"`** computes some features of the [`WolframModel`](/Documentation/SymbolsAndFunctions/
-WolframModelAndWolframModelEvolutionObject/WolframModelAndWolframModelEvolutionObject.md) evolution and returns an
-[`Association`](https://reference.wolfram.com/language/ref/Association.html) whose keys describe each feature computed.
+**`"FeatureAssociation"`** computes some features of
+the [`WolframModel`](/Documentation/SymbolsAndFunctions/WolframModelAndWolframModelEvolutionObject/WolframModelAndWolframModelEvolutionObject.md)
+evolution and returns
+an [`Association`](https://reference.wolfram.com/language/ref/Association.html) whose keys describe each feature
+computed.
 For now, it computes properties associated with these feature groups:
 
 - [`"CausalGraph"`](/Documentation/SymbolsAndFunctions/WolframModelAndWolframModelEvolutionObject/Properties/CausalGraphs.md)
 - `"StructurePreservingFinalStateGraph"`: The [`Graph`](https://reference.wolfram.com/language/ref/Graph.html)
-version of the [`"FinalState"`](/Documentation/SymbolsAndFunctions/WolframModelAndWolframModelEvolutionObject/
-Properties/States.md) as given by [`HypergraphToGraph`](/Documentation/SymbolsAndFunctions/UtilityFunctions/
-HypergraphToGraph.md) using the `"StructurePreserving"` transformation
+version of
+the [`"FinalState"`](/Documentation/SymbolsAndFunctions/WolframModelAndWolframModelEvolutionObject/Properties/States.md)
+as given by [`HypergraphToGraph`](/Documentation/SymbolsAndFunctions/UtilityFunctions/HypergraphToGraph.md) using the
+`"StructurePreserving"` transformation
 
 ```wl
 In[] := WolframModel[{{x, y}, {x, z}} -> {{x, z}, {x, w}, {y, w}, {z, w}}, {{0, 0}, {0, 0}}, 5]["FeatureAssociation"]
@@ -47,12 +50,13 @@ In[] := BlockRandom[
 
 <img src="/Documentation/Images/FeatureAssociationFeatureSpacePlot.png" width="684.6">
 
-For [Multiway Systems](/Documentation/SymbolsAndFunctions/WolframModelAndWolframModelEvolutionObject/Properties/
-MultiwayQ.md) it only computes features associated with the [causal graph](/Documentation/SymbolsAndFunctions/
-WolframModelAndWolframModelEvolutionObject/Properties/CausalGraphs.md), returning
-`Missing["NotExistent", {"MultiwaySystem", "FinalState"}]` for features related to
-`"StructurePreservingFinalStateGraph"`, as there is no [`"FinalState"`](/Documentation/SymbolsAndFunctions/
-WolframModelAndWolframModelEvolutionObject/Properties/States.md) in a Multiway System:
+For [Multiway Systems](/Documentation/SymbolsAndFunctions/WolframModelAndWolframModelEvolutionObject/Properties/MultiwayQ.md)
+it only computes features associated with
+the [causal graph](/Documentation/SymbolsAndFunctions/WolframModelAndWolframModelEvolutionObject/Properties/CausalGraphs.md),
+returning `Missing["NotExistent", {"MultiwaySystem", "FinalState"}]` for features related to
+`"StructurePreservingFinalStateGraph"`, as there is
+no [`"FinalState"`](/Documentation/SymbolsAndFunctions/WolframModelAndWolframModelEvolutionObject/Properties/States.md)
+in a Multiway System:
 
 ```wl
 In[] := WolframModel[

--- a/Documentation/SymbolsAndFunctions/WolframModelAndWolframModelEvolutionObject/Properties/FeatureVector.md
+++ b/Documentation/SymbolsAndFunctions/WolframModelAndWolframModelEvolutionObject/Properties/FeatureVector.md
@@ -2,17 +2,18 @@
 
 # Feature Vector
 
-**`"FeatureVector"`** returns the values of the features of the [`WolframModel`](/Documentation/SymbolsAndFunctions/
-WolframModelAndWolframModelEvolutionObject/WolframModelAndWolframModelEvolutionObject.md) evolution as computed by
-[`"FeatureAssociation"`](/Documentation/SymbolsAndFunctions/WolframModelAndWolframModelEvolutionObject/Properties/
-FeatureAssociation.md).
+**`"FeatureVector"`** returns the values of the features of
+the [`WolframModel`](/Documentation/SymbolsAndFunctions/WolframModelAndWolframModelEvolutionObject/WolframModelAndWolframModelEvolutionObject.md)
+evolution as computed
+by [`"FeatureAssociation"`](/Documentation/SymbolsAndFunctions/WolframModelAndWolframModelEvolutionObject/Properties/FeatureAssociation.md).
 
 ```wl
 In[] := WolframModel[{{x, y}, {x, z}} -> {{x, z}, {x, w}, {y, w}, {z, w}}, {{0, 0}, {0, 0}}, 5]["FeatureVector"]
 Out[] = {22, 42, 1, 2, 2, 2, 6, 6, 115, 138, 2, 2, 2, 2, 2, 8}
 ```
 
-For the list of features see [`FeatureAssociation`](/Documentation/SymbolsAndFunctions/WolframModelAndWolframModelEvolutionObject/Properties/FeatureAssociation.md).
+For the list of features
+see [`FeatureAssociation`](/Documentation/SymbolsAndFunctions/WolframModelAndWolframModelEvolutionObject/Properties/FeatureAssociation.md).
 
 This property is useful for applying machine learning to Wolfram Models explorations.
 


### PR DESCRIPTION
## Changes

* Fixes broken links in `Feature*` functions.
* The links were split into multiple lines which caused them to not render on GitHub.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/615)
<!-- Reviewable:end -->
