### PR TITLE
Fix labels for list-types in $SetReplaceTypeGraph

### DIFF
--- a/Kernel/A1$typeSystem.m
+++ b/Kernel/A1$typeSystem.m
@@ -204,7 +204,7 @@ SyntaxInformation[SetReplaceMethodImplementation] = {"SetReplaceMethodImplementa
 
 typeGraphVertexLabel[kind_, name_] :=
   If[!freeFromInternalSymbolsQ[name] || kind === SetReplaceMethodImplementation, Placed[#, Tooltip] &, Identity] @
-    If[kind === SetReplaceProperty, ToString[#] <> "[\[Ellipsis]]" &, Identity] @
+    If[kind === SetReplaceProperty, ToString[#] <> "[\[Ellipsis]]" &, ToString] @
       name;
 
 insertImplementationVertex[inputEdge : DirectedEdge[from_, to_]] := ModuleScope[


### PR DESCRIPTION
## Changes

* Labels for types that are lists (e.g., `{MultisetSubstitutionSystem, 0}`) don't currently show correctly due to `Graph` interpreting `MultisetSubstitutionSystem` and `0` as separate labels and plotting them on top of each other.
* This PR fixes that by converting labels to strings.

## Examples

* Declare a type:

```wl
SetReplace`PackageScope`declareTypeTranslation[Identity, {String, 0}, {Integer, 0}];
Unprotect[$SetReplaceTypes];
Unprotect[$SetReplaceProperties];
Unprotect[$SetReplaceTypeGraph];
SetReplace`PackageScope`initializeTypeSystem[];
```

* Show a type graph which is now rendered correctly:

```wl
In[] := $SetReplaceTypeGraph
```

<img width="478" alt="image" src="https://user-images.githubusercontent.com/1479325/111526067-47551080-872c-11eb-86db-235d9d17f16d.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/625)
<!-- Reviewable:end -->
