### PR TITLE
Apple ARM support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,13 +171,18 @@ jobs:
             cp -r $cmakeDir/CMake.app/Contents/share/* /usr/local/share/
 
       - run:
-          name: Build
-          command: scripts/buildLibraryResources.sh
+          name: Build arm64
+          command: scripts/buildLibraryResources.sh arm64
+
+      - run:
+          name: Build x86_64
+          command: scripts/buildLibraryResources.sh x86_64
 
       - persist_to_workspace:
           root: LibraryResources
           paths:
             - MacOSX-x86-64
+            - MacOSX-ARM64
 
       - store_artifacts:
           path: ./LibraryResources/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,17 @@ cmake_minimum_required(VERSION 3.13)
 project(SetReplace
     VERSION 0.3.0
     LANGUAGES CXX)
-set(CMAKE_OSX_ARCHITECTURES arm64 x86_64)
 message(STATUS "${PROJECT_NAME} version: ${PROJECT_VERSION}")
+
+option(SET_REPLACE_BUILD_OSX_ARM64 "Build for arm64 on macOS" ON)
+option(SET_REPLACE_BUILD_OSX_X86_64 "Build for x86_64 on macOS" ON)
+
+if(SET_REPLACE_BUILD_OSX_ARM64)
+  list(APPEND CMAKE_OSX_ARCHITECTURES arm64)
+endif()
+if(SET_REPLACE_BUILD_OSX_X86_64)
+  list(APPEND CMAKE_OSX_ARCHITECTURES x86_64)
+endif()
 
 option(SET_REPLACE_BUILD_TESTING "Enable cpp testing." OFF)
 include(GNUInstallDirs) # Define CMAKE_INSTALL_xxx: LIBDIR, INCLUDEDIR

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,16 +4,6 @@ project(SetReplace
     LANGUAGES CXX)
 message(STATUS "${PROJECT_NAME} version: ${PROJECT_VERSION}")
 
-option(SET_REPLACE_BUILD_OSX_ARM64 "Build for arm64 on macOS" ON)
-option(SET_REPLACE_BUILD_OSX_X86_64 "Build for x86_64 on macOS" ON)
-
-if(SET_REPLACE_BUILD_OSX_ARM64)
-  list(APPEND CMAKE_OSX_ARCHITECTURES arm64)
-endif()
-if(SET_REPLACE_BUILD_OSX_X86_64)
-  list(APPEND CMAKE_OSX_ARCHITECTURES x86_64)
-endif()
-
 option(SET_REPLACE_BUILD_TESTING "Enable cpp testing." OFF)
 include(GNUInstallDirs) # Define CMAKE_INSTALL_xxx: LIBDIR, INCLUDEDIR
 set(SetReplace_export_file "${PROJECT_BINARY_DIR}/SetReplaceTargets.cmake")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.13)
 project(SetReplace
     VERSION 0.3.0
     LANGUAGES CXX)
+set(CMAKE_OSX_ARCHITECTURES arm64 x86_64)
 message(STATUS "${PROJECT_NAME} version: ${PROJECT_VERSION}")
 
 option(SET_REPLACE_BUILD_TESTING "Enable cpp testing." OFF)

--- a/PacletInfo.m
+++ b/PacletInfo.m
@@ -7,7 +7,7 @@ Paclet[
   Description -> "SetReplace implements WolframModel and other functions used in the Wolfram Physics Project.",
   Creator -> "Wolfram Research",
   URL -> "https://github.com/maxitg/SetReplace",
-  SystemID -> {"MacOSX-x86-64", "Linux-x86-64", "Windows-x86-64"},
+  SystemID -> {"MacOSX-x86-64", "Linux-x86-64", "Windows-x86-64", "MacOSX-ARM64"},
   Extensions -> {
     {"Kernel", Context -> "SetReplace`"},
     {"LibraryLink"}

--- a/scripts/buildLibraryResources.sh
+++ b/scripts/buildLibraryResources.sh
@@ -15,13 +15,11 @@ fi
 # Set the platform-specific names
 
 if [[ "$(uname -s)" == "Darwin" && "$arch" == "arm64" ]]; then
-  macOSBuildArm64="ON"
-  macOSBuildX86_64="OFF"
+  cmakeArchitectureArgs="-DCMAKE_OSX_ARCHITECTURES=arm64"
   libraryResourcesDirName=MacOSX-ARM64
   libraryExtension=dylib
 elif [[ "$(uname -s)" == "Darwin" && "$arch" == "x86_64" ]]; then
-  macOSBuildArm64="OFF"
-  macOSBuildX86_64="ON"
+  cmakeArchitectureArgs="-DCMAKE_OSX_ARCHITECTURES=x86_64"
   libraryResourcesDirName=MacOSX-x86-64
   libraryExtension=dylib
 elif [[ "$(uname -s)" == "Linux" && "$arch" == "x86_64" ]]; then
@@ -76,8 +74,7 @@ echo "libSetReplace sources hash: $shortSHA"
 
 mkdir -p build
 cd build
-cmake .. -DSET_REPLACE_ENABLE_ALLWARNINGS=ON -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Release \
-  -DSET_REPLACE_BUILD_OSX_ARM64="$macOSBuildArm64" -DSET_REPLACE_BUILD_OSX_X86_64="$macOSBuildX86_64"
+cmake .. -DSET_REPLACE_ENABLE_ALLWARNINGS=ON -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Release "$cmakeArchitectureArgs"
 cmake --build . --config Release # Needed for multi-config generators
 cd ..
 

--- a/scripts/buildLibraryResources.sh
+++ b/scripts/buildLibraryResources.sh
@@ -20,10 +20,10 @@ if [[ "$(uname -s)" == "Darwin" && "$arch" == "arm64" ]]; then
   libraryResourcesDirName=MacOSX-ARM64
   libraryExtension=dylib
 elif [[ "$(uname -s)" == "Darwin" && "$arch" == "x86_64" ]]; then
-  libraryResourcesDirName=MacOSX-x86-64
-  libraryExtension=dylib
   macOSBuildArm64="OFF"
   macOSBuildX86_64="ON"
+  libraryResourcesDirName=MacOSX-x86-64
+  libraryExtension=dylib
 elif [[ "$(uname -s)" == "Linux" && "$arch" == "x86_64" ]]; then
   libraryResourcesDirName=Linux-x86-64
   libraryExtension=so

--- a/scripts/buildLibraryResources.sh
+++ b/scripts/buildLibraryResources.sh
@@ -74,7 +74,8 @@ echo "libSetReplace sources hash: $shortSHA"
 
 mkdir -p build
 cd build
-cmake .. -DSET_REPLACE_ENABLE_ALLWARNINGS=ON -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Release "$cmakeArchitectureArgs"
+cmake .. -DSET_REPLACE_ENABLE_ALLWARNINGS=ON -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Release \
+  ${cmakeArchitectureArgs:+"$cmakeArchitectureArgs"}
 cmake --build . --config Release # Needed for multi-config generators
 cd ..
 

--- a/scripts/buildLibraryResources.sh
+++ b/scripts/buildLibraryResources.sh
@@ -15,11 +15,11 @@ fi
 # Set the platform-specific names
 
 if [[ "$(uname -s)" == "Darwin" && "$arch" == "arm64" ]]; then
-  cmakeArchitectureArgs="-DCMAKE_OSX_ARCHITECTURES=arm64"
+  cmakeArchitectureArg="-DCMAKE_OSX_ARCHITECTURES=arm64"
   libraryResourcesDirName=MacOSX-ARM64
   libraryExtension=dylib
 elif [[ "$(uname -s)" == "Darwin" && "$arch" == "x86_64" ]]; then
-  cmakeArchitectureArgs="-DCMAKE_OSX_ARCHITECTURES=x86_64"
+  cmakeArchitectureArg="-DCMAKE_OSX_ARCHITECTURES=x86_64"
   libraryResourcesDirName=MacOSX-x86-64
   libraryExtension=dylib
 elif [[ "$(uname -s)" == "Linux" && "$arch" == "x86_64" ]]; then
@@ -75,7 +75,7 @@ echo "libSetReplace sources hash: $shortSHA"
 mkdir -p build
 cd build
 cmake .. -DSET_REPLACE_ENABLE_ALLWARNINGS=ON -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Release \
-  ${cmakeArchitectureArgs:+"$cmakeArchitectureArgs"}
+  ${cmakeArchitectureArg:+"$cmakeArchitectureArg"}
 cmake --build . --config Release # Needed for multi-config generators
 cd ..
 


### PR DESCRIPTION
## Changes

* Compiles the Mac library for both arm64 and x86_64 to enable Apple Silicon support.

## Comments

- [x] Works on x86_64
- [x] Works on ARM

## Tests

To check an architecture and mark the checkbox, evaluate:

```wl
PacletUninstall["SetReplace"];
Quit;
PacletInstall["path_to_built_paclet_in_CI"];
<< SetReplace`;
WolframModel[{{1, 2}} -> {{1, 3}, {1, 3}, {3, 2}}, {{1, 1}}, 4, "FinalStatePlot", Method -> "LowLevel"]
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/651)
<!-- Reviewable:end -->
