### PR TITLE
Obtain googletest from master

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,7 +116,7 @@ if(SET_REPLACE_BUILD_TESTING)
   FetchContent_Declare(
     googletest
     GIT_REPOSITORY https://github.com/google/googletest.git
-    GIT_TAG v1.10.x
+    GIT_TAG master
   )
 
   set(CMAKE_POLICY_DEFAULT_CMP0048 NEW) # google test raises warning about it


### PR DESCRIPTION
## Changes

* v1.10.x of googletest has not been updated for a while, and is now triggering a CMake deprecation warning.
* This gets googletest from master to avoid that.

## Examples

* Before:
```console
$ cmake .. -DSET_REPLACE_BUILD_TESTING=ON 
-- SetReplace version: 0.3.0
-- SetReplace using CMAKE_CXX_STANDARD: 17
-- CMAKE_BUILD_TYPE: Debug
-- SET_REPLACE_BUILD_TESTING: ON
-- SET_REPLACE_COMPILE_OPTIONS: 
CMake Deprecation Warning at build/_deps/googletest-src/CMakeLists.txt:4 (cmake_minimum_required):
  Compatibility with CMake < 2.8.12 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.


-- The C compiler identification is AppleClang 12.0.0.12000032
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
CMake Deprecation Warning at build/_deps/googletest-src/googlemock/CMakeLists.txt:45 (cmake_minimum_required):
  Compatibility with CMake < 2.8.12 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.


CMake Deprecation Warning at build/_deps/googletest-src/googletest/CMakeLists.txt:56 (cmake_minimum_required):
  Compatibility with CMake < 2.8.12 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.


-- Found PythonInterp: /Users/maxitg/.pyenv/shims/python (found version "3.9.1") 
-- Looking for pthread.h
-- Looking for pthread.h - found
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE  
-- SET_REPLACE_LIBRARIES: SetReplace
-- Configuring done
-- Generating done
-- Build files have been written to: /Users/maxitg/git/SetReplace/build
```

* After:
```console
$ cmake .. -DSET_REPLACE_BUILD_TESTING=ON                                      
-- The CXX compiler identification is AppleClang 12.0.0.12000032
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- SetReplace version: 0.3.0
-- Setting build type to 'Release' as none was specified.
-- SetReplace using CMAKE_CXX_STANDARD: 17
-- CMAKE_BUILD_TYPE: Release
-- SET_REPLACE_BUILD_TESTING: ON
-- SET_REPLACE_COMPILE_OPTIONS: 
-- The C compiler identification is AppleClang 12.0.0.12000032
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Found Python: /usr/local/Frameworks/Python.framework/Versions/3.9/bin/python3.9 (found version "3.9.2") found components: Interpreter 
-- Looking for pthread.h
-- Looking for pthread.h - found
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE  
-- SET_REPLACE_LIBRARIES: SetReplace
-- Configuring done
-- Generating done
-- Build files have been written to: /Users/maxitg/git/SetReplace/build
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/616)
<!-- Reviewable:end -->
