### PR TITLE
System`Dump`LibraryExtension -> Internal`DynamicLibraryExtension

### DIFF
--- a/DevUtils/BuildLibSetReplace.m
+++ b/DevUtils/BuildLibSetReplace.m
@@ -76,7 +76,7 @@ BuildLibSetReplace[OptionsPattern[]] := ModuleScope[
   finalHash = Base36Hash[{sourceHashes, hashedOptions}];
 
   (* derive final paths *)
-  libraryFileName = StringJoin["libSetReplace-", finalHash, ".", System`Dump`LibraryExtension[]];
+  libraryFileName = StringJoin["libSetReplace-", finalHash, ".", Internal`DynamicLibraryExtension[]];
   libraryPath = FileNameJoin[{libraryTargetDirectory, libraryFileName}];
 
   calculateBuildData[] := Association[


### PR DESCRIPTION
## Changes

* Changes ``System`Dump`LibraryExtension`` to ``Internal`DynamicLibraryExtension`` due to impending deprecation.

## Examples

* Remove cache:
```console
$ rm -rf LibraryResources
```

* Build *libSetReplace*:
```wl
In[] := BuildLibSetReplace[]
Out[] = <|"LibraryPath" -> "/Users/maxitg/git/SetReplace/LibraryResources/MacOSX-x86-64/libSetReplace-165zdmc3jmt79.dylib", 
 "LibraryFileName" -> "libSetReplace-165zdmc3jmt79.dylib", "LibraryBuildTime" -> {2021, 6, 13, 17, 31, 13}, 
 "LibrarySourceHash" -> "165zdmc3jmt79", "FromCache" -> False|>
```

* The library extension is correct (at least on a Mac).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/655)
<!-- Reviewable:end -->
