### PR TITLE
Fix Multiset to WolframModelEvolutionObject for "Complete" termination reason

### DIFF
--- a/Kernel/MultisetToWolframModelEvolutionObject.m
+++ b/Kernel/MultisetToWolframModelEvolutionObject.m
@@ -10,7 +10,7 @@ toWolframModelEvolutionObject[Multihistory[_, data_]] := WolframModelEvolutionOb
   "Rules" -> Normal @ checkNotMissing[data["Rules"]],
   "MaxCompleteGeneration" -> Missing[],
   "TerminationReason" -> Switch[data["TerminationReason"],
-    "Completed", "FixedPoint",
+    "Complete", "FixedPoint",
     "MaxEvents", "MaxEvents",
     _, throw[Failure["corruptMultisetMultihistory", <||>]]],
   "AtomLists" -> Normal @ checkNotMissing[data["Expressions"]],

--- a/Tests/MultisetToWolframModelEvolutionObject.wlt
+++ b/Tests/MultisetToWolframModelEvolutionObject.wlt
@@ -1,0 +1,32 @@
+<|
+  "Multiset -> WolframModelEvolutionObject" -> <|
+    "init" -> (
+      Attributes[Global`testUnevaluated] = Attributes[Global`testSymbolLeak] = {HoldAll};
+      Global`testUnevaluated[args___] := SetReplace`PackageScope`testUnevaluated[VerificationTest, args];
+      Global`testSymbolLeak[args___] := SetReplace`PackageScope`testSymbolLeak[VerificationTest, args];
+    ),
+    "tests" -> {
+      VerificationTest[
+        (VertexCount @ #["ExpressionsEventsGraph"] &) @
+          SetReplaceTypeConvert[{WolframModelEvolutionObject, 2}] @
+            GenerateMultihistory[MultisetSubstitutionSystem[{a_, b_} :> {a + b}],
+                                 {"MaxGeneration" -> 1, "MaxEventInputs" -> 2},
+                                 None,
+                                 EventOrderingFunctions[MultisetSubstitutionSystem],
+                                 {}] @
+              {1, 2, 3},
+        15],
+
+      VerificationTest[
+        (#["EventsCount"] &) @
+          SetReplaceTypeConvert[{WolframModelEvolutionObject, 2}] @
+            GenerateMultihistory[MultisetSubstitutionSystem[{a_, b_} :> {a + b}],
+                                 {"MaxEventInputs" -> 2},
+                                 None,
+                                 EventOrderingFunctions[MultisetSubstitutionSystem],
+                                 {"MaxEvents" -> 10}] @
+              {1, 2, 3},
+        10]
+    }
+  |>
+|>


### PR DESCRIPTION
## Changes

* Due to a typo in `"Complete"` termination reason, conversion to `WolframModelEvolutionObject` was failing.
* This is now fixed.

## Examples

* The case that did not previously work:

```wl
In[] := SetReplaceTypeConvert[{WolframModelEvolutionObject, 2}] @
   GenerateMultihistory[
         MultisetSubstitutionSystem[{a_, b_} :> {a + b}],
         {"MaxGeneration" -> 1, "MaxEventInputs" -> 2},
         None,
         EventOrderingFunctions[MultisetSubstitutionSystem],
         {}] @
      {1, 2, 3}
```

<img width="588.6" alt="image" src="https://user-images.githubusercontent.com/1479325/113224834-e3fdcf00-9251-11eb-8867-b93306c646b8.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/633)
<!-- Reviewable:end -->
