### PR TITLE
Fix linting with new tool versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
 
   cpp-test:
     docker:
-      - image: alpine:3.12.1
+      - image: alpine:3.13.5
         auth:
           username: maxitg
           password: $DOCKERHUB_PASSWORD
@@ -98,7 +98,7 @@ jobs:
 
   cpp-32-test:
     docker:
-      - image: i386/alpine:3.12.1
+      - image: i386/alpine:3.13.5
         auth:
           username: maxitg
           password: $DOCKERHUB_PASSWORD

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
 
   cpp-test:
     docker:
-      - image: alpine:20210212
+      - image: alpine:3.13.5
         auth:
           username: maxitg
           password: $DOCKERHUB_PASSWORD
@@ -65,7 +65,8 @@ jobs:
       - run:
           name: Install Required Tools
           command: |
-            apk add --no-cache bash git g++ make cmake clang py-pip shellcheck shfmt grep npm
+            apk add --no-cache bash git g++ make cmake clang py-pip shellcheck grep npm
+            apk add --no-cache shfmt --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community
             pip install cpplint
             npm install -g markdownlint-cli
 
@@ -98,7 +99,7 @@ jobs:
 
   cpp-32-test:
     docker:
-      - image: i386/alpine:20210212
+      - image: i386/alpine:3.13.5
         auth:
           username: maxitg
           password: $DOCKERHUB_PASSWORD

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
 
   cpp-test:
     docker:
-      - image: alpine:3.13.5
+      - image: alpine:20210212
         auth:
           username: maxitg
           password: $DOCKERHUB_PASSWORD
@@ -98,7 +98,7 @@ jobs:
 
   cpp-32-test:
     docker:
-      - image: i386/alpine:3.13.5
+      - image: i386/alpine:20210212
         auth:
           username: maxitg
           password: $DOCKERHUB_PASSWORD

--- a/lint.sh
+++ b/lint.sh
@@ -51,9 +51,9 @@ fi
 exitStatus=0
 
 for file in "${filesToLint[@]}"; do
-  if [[ "$file" == *.png || \
-    "$file" == Dependencies/* || \
-    "$file" == libSetReplace/WolframHeaders/* || \
+  if [[ "$file" == *.png ||
+    "$file" == Dependencies/* ||
+    "$file" == libSetReplace/WolframHeaders/* ||
     "$file" == *.xcodeproj/* ]]; then
     :
   elif [[ "$file" == *.cpp || "$file" == *.hpp || "$file" == *.h ]]; then

--- a/scripts/checkLineWidth.sh
+++ b/scripts/checkLineWidth.sh
@@ -12,7 +12,6 @@ widthLimit="$2"
 grepOutput=$(grep --line-number --color=never --extended-regexp ".{$((widthLimit + 1))}" "$filename" || :)
 
 if [ -n "$grepOutput" ]; then
-  filename="$filename"
   echo "$grepOutput" | awk -v filename="$filename" '{print filename ":" $0}'
   exit 1
 fi


### PR DESCRIPTION
## Changes

* Removes unnecessary `\` at the ends of lines in `lint.sh`.
* Removes unnecessary self-assignment in `checkLineWidth.sh`.

## Examples

* `./lint.sh` no longer generates errors:

```console
$ ./lint.sh
$
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/654)
<!-- Reviewable:end -->
