### PR TITLE
Allow trailing comments in test files

### DIFF
--- a/test.wls
+++ b/test.wls
@@ -78,7 +78,7 @@ If[!FileExistsQ[#],
 printFileLineError[FileLine[file_, line_] -> error_] := Print[file <> ":" <> IntegerString[line] <> "\t" <> error];
 
 importAsHeldExpression[file_] := Module[{exprs},
-  exprs = Quiet @ ToExpression[Import[file, "Text"], StandardForm, Hold];
+  exprs = Quiet @ (DeleteCases[#, Null] &) @ ToExpression[Import[file, "Text"], InputForm, Hold];
   If[!$allowParallelization, exprs = exprs /. HoldPattern[ParallelMap] -> Map];
   If[FailureQ[exprs],
     WriteString["stdout", $redColor <> "There were syntax errors in \"" <> file <> "\"" <> $endColor, ":"];

--- a/test.wls
+++ b/test.wls
@@ -78,7 +78,7 @@ If[!FileExistsQ[#],
 printFileLineError[FileLine[file_, line_] -> error_] := Print[file <> ":" <> IntegerString[line] <> "\t" <> error];
 
 importAsHeldExpression[file_] := Module[{exprs},
-  exprs = Quiet @ (Take[#, 1] &) @ ToExpression[Import[file, "Text"], InputForm, Hold];
+  exprs = Quiet @ ToExpression[Import[file, "Text"], StandardForm, Hold];
   If[!$allowParallelization, exprs = exprs /. HoldPattern[ParallelMap] -> Map];
   If[FailureQ[exprs],
     WriteString["stdout", $redColor <> "There were syntax errors in \"" <> file <> "\"" <> $endColor, ":"];

--- a/test.wls
+++ b/test.wls
@@ -78,7 +78,7 @@ If[!FileExistsQ[#],
 printFileLineError[FileLine[file_, line_] -> error_] := Print[file <> ":" <> IntegerString[line] <> "\t" <> error];
 
 importAsHeldExpression[file_] := Module[{exprs},
-  exprs = Quiet @ ToExpression[Import[file, "Text"], InputForm, Hold];
+  exprs = Quiet @ (Take[#, 1] &) @ ToExpression[Import[file, "Text"], InputForm, Hold];
   If[!$allowParallelization, exprs = exprs /. HoldPattern[ParallelMap] -> Map];
   If[FailureQ[exprs],
     WriteString["stdout", $redColor <> "There were syntax errors in \"" <> file <> "\"" <> $endColor, ":"];


### PR DESCRIPTION
## Changes

* `test.wls` fails the test file parsing if there are trailing/leading comments.
* The reason is that `ToExpression[_, InputForm, Hold]` would pass multiple arguments to `Hold` in case multiple expressions were read from the file. And comments were treated as `Null` expressions.
* I'm now manually deleting `Null` expressions, which should solve it unless there actually are multiple non-`Null` expressions.

## Comments

* Any edge cases I might be missing?

## Examples

* Add some comments on new lines to the end of a test file, e.g., `SetReplace.wlt`:

```wl

(* sdfsdfsdf *)


(* sdfsdfsdf *)

```

* Now, run the tests (ignore the macOS front-end error):

```console
$ ./test.wls SetReplace
Loading SetReplace from /Users/maxitg/git/SetReplace/Kernel/init.m
SetReplace                              [ok]
2021-03-25 13:26:50.514 MathematicaServer[34509:8439387] Warning: Expected min height of view: (<NSButton: 0x7f9ea56aba20>) to be less than or equal to 30 but got a height of 32.000000. This error will be logged once per view in violation.
Report file: /private/var/folders/f_/klrm3n7d4_989wy4dxx9_l9c0000gn/T/m000001344961/testReport.nb
Tests passed.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/629)
<!-- Reviewable:end -->
