### PR TITLE
Avoid passing 64-bit ints through LibraryLink

### DIFF
--- a/Kernel/setSubstitutionSystem$cpp.m
+++ b/Kernel/setSubstitutionSystem$cpp.m
@@ -172,7 +172,7 @@ setSubstitutionSystem$cpp[
     maxDestroyerEvents[stepSpec[$maxDestroyerEvents], eventSelectionFunction],
     Catenate[Replace[eventOrderingFunction, $orderingFunctionCodes, {2}]],
     Replace[eventDeduplication, $eventDeduplicationCodes],
-    FromDigits[#, 2] & /@ Partition[IntegerDigits[RandomInteger[{0, $maxUInt32}], 2, 32], 16]
+    IntegerDigits[RandomInteger[{0, $maxUInt32}], 2^16, 2]
   ];
   TimeConstrained[
     CheckAbort[

--- a/Kernel/setSubstitutionSystem$cpp.m
+++ b/Kernel/setSubstitutionSystem$cpp.m
@@ -102,8 +102,8 @@ ruleAtomsToIndices[left_ :> right_, globalIndex_, localIndex_] := ModuleScope[
   newLeft -> newRight
 ];
 
-$maxInt64 = 2^63 - 1;
-$maxUInt32 = 2^32 - 1;
+$unset = -1;
+$maxInt32 = 2^31 - 1;
 
 $terminationReasonCodes = <|
   0 -> $notTerminated,
@@ -119,7 +119,7 @@ $terminationReasonCodes = <|
 (* GlobalSpacelike is syntactic sugar for "EventSelectionFunction" -> "MultiwaySpacelike", "MaxDestroyerEvents" -> 1 *)
 
 maxDestroyerEvents[_, $globalSpacelike] = 1;
-maxDestroyerEvents[Automatic | _ ? MissingQ | Infinity, _] = $maxInt64;
+maxDestroyerEvents[Automatic | _ ? MissingQ | Infinity, _] = $unset;
 maxDestroyerEvents[n_, _] := n;
 
 (* 0 -> All
@@ -171,7 +171,7 @@ setSubstitutionSystem$cpp[
     maxDestroyerEvents[stepSpec[$maxDestroyerEvents], eventSelectionFunction],
     Catenate[Replace[eventOrderingFunction, $orderingFunctionCodes, {2}]],
     Replace[eventDeduplication, $eventDeduplicationCodes],
-    RandomInteger[{0, $maxUInt32}]
+    RandomInteger[{0, $maxInt32}]
   ];
   TimeConstrained[
     CheckAbort[
@@ -179,7 +179,7 @@ setSubstitutionSystem$cpp[
         setID,
         stepSpec /@ {
             $maxEvents, $maxGenerationsLocal, $maxFinalVertices, $maxFinalVertexDegree, $maxFinalExpressions} /.
-          {Infinity | (_ ? MissingQ) -> $maxInt64}],
+          {Infinity | (_ ? MissingQ) -> $unset}],
       If[!returnOnAbortQ, Abort[], terminationReason = $Aborted]],
     timeConstraint,
     If[!returnOnAbortQ, Return[$Aborted], terminationReason = $timeConstraint]];

--- a/Kernel/setSubstitutionSystem$cpp.m
+++ b/Kernel/setSubstitutionSystem$cpp.m
@@ -13,7 +13,8 @@ importLibSetReplaceFunction[
    Integer,                  (* event selection function *)
    {Integer, 1, "Constant"}, (* ordering function index, forward / reverse, function, forward / reverse, ... *)
    Integer,                  (* event deduplication *)
-   Integer},                 (* random seed *)
+   (* random seed, passed as two numbers because LibraryLink does not support unsigned ints *)
+   {Integer, 1, "Constant"}},
   "Void"];
 
 importLibSetReplaceFunction[
@@ -103,7 +104,7 @@ ruleAtomsToIndices[left_ :> right_, globalIndex_, localIndex_] := ModuleScope[
 ];
 
 $unset = -1;
-$maxInt32 = 2^31 - 1;
+$maxUInt32 = 2^32 - 1;
 
 $terminationReasonCodes = <|
   0 -> $notTerminated,
@@ -171,7 +172,7 @@ setSubstitutionSystem$cpp[
     maxDestroyerEvents[stepSpec[$maxDestroyerEvents], eventSelectionFunction],
     Catenate[Replace[eventOrderingFunction, $orderingFunctionCodes, {2}]],
     Replace[eventDeduplication, $eventDeduplicationCodes],
-    RandomInteger[{0, $maxInt32}]
+    FromDigits[#, 2] & /@ Partition[IntegerDigits[RandomInteger[{0, $maxUInt32}], 2, 32], 16]
   ];
   TimeConstrained[
     CheckAbort[


### PR DESCRIPTION
## Changes

* Closes #641.
* We are currently passing 64-bit ints for disabled step specs, and an unsigned 32-bit for the seed initialization. WL LibraryLink does not support that on 32-bit platforms, so any calls to `libSetReplace` would fail.
* This PR changes it to pass -1 and 31-bit ints instead, which should fix that issue.

## Comments

* Someone with a 32-bit system needs to confirm there is nothing else here I'm missing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/648)
<!-- Reviewable:end -->
