### PR TITLE
MultisetSubstitutionSystem: allow patterns like {a__, b__} to be matched multiple times

### DIFF
--- a/Kernel/A1$GenerateMultihistory.m
+++ b/Kernel/A1$GenerateMultihistory.m
@@ -52,7 +52,7 @@ $constraintsSpecPattern =
      MultisetSubstitutionSystem,
      <|"MaxGeneration" -> {Infinity, "NonNegativeIntegerOrInfinity"},
        "MinEventInputs" -> {0, "NonNegativeIntegerOrInfinity"}|>,
-     {"InputCount", "SortedInputTokenIndices", "InputTokenIndices", "RuleIndex"},
+     {"InputCount", "SortedInputTokenIndices", "InputTokenIndices", "RuleIndex", "InstantiationIndex"},
      <|"MaxEvents" -> {Infinity, "NonNegativeIntegerOrInfinity"}|>] *)
 
 declareMultihistoryGenerator[implementationFunction_,

--- a/Kernel/MultisetSubstitutionSystem.m
+++ b/Kernel/MultisetSubstitutionSystem.m
@@ -111,16 +111,16 @@ evaluateSingleEvent[
     destroyerChoices,
     instantiationCounts,
     instantiations];
-  createEvent[rules, ruleIndex, matchedExpressions][expressions,
-                                                    eventRuleIndices,
-                                                    eventInputs,
-                                                    eventOutputs,
-                                                    eventGenerations,
-                                                    expressionCreatorEvents,
-                                                    expressionDestroyerEventCounts,
-                                                    destroyerChoices,
-                                                    instantiationCounts,
-                                                    instantiations]
+  createEvent[ruleIndex, matchedExpressions][expressions,
+                                             eventRuleIndices,
+                                             eventInputs,
+                                             eventOutputs,
+                                             eventGenerations,
+                                             expressionCreatorEvents,
+                                             expressionDestroyerEventCounts,
+                                             destroyerChoices,
+                                             instantiationCounts,
+                                             instantiations]
 ];
 
 (* Matching *)
@@ -230,16 +230,16 @@ expressionsSeparation[expressionCreatorEvents_, destroyerChoices_][firstExpressi
   "Spacelike"
 ];
 
-createEvent[rules_, ruleIndex_, matchedExpressions_][expressions_,
-                                                     eventRuleIndices_,
-                                                     eventInputs_,
-                                                     eventOutputs_,
-                                                     eventGenerations_,
-                                                     expressionCreatorEvents_,
-                                                     expressionDestroyerEventCounts_,
-                                                     destroyerChoices_,
-                                                     instantiationCounts_,
-                                                     instantiations_] := ModuleScope[
+createEvent[ruleIndex_, matchedExpressions_][expressions_,
+                                             eventRuleIndices_,
+                                             eventInputs_,
+                                             eventOutputs_,
+                                             eventGenerations_,
+                                             expressionCreatorEvents_,
+                                             expressionDestroyerEventCounts_,
+                                             destroyerChoices_,
+                                             instantiationCounts_,
+                                             instantiations_] := ModuleScope[
   ruleInputContents = expressions["Part", #] & /@ matchedExpressions;
   possibleOutputs = instantiations["Lookup", {ruleIndex, matchedExpressions}];
   possibleMatchCount = Length[possibleOutputs];

--- a/Kernel/MultisetSubstitutionSystem.m
+++ b/Kernel/MultisetSubstitutionSystem.m
@@ -246,7 +246,7 @@ $supportedEventOrdering =
   {"InputCount", "SortedInputTokenIndices", "InputTokenIndices", "RuleIndex", "InstantiationIndex"};
 parseEventOrdering[ordering : $supportedEventOrdering] := ordering;
 declareMessage[General::eventOrderingNotImplemented,
-               "Only " <> $supportedEventOrdering <> " event ordering is implemented at this time."];
+               "Only " <> ToString[$supportedEventOrdering] <> " event ordering is implemented at this time."];
 parseEventOrdering[_] := throw[Failure["eventOrderingNotImplemented", <||>]];
 
 parseInit[init_List] := init;

--- a/Tests/MultisetSubstitutionSystem.wlt
+++ b/Tests/MultisetSubstitutionSystem.wlt
@@ -287,7 +287,7 @@
            "InstantiationCounts" *)
         VerificationTest[
           With[{
-              serializeMultihistory = (Normal /@ # &) /@ Normal /@ KeyDrop[Last@#, "InstantiationCounts"] &,
+              serializeMultihistory = (Normal /@ # &) /@ Normal /@ KeyDrop[Last @ #, "InstantiationCounts"] &,
               multihistories = GenerateMultihistory[
                 MultisetSubstitutionSystem[
                   {{v1_, v2_}, {v2_, v3_, v4_}} :>

--- a/Tests/MultisetSubstitutionSystem.wlt
+++ b/Tests/MultisetSubstitutionSystem.wlt
@@ -180,7 +180,12 @@
             <|"MaxGeneration" -> 1, "MinEventInputs" -> 3, "MaxEventInputs" -> 3|>,
             <||>,
             {1, 2, 3},
-            {{1}, {2, 3}, {1, 2}, {3}}}},
+            {{1}, {2, 3}, {1, 2}, {3}}},
+           {{Longest[a__], b__} /; OrderedQ[{a, b}] :> {{a}, {b}},
+            <|"MaxGeneration" -> 1, "MinEventInputs" -> 3, "MaxEventInputs" -> 3|>,
+            <||>,
+            {1, 2, 3},
+            {{1, 2}, {3}, {1}, {2, 3}}}},
 
         VerificationTest[
           eventCount @ GenerateMultihistory[

--- a/Tests/MultisetSubstitutionSystem.wlt
+++ b/Tests/MultisetSubstitutionSystem.wlt
@@ -282,12 +282,12 @@
            {{a1}, {b1}, {a2}, {a3}, {m1}, {b2}, {m1}, {m2}, {m2}}}},
 
         (* non-overlapping systems produce the same behavior *)
-        (* "EventInputsMatchCount" stores the sequences of expressions that were tried but do not match.
-           "MaxDestroyerEvents" prevents them from being tried in the first place, thus changing
-           "EventInputsMatchCount" *)
+        (* "InstantiationCounts" stores the sequences of expressions that were tried but do not match.
+           "MaxDestroyerEvents" prevents some of these sequences to be tried in the first place, thus changing
+           "InstantiationCounts" *)
         VerificationTest[
           With[{
-              serializeMultihistory = (Normal /@ # &) /@ Normal /@ KeyDrop[Last@#, "EventInputsMatchCount"] &,
+              serializeMultihistory = (Normal /@ # &) /@ Normal /@ KeyDrop[Last@#, "InstantiationCounts"] &,
               multihistories = GenerateMultihistory[
                 MultisetSubstitutionSystem[
                   {{v1_, v2_}, {v2_, v3_, v4_}} :>

--- a/Tests/MultisetSubstitutionSystem.wlt
+++ b/Tests/MultisetSubstitutionSystem.wlt
@@ -6,8 +6,7 @@
       Global`testSymbolLeak[args___] := SetReplace`PackageScope`testSymbolLeak[VerificationTest, args];
     ),
     "tests" -> {
-      With[{anEventOrdering =
-          {"InputCount", "SortedInputTokenIndices", "InputTokenIndices", "RuleIndex", "InstantiationIndex"}}, {
+      With[{anEventOrdering = EventOrderingFunctions[MultisetSubstitutionSystem]}, {
         (* Symbol Leak *)
         testSymbolLeak[
           GenerateMultihistory[
@@ -63,8 +62,7 @@
       lastEventGeneration[Multihistory[_, data_]] := data["EventGenerations"]["Part", -1];
     ),
     "tests" -> {
-      With[{anEventOrdering =
-          {"InputCount", "SortedInputTokenIndices", "InputTokenIndices", "RuleIndex", "InstantiationIndex"}}, {
+      With[{anEventOrdering = EventOrderingFunctions[MultisetSubstitutionSystem]}, {
         Function[{rules, selection, stopping, init, expectedCreatedExpressions},
             VerificationTest[
               allExpressions @ GenerateMultihistory[
@@ -230,8 +228,7 @@
       allExpressions[Multihistory[_, data_]] := Normal @ data["Expressions"];
     ),
     "tests" -> {
-      With[{anEventOrdering =
-          {"InputCount", "SortedInputTokenIndices", "InputTokenIndices", "RuleIndex", "InstantiationIndex"}}, {
+      With[{anEventOrdering = EventOrderingFunctions[MultisetSubstitutionSystem]}, {
         Function[{rule, selection, init, expectedCreatedExpressions},
           VerificationTest[
             allExpressions @ GenerateMultihistory[
@@ -320,13 +317,11 @@
     "tests" -> {
       Function[{rule, init, lastEventInputsOutput},
         VerificationTest[
-          lastEventInputs @
-            GenerateMultihistory[
-              MultisetSubstitutionSystem[rule],
-              <||>,
-              None,
-              {"InputCount", "SortedInputTokenIndices", "InputTokenIndices", "RuleIndex", "InstantiationIndex"},
-              <|"MaxEvents" -> 1|>] @ init,
+          lastEventInputs @ GenerateMultihistory[MultisetSubstitutionSystem[rule],
+                                                 <||>,
+                                                 None,
+                                                 EventOrderingFunctions[MultisetSubstitutionSystem],
+                                                 <|"MaxEvents" -> 1|>] @ init,
           lastEventInputsOutput]
       ] @@@ {
         {{{2, 3, 4} -> {X}, {3} -> {X}}, {1, 2, 3, 4, 5}, {3}},
@@ -337,13 +332,11 @@
 
       Function[{rule, inits, lastExpressions},
         VerificationTest[
-          lastExpression @*
-            GenerateMultihistory[
-              MultisetSubstitutionSystem[rule],
-              <||>,
-              None,
-              {"InputCount", "SortedInputTokenIndices", "InputTokenIndices", "RuleIndex", "InstantiationIndex"},
-              <|"MaxEvents" -> 1|>] /@ inits,
+          lastExpression @* GenerateMultihistory[MultisetSubstitutionSystem[rule],
+                                                 <||>,
+                                                 None,
+                                                 EventOrderingFunctions[MultisetSubstitutionSystem],
+                                                 <|"MaxEvents" -> 1|>] /@ inits,
           lastExpressions]
       ] @@@ {
         {{{{1, 2}, {2, 3}} -> {1}, {{4, 5}, {5, 6}} -> {2}},
@@ -371,8 +364,7 @@
       destroyerEventCounts[Multihistory[_, data_]] := Normal @ data["ExpressionDestroyerEventCounts"];
     ),
     "tests" -> {
-      With[{anEventOrdering =
-          {"InputCount", "SortedInputTokenIndices", "InputTokenIndices", "RuleIndex", "InstantiationIndex"}}, {
+      With[{anEventOrdering = EventOrderingFunctions[MultisetSubstitutionSystem]}, {
         Function[{
             rule, selection, stopping, init, expectedMaxEventGeneration, expectedEventCount, expectedTerminationReason},
           VerificationTest[

--- a/Tests/hypergraphMatching.wlt
+++ b/Tests/hypergraphMatching.wlt
@@ -22,13 +22,11 @@
 
       matchingFunction[MultisetSubstitutionSystem] =
         (#["EventRuleIndices"]["Length"] > 1 &) @
-          Last @
-            GenerateMultihistory[
-              MultisetSubstitutionSystem[ToPatternRules[#HypergraphRule]],
-              <||>,
-              None,
-              {"InputCount", "SortedInputTokenIndices", "InputTokenIndices", "RuleIndex", "InstantiationIndex"},
-              <||>] @ #Init &;
+          Last @ GenerateMultihistory[MultisetSubstitutionSystem[ToPatternRules[#HypergraphRule]],
+                                      <||>,
+                                      None,
+                                      EventOrderingFunctions[MultisetSubstitutionSystem],
+                                      <||>] @ #Init &;
 
       graphFromHyperedges[edges_] := Graph[UndirectedEdge @@@ Flatten[Partition[#, 2, 1] & /@ edges, 1]];
 
@@ -124,13 +122,11 @@
       VerificationTest[
         Normal @
           (#["Expressions"] &) @
-            Last @
-              GenerateMultihistory[
-                MultisetSubstitutionSystem[ToPatternRules[{{1, 2}, {2, 3}} -> {{1, 3}}]],
-                <||>,
-                None,
-                {"InputCount", "SortedInputTokenIndices", "InputTokenIndices", "RuleIndex", "InstantiationIndex"},
-                <|"MaxEvents" -> 1|>][{{1, 2}, {2, 1}}],
+            Last @ GenerateMultihistory[MultisetSubstitutionSystem[ToPatternRules[{{1, 2}, {2, 3}} -> {{1, 3}}]],
+                                        <||>,
+                                        None,
+                                        EventOrderingFunctions[MultisetSubstitutionSystem],
+                                        <|"MaxEvents" -> 1|>][{{1, 2}, {2, 1}}],
         {{1, 2}, {2, 1}, {1, 1}}
       ],
 

--- a/Tests/hypergraphMatching.wlt
+++ b/Tests/hypergraphMatching.wlt
@@ -23,11 +23,12 @@
       matchingFunction[MultisetSubstitutionSystem] =
         (#["EventRuleIndices"]["Length"] > 1 &) @
           Last @
-            GenerateMultihistory[MultisetSubstitutionSystem[ToPatternRules[#HypergraphRule]],
-                                 <||>,
-                                 None,
-                                 {"InputCount", "SortedInputTokenIndices", "InputTokenIndices", "RuleIndex"},
-                                 <||>] @ #Init &;
+            GenerateMultihistory[
+              MultisetSubstitutionSystem[ToPatternRules[#HypergraphRule]],
+              <||>,
+              None,
+              {"InputCount", "SortedInputTokenIndices", "InputTokenIndices", "RuleIndex", "InstantiationIndex"},
+              <||>] @ #Init &;
 
       graphFromHyperedges[edges_] := Graph[UndirectedEdge @@@ Flatten[Partition[#, 2, 1] & /@ edges, 1]];
 
@@ -124,11 +125,12 @@
         Normal @
           (#["Expressions"] &) @
             Last @
-              GenerateMultihistory[MultisetSubstitutionSystem[ToPatternRules[{{1, 2}, {2, 3}} -> {{1, 3}}]],
-                                   <||>,
-                                   None,
-                                   {"InputCount", "SortedInputTokenIndices", "InputTokenIndices", "RuleIndex"},
-                                   <|"MaxEvents" -> 1|>][{{1, 2}, {2, 1}}],
+              GenerateMultihistory[
+                MultisetSubstitutionSystem[ToPatternRules[{{1, 2}, {2, 3}} -> {{1, 3}}]],
+                <||>,
+                None,
+                {"InputCount", "SortedInputTokenIndices", "InputTokenIndices", "RuleIndex", "InstantiationIndex"},
+                <|"MaxEvents" -> 1|>][{{1, 2}, {2, 1}}],
         {{1, 2}, {2, 1}, {1, 1}}
       ],
 

--- a/performanceTest.wls
+++ b/performanceTest.wls
@@ -64,7 +64,12 @@ Check[
             {14, 9, 9}}},
       {{3, 3, 3, 6}, {3, 3, 7, 3}, {3, 5, 5}, {3, 3, 1}, {3, 2, 3}, {3, 3, 3, 3, 3, 3}, {4, 6, 6}, {4, 4, 4, 4, 4, 4},
         {8, 7, 7}, {8, 8, 8, 8, 8, 8}, {1, 4, 1}, {1, 1, 1, 1, 1}, {2, 2, 8}, {2, 2}},
-      64]
+      64],
+    "Multiset addition" -> GenerateMultihistory[MultisetSubstitutionSystem[{a_, b_} :> {a + b}],
+                                                {"MaxGeneration" -> 2, "MinEventInputs" -> 2, "MaxEventInputs" -> 2},
+                                                None,
+                                                EventOrderingFunctions[MultisetSubstitutionSystem],
+                                                {}][{1, 2, 3, 4}]
   |>;
 
   $defaultMeasurementsCount = 5;


### PR DESCRIPTION
## Changes

* Closes #637.
* Left-hand sides of rules such as `{a__, b__}` will now be matched multiple times even if the ordered sequence of tokens is the same (e.g., as `{{a} -> {1}, {b} -> {2, 3}}` and `{{a} -> {1, 2}, {b} -> {3}}`).
* This was done by allowing the same sequence of tokens to be matched multiple times (how many times is computed during the matching step).
* This required adding another ordering function, `"InstantiationIndex"`, which controls which of the instantiations will be used first. (There is still no customization of the ordering at the moment.)

## Examples

* The example from the issue can now generate both matches:

```wl
In[] := #["ExpressionsEventsGraph", VertexLabels -> Automatic] &@
 SetReplaceTypeConvert[{WolframModelEvolutionObject, 2}]@
  GenerateMultihistory[
    MultisetSubstitutionSystem[{a__, b__} /; OrderedQ[{a, b}] :> {{a}, {b}}], {"MaxGeneration" -> 1,
     "MinEventInputs" -> 3, "MaxEventInputs" -> 3},
    None, {"InputCount", "SortedInputTokenIndices", "InputTokenIndices", "RuleIndex"}, {}][{1, 2, 3}]
```

<img width="478" alt="image" src="https://user-images.githubusercontent.com/1479325/114638668-ce48ca80-9c91-11eb-81f0-de632ed56ff2.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/638)
<!-- Reviewable:end -->
