### PR TITLE
New names for MultisetSubstitutionSystem ordering functions

### DIFF
--- a/Kernel/A1$GenerateMultihistory.m
+++ b/Kernel/A1$GenerateMultihistory.m
@@ -52,7 +52,7 @@ $constraintsSpecPattern =
      MultisetSubstitutionSystem,
      <|"MaxGeneration" -> {Infinity, "NonNegativeIntegerOrInfinity"},
        "MinEventInputs" -> {0, "NonNegativeIntegerOrInfinity"}|>,
-     {"InputCount", "SortedInputExpressions", "UnsortedInputExpressions", "RuleIndex"},
+     {"InputCount", "SortedInputTokenIndices", "InputTokenIndices", "RuleIndex"},
      <|"MaxEvents" -> {Infinity, "NonNegativeIntegerOrInfinity"}|>] *)
 
 declareMultihistoryGenerator[implementationFunction_,

--- a/Kernel/MultisetSubstitutionSystem.m
+++ b/Kernel/MultisetSubstitutionSystem.m
@@ -20,7 +20,7 @@ declareMultihistoryGenerator[
     "MaxDestroyerEvents" -> {Infinity, "NonNegativeIntegerOrInfinity"},
     "MinEventInputs" -> {0, "NonNegativeIntegerOrInfinity"},
     "MaxEventInputs" -> {Infinity, "NonNegativeIntegerOrInfinity"}|>,
-  {"InputCount", "SortedInputExpressions", "UnsortedInputExpressions", "RuleIndex"},
+  {"InputCount", "SortedInputTokenIndices", "InputTokenIndices", "RuleIndex"},
   <|"MaxEvents" -> {Infinity, "NonNegativeIntegerOrInfinity"}|>];
 
 generateMultisetSubstitutionSystem[MultisetSubstitutionSystem[rawRules___],
@@ -245,7 +245,7 @@ declareMessage[General::tokenDeduplicationNotImplemented,
                "Token deduplication is not implemented for Multiset Substitution System."];
 parseTokenDeduplication[_] := throw[Failure["tokenDeduplicationNotImplemented", <||>]];
 
-$supportedEventOrdering = {"InputCount", "SortedInputExpressions", "UnsortedInputExpressions", "RuleIndex"};
+$supportedEventOrdering = {"InputCount", "SortedInputTokenIndices", "InputTokenIndices", "RuleIndex"};
 parseEventOrdering[ordering : $supportedEventOrdering] := ordering;
 declareMessage[General::eventOrderingNotImplemented,
                "Only " <> $supportedEventOrdering <> " event ordering is implemented at this time."];

--- a/Tests/MultisetSubstitutionSystem.wlt
+++ b/Tests/MultisetSubstitutionSystem.wlt
@@ -6,7 +6,7 @@
       Global`testSymbolLeak[args___] := SetReplace`PackageScope`testSymbolLeak[VerificationTest, args];
     ),
     "tests" -> {
-      With[{anEventOrdering = {"InputCount", "SortedInputExpressions", "UnsortedInputExpressions", "RuleIndex"}}, {
+      With[{anEventOrdering = {"InputCount", "SortedInputTokenIndices", "InputTokenIndices", "RuleIndex"}}, {
         (* Symbol Leak *)
         testSymbolLeak[
           GenerateMultihistory[
@@ -62,7 +62,7 @@
       lastEventGeneration[Multihistory[_, data_]] := data["EventGenerations"]["Part", -1];
     ),
     "tests" -> {
-      With[{anEventOrdering = {"InputCount", "SortedInputExpressions", "UnsortedInputExpressions", "RuleIndex"}}, {
+      With[{anEventOrdering = {"InputCount", "SortedInputTokenIndices", "InputTokenIndices", "RuleIndex"}}, {
         Function[{rules, selection, stopping, init, expectedCreatedExpressions},
             VerificationTest[
               allExpressions @ GenerateMultihistory[
@@ -219,7 +219,7 @@
       allExpressions[Multihistory[_, data_]] := Normal @ data["Expressions"];
     ),
     "tests" -> {
-      With[{anEventOrdering = {"InputCount", "SortedInputExpressions", "UnsortedInputExpressions", "RuleIndex"}}, {
+      With[{anEventOrdering = {"InputCount", "SortedInputTokenIndices", "InputTokenIndices", "RuleIndex"}}, {
         Function[{rule, selection, init, expectedCreatedExpressions},
           VerificationTest[
             allExpressions @ GenerateMultihistory[
@@ -309,7 +309,7 @@
             GenerateMultihistory[MultisetSubstitutionSystem[rule],
                                  <||>,
                                  None,
-                                 {"InputCount", "SortedInputExpressions", "UnsortedInputExpressions", "RuleIndex"},
+                                 {"InputCount", "SortedInputTokenIndices", "InputTokenIndices", "RuleIndex"},
                                  <|"MaxEvents" -> 1|>] @ init,
           lastEventInputsOutput]
       ] @@@ {
@@ -325,7 +325,7 @@
             GenerateMultihistory[MultisetSubstitutionSystem[rule],
                                  <||>,
                                  None,
-                                 {"InputCount", "SortedInputExpressions", "UnsortedInputExpressions", "RuleIndex"},
+                                 {"InputCount", "SortedInputTokenIndices", "InputTokenIndices", "RuleIndex"},
                                  <|"MaxEvents" -> 1|>] /@ inits,
           lastExpressions]
       ] @@@ {
@@ -354,7 +354,7 @@
       destroyerEventCounts[Multihistory[_, data_]] := Normal @ data["ExpressionDestroyerEventCounts"];
     ),
     "tests" -> {
-      With[{anEventOrdering = {"InputCount", "SortedInputExpressions", "UnsortedInputExpressions", "RuleIndex"}}, {
+      With[{anEventOrdering = {"InputCount", "SortedInputTokenIndices", "InputTokenIndices", "RuleIndex"}}, {
         Function[{
             rule, selection, stopping, init, expectedMaxEventGeneration, expectedEventCount, expectedTerminationReason},
           VerificationTest[

--- a/Tests/hypergraphMatching.wlt
+++ b/Tests/hypergraphMatching.wlt
@@ -26,7 +26,7 @@
             GenerateMultihistory[MultisetSubstitutionSystem[ToPatternRules[#HypergraphRule]],
                                  <||>,
                                  None,
-                                 {"InputCount", "SortedInputExpressions", "UnsortedInputExpressions", "RuleIndex"},
+                                 {"InputCount", "SortedInputTokenIndices", "InputTokenIndices", "RuleIndex"},
                                  <||>] @ #Init &;
 
       graphFromHyperedges[edges_] := Graph[UndirectedEdge @@@ Flatten[Partition[#, 2, 1] & /@ edges, 1]];
@@ -127,7 +127,7 @@
               GenerateMultihistory[MultisetSubstitutionSystem[ToPatternRules[{{1, 2}, {2, 3}} -> {{1, 3}}]],
                                    <||>,
                                    None,
-                                   {"InputCount", "SortedInputExpressions", "UnsortedInputExpressions", "RuleIndex"},
+                                   {"InputCount", "SortedInputTokenIndices", "InputTokenIndices", "RuleIndex"},
                                    <|"MaxEvents" -> 1|>][{{1, 2}, {2, 1}}],
         {{1, 2}, {2, 1}, {1, 1}}
       ],


### PR DESCRIPTION
## Changes

* `"SortedInputExpressions"` and `"UnsortedInputExpressions"` weren't good names for ordering functions because, using the word "expression" instead of "token", they are specific to the multiset system, and it's better if they are not since they can then have shared documentation.
* This PR renames them to `"SortedInputTokenIndices"` and `"InputTokenIndices"`.

## Comments

* `"SortedInputTokenIndices"` might be harder to understand at first than `"OldestToken"`, but I think it's better because it explains exactly what it is whereas `"OldestToken"` might be interpreted in different ways. `"OldestToken"` is actually closer to `"MinInputTokenIndex"`, which we don't have yet, but we might in the future.
* Not sure if `"Unsorted"` is necessary in `"InputTokenIndices"`, so I removed it.

## Examples

* New names:

```wl
In[] := EventOrderingFunctions[MultisetSubstitutionSystem]
Out[] = {"InputCount", "SortedInputTokenIndices", "InputTokenIndices", "RuleIndex"}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/635)
<!-- Reviewable:end -->
