### PR TITLE
Wolfram Language 12.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,32 +52,6 @@ jobs:
               ./performanceTest.wls master HEAD 2
             fi
 
-  wolfram-language-paclet-test-prerelease:
-    docker:
-      - image: maxitg/set-replace-wl-ci:12.4.0
-        auth:
-          username: maxitg
-          password: $DOCKERHUB_PASSWORD
-    parallelism: 4
-
-    steps:
-      - checkout
-
-      - attach_workspace:
-          at: /tmp/workspace
-
-      - run:
-          name: Copy libraries
-          command: mkdir -p ./LibraryResources && cp -r /tmp/workspace/* ./LibraryResources/
-
-      - run:
-          name: Install
-          command: ./install.wls
-
-      - run:
-          name: Test
-          command: ./.circleci/test.sh
-
   cpp-test:
     docker:
       - image: alpine:3.12.1
@@ -228,6 +202,3 @@ workflows:
           requires:
             - macos-build
             - windows-build
-      - wolfram-language-paclet-test-prerelease:
-          requires:
-            - wolfram-language-paclet-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 jobs:
   wolfram-language-paclet-test:
     docker:
-      - image: maxitg/set-replace-wl-ci:12.2.0
+      - image: maxitg/set-replace-wl-ci:12.3.0
         auth:
           username: maxitg
           password: $DOCKERHUB_PASSWORD
@@ -54,7 +54,7 @@ jobs:
 
   wolfram-language-paclet-test-prerelease:
     docker:
-      - image: maxitg/set-replace-wl-ci:12.3.0
+      - image: maxitg/set-replace-wl-ci:12.4.0
         auth:
           username: maxitg
           password: $DOCKERHUB_PASSWORD

--- a/DevUtils/GitLink.m
+++ b/DevUtils/GitLink.m
@@ -2,8 +2,6 @@ Package["SetReplaceDevUtils`"]
 
 PackageImport["GeneralUtilities`"]
 
-PackageImport["PacletManager`"] (* for PacletFind, PacletInstall in versions prior to 12.1 *)
-
 PackageExport["$GitLinkAvailableQ"]
 PackageExport["GitSHAWithDirtyStar"]
 PackageExport["InstallGitLink"]

--- a/DevUtils/PackSetReplace.m
+++ b/DevUtils/PackSetReplace.m
@@ -71,18 +71,13 @@ PackSetReplace[OptionsPattern[]] := ModuleScope[
 
   fileInputs = {kernelDir, libraryDir, pacletInfoFile, tempBuildInfoFile};
 
-  pacletCreatorFunction = If[$VersionNumber >= 12.1,
-    Symbol["System`CreatePacletArchive"]
-  ,
-    Symbol["PacletManager`PackPaclet"]
-  ];
-  pacletFileName = pacletCreatorFunction[fileInputs, outputDirectory];
+  pacletFileName = CreatePacletArchive[fileInputs, outputDirectory];
 
   If[StringQ[pacletFileName],
     If[verbose,
       Print["Paclet file written to ", pacletFileName]
     ];
-    Return @ If[$VersionNumber >= 12.1, PacletObject[File[pacletFileName]], <|"Location" -> pacletFileName|>]
+    Return @ PacletObject[File[pacletFileName]]
   ,
     If[verbose, Print["Pack failed."]];
     ReturnFailed["packfailed", sourceDirectory, outputDirectory]

--- a/Kernel/convexHullPolygon.m
+++ b/Kernel/convexHullPolygon.m
@@ -20,7 +20,7 @@ rotationDirection[pt1_, pt2_, pt3_] :=
   (pt2[[1]] - pt1[[1]]) (pt3[[2]] - pt2[[2]]) - (pt2[[2]] - pt1[[2]]) (pt3[[1]] - pt2[[1]]);
 
 convexHullPolygon[points_] := ModuleScope[
-  (* Sort is broken for symbolic values in Wolfram Language 12.2 *)
+  (* Sort uses lexicographic rather than numeric ordering, so it might not work if the points are not numeric. *)
   numericPoints = N[points];
   stack = CreateDataStructure["Stack"];
   (* find a bottommost point, if multiple, find the leftmost one *)

--- a/PacletInfo.m
+++ b/PacletInfo.m
@@ -3,7 +3,7 @@
 Paclet[
   Name -> "SetReplace",
   Version -> "0.3",
-  MathematicaVersion -> "12.2+",
+  MathematicaVersion -> "12.3+",
   Description -> "SetReplace implements WolframModel and other functions used in the Wolfram Physics Project.",
   Creator -> "Wolfram Research",
   URL -> "https://github.com/maxitg/SetReplace",

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Out[] = {5, 3, 6, 3}
 ```
 
 Note that this is similar to [`SubsetReplace`](https://reference.wolfram.com/language/ref/SubsetReplace.html) function
-of Wolfram Language (introduced in version 12.1, it replaces all non-overlapping subsets at once by default):
+of Wolfram Language (it replaces all non-overlapping subsets at once by default):
 
 ```wl
 In[] := SubsetReplace[{1, 2, 5, 3, 6}, {a_, b_} :> a + b]
@@ -110,7 +110,7 @@ You only need three things to use *SetReplace*:
 * Windows, macOS 10.12+, or Linux.
 * Windows only &mdash;
   [Microsoft Visual C++ Redistributable 2015+](https://support.microsoft.com/en-us/topic/the-latest-supported-visual-c-downloads-2647da03-1eea-4433-9aff-95f26a218cc0).
-* [Wolfram Language 12.2+](https://www.wolfram.com/language/)
+* [Wolfram Language 12.3+](https://www.wolfram.com/language/)
   including [WolframScript](https://www.wolfram.com/wolframscript/). A free version is available
   as [Wolfram Engine](https://www.wolfram.com/engine/).
 * A C++17 compiler to build the low-level part of the package. Instructions on how to set up a compiler to use in

--- a/install.wls
+++ b/install.wls
@@ -3,7 +3,6 @@
 Check[
   Get[FileNameJoin[{DirectoryName[$InputFileName], "DevUtils", "init.m"}]];
   Off[General::stop];
-  If[$VersionNumber < 12.1, Needs["PacletManager`"]];
 ,
   Print["Message occurred during loading of DevUtils. Build failed."];
   Exit[1];


### PR DESCRIPTION
## Changes

* Updates the minimum required WL version to 12.3.
* Removes WL prerelease tests.
* Removes unnecessary backward-compatibility code.

## Comments

* This allows us to use WL 12.3 features without any restrictions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/652)
<!-- Reviewable:end -->
