### PR TITLE
Fix seeding for multi-rule systems

### DIFF
--- a/libSetReplace/test/HypergraphSubstitutionSystem_test.cpp
+++ b/libSetReplace/test/HypergraphSubstitutionSystem_test.cpp
@@ -149,4 +149,16 @@ TEST(HypergraphSubstitutionSystem, replaceOnce) {
       {{{{-1}}, {{-1, -1}}}}, {{1}}, 1, orderingSpec, HypergraphMatcher::EventDeduplication::None, 0);
   EXPECT_EQ(system.replaceOnce(doNotAbort), 1);
 }
+
+TEST(HypergraphSubstitutionSystem, multiruleSeeding) {
+  std::array<int, 2> replacedTokenCounts = {0, 0};
+  constexpr int trialCount = 100;
+  for (int i = 0; i < trialCount; ++i) {
+    HypergraphSubstitutionSystem system(
+        {{{{1, 2}}, {}}, {{{2, 3}}, {}}}, {{1, 2}, {2, 3}}, 1, {}, HypergraphMatcher::EventDeduplication::None, 123);
+    system.replaceOnce(doNotAbort);
+    ++replacedTokenCounts[system.events()[1].inputTokens[0]];
+  }
+  EXPECT_EQ(std::max(replacedTokenCounts[0], replacedTokenCounts[1]), trialCount);
+}
 }  // namespace SetReplace


### PR DESCRIPTION
## Changes

* Resolves #642.
* Fixes seeding in multi-rule `WolframModel`.

## Comments

* Adding matches for different rules in parallel caused non-determinism, which broke consistency with specified seeds.
* In the case of multiple rules, the matches are now added to intermediate storage (similar to `EventDeduplication::SameInputSetIsomorphicOutputs`), and then sorted before being added to the main storage.

## Examples

```wl
In[] := Counts @ Table[
  BlockRandom[
    WolframModel[<|"PatternRules" -> {{{1, 2}} -> {}, {{2, 3}} -> {}}|>,
                 {{1, 2}, {2, 3}},
                 <|"MaxEvents" -> 1|>,
                 "EventOrderingFunction" -> "Random"]["FinalState"],
    RandomSeeding -> 123],
  100]
Out[] = <|{{2, 3}} -> 100|>
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/653)
<!-- Reviewable:end -->
