### PR TITLE
Update minimum Wolfram Language version to 12.2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 jobs:
   wolfram-language-paclet-test:
     docker:
-      - image: maxitg/set-replace-wl-ci:12.1.1
+      - image: maxitg/set-replace-wl-ci:12.2.0
         auth:
           username: maxitg
           password: $DOCKERHUB_PASSWORD

--- a/PacletInfo.m
+++ b/PacletInfo.m
@@ -3,7 +3,7 @@
 Paclet[
   Name -> "SetReplace",
   Version -> "0.3",
-  MathematicaVersion -> "12.1+",
+  MathematicaVersion -> "12.2+",
   Description -> "SetReplace implements WolframModel and other functions used in the Wolfram Physics Project.",
   Creator -> "Wolfram Research",
   URL -> "https://github.com/maxitg/SetReplace",

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Exploring the hypergraph models of this variety is the primary purpose of this p
 You only need three things to use *SetReplace*:
 
 * Windows, macOS 10.12+, or Linux.
-* [Wolfram Language 12.1+](https://www.wolfram.com/language/)
+* [Wolfram Language 12.2+](https://www.wolfram.com/language/)
   including [WolframScript](https://www.wolfram.com/wolframscript/). A free version is available
   as [Wolfram Engine](https://www.wolfram.com/engine/).
 * A C++17 compiler to build the low-level part of the package. Instructions on how to set up a compiler to use in


### PR DESCRIPTION
## Changes

* Wolfram Language 12.2 was released a while ago, and it has some useful features (e.g., for arguments checking), so I think it's a good time to start using it.

## Comments

* If there are any objections, let me know.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/627)
<!-- Reviewable:end -->
