### PR TITLE
TokenEventGraph

### DIFF
--- a/Kernel/GeneralizedGridGraph.m
+++ b/Kernel/GeneralizedGridGraph.m
@@ -32,8 +32,8 @@ expr : GeneralizedGridGraph[args___] /; Developer`CheckArgumentCount[expr, 1, 1]
 ];
 
 generalizedGridGraph[dimensionSpecs_List, opts___] := (
-  assertKnownOptions[GeneralizedGridGraph, {opts}];
-  assertEnumOptionValue[GeneralizedGridGraph, "VertexNamingFunction", $vertexNamingFunctions, {opts}];
+  checkKnownOptions[GeneralizedGridGraph, {opts}];
+  checkEnumOptionValue[GeneralizedGridGraph, "VertexNamingFunction", $vertexNamingFunctions, {opts}];
   generalizedGridGraphExplicit[toExplicitDimSpec /@ dimensionSpecs, opts]
 );
 

--- a/Kernel/GeneralizedGridGraph.m
+++ b/Kernel/GeneralizedGridGraph.m
@@ -34,13 +34,11 @@ expr : GeneralizedGridGraph[args___] := ModuleScope[
 generalizedGridGraph[args___] /; !Developer`CheckArgumentCount[GeneralizedGridGraph[args], 1, 1] :=
   throw[Failure[None, <||>]];
 
-generalizedGridGraph[args_, opts___] /; !knownOptionsQ[GeneralizedGridGraph, {opts}] := 0;
-
-generalizedGridGraph[args_, opts___] /;
-    !supportedOptionQ[GeneralizedGridGraph, "VertexNamingFunction", $vertexNamingFunctions, {opts}] := 0;
-
-generalizedGridGraph[dimensionSpecs_List, opts___] :=
-  generalizedGridGraphExplicit[toExplicitDimSpec /@ dimensionSpecs, opts];
+generalizedGridGraph[dimensionSpecs_List, opts___] := (
+  assertKnownOptions[GeneralizedGridGraph, {opts}];
+  assertEnumOptionValue[GeneralizedGridGraph, "VertexNamingFunction", $vertexNamingFunctions, {opts}];
+  generalizedGridGraphExplicit[toExplicitDimSpec /@ dimensionSpecs, opts]
+);
 
 declareMessage[GeneralizedGridGraph::dimsNotList, "Dimensions specification `dimSpec` should be a list."];
 

--- a/Kernel/GeneralizedGridGraph.m
+++ b/Kernel/GeneralizedGridGraph.m
@@ -25,14 +25,11 @@ FE`Evaluate[FEPrivate`AddSpecialArgCompletion["GeneralizedGridGraph" -> {{"Circu
 
 (* Implementation *)
 
-expr : GeneralizedGridGraph[args___] := ModuleScope[
+expr : GeneralizedGridGraph[args___] /; Developer`CheckArgumentCount[expr, 1, 1] := ModuleScope[
   result = Catch[
     generalizedGridGraph[args], _ ? FailureQ, message[GeneralizedGridGraph, #, <|"expr" -> HoldForm[expr]|>] &];
   result /; !FailureQ[result]
 ];
-
-generalizedGridGraph[args___] /; !Developer`CheckArgumentCount[GeneralizedGridGraph[args], 1, 1] :=
-  throw[Failure[None, <||>]];
 
 generalizedGridGraph[dimensionSpecs_List, opts___] := (
   assertKnownOptions[GeneralizedGridGraph, {opts}];

--- a/Kernel/GeneralizedGridGraph.m
+++ b/Kernel/GeneralizedGridGraph.m
@@ -32,7 +32,7 @@ expr : GeneralizedGridGraph[args___] /; Developer`CheckArgumentCount[expr, 1, 1]
 ];
 
 generalizedGridGraph[dimensionSpecs_List, opts___] := (
-  checkKnownOptions[GeneralizedGridGraph, {opts}];
+  checkIfKnownOptions[GeneralizedGridGraph, {opts}];
   checkEnumOptionValue[GeneralizedGridGraph, "VertexNamingFunction", $vertexNamingFunctions, {opts}];
   generalizedGridGraphExplicit[toExplicitDimSpec /@ dimensionSpecs, opts]
 );

--- a/Kernel/HypergraphPlot.m
+++ b/Kernel/HypergraphPlot.m
@@ -201,9 +201,9 @@ parseStyles[newSpec_, elements_, oldSpec_, oldToNewTransform_] /;
 hypergraphPlot[___] := $Failed;
 
 correctHypergraphPlotOptionsQ[head_, edges_, opts_] := (
-  assertKnownOptions[head, opts];
-  assertEnumOptionValue[head, "HyperedgeRendering", $hyperedgeRenderings, opts];
-  assertCorrectVertexCoordinates[OptionValue[HypergraphPlot, opts, VertexCoordinates]];
+  checkKnownOptions[head, opts];
+  checkEnumOptionValue[head, "HyperedgeRendering", $hyperedgeRenderings, opts];
+  checkCorrectVertexCoordinates[OptionValue[HypergraphPlot, opts, VertexCoordinates]];
   And[
     correctHighlightQ[OptionValue[HypergraphPlot, opts, GraphHighlight]],
     correctSizeQ["Vertex size", OptionValue[HypergraphPlot, opts, VertexSize], {}],
@@ -224,7 +224,7 @@ correctHypergraphPlotOptionsQ[head_, edges_, opts_] := (
 declareMessage[General::invalidCoordinates,
                "Coordinates `coordinates` should be a list of rules from vertices to pairs of numbers."];
 
-assertCorrectVertexCoordinates[vertexCoordinates_] :=
+checkCorrectVertexCoordinates[vertexCoordinates_] :=
   If[!MatchQ[vertexCoordinates, Automatic | {(_ -> {Repeated[_ ? NumericQ, {2}]})...}],
     throw[Failure["invalidCoordinates", <|"coordinates" -> vertexCoordinates|>]]
   ];

--- a/Kernel/HypergraphPlot.m
+++ b/Kernel/HypergraphPlot.m
@@ -200,25 +200,26 @@ parseStyles[newSpec_, elements_, oldSpec_, oldToNewTransform_] /;
 
 hypergraphPlot[___] := $Failed;
 
-correctHypergraphPlotOptionsQ[head_, edges_, opts_] :=
-  knownOptionsQ[head, opts] &&
-  (And @@ (supportedOptionQ[head, ##, opts] & @@@ {
-      {"HyperedgeRendering", $hyperedgeRenderings}})) &&
-  correctVertexCoordinatesQ[OptionValue[HypergraphPlot, opts, VertexCoordinates]] &&
-  correctHighlightQ[OptionValue[HypergraphPlot, opts, GraphHighlight]] &&
-  correctSizeQ["Vertex size", OptionValue[HypergraphPlot, opts, VertexSize], {}] &&
-  correctSizeQ["Arrowhead length", OptionValue[HypergraphPlot, opts, "ArrowheadLength"], {Automatic}] &&
-  correctPlotStyleQ[OptionValue[HypergraphPlot, opts, PlotStyle]] &&
-  correctStyleLengthQ[
-    "vertices",
-    MatchQ[edges, {$hypergraphPattern..}],
-    Length[vertexList[edges]],
-    OptionValue[HypergraphPlot, opts, VertexStyle]] &&
-  And @@ (correctStyleLengthQ[
-    "edges",
-    MatchQ[edges, {$hypergraphPattern..}],
-    Length[edges],
-    OptionValue[HypergraphPlot, opts, #]] & /@ {EdgeStyle, "EdgePolygonStyle"});
+correctHypergraphPlotOptionsQ[head_, edges_, opts_] := (
+  assertKnownOptions[head, opts];
+  assertEnumOptionValue[head, "HyperedgeRendering", $hyperedgeRenderings, opts];
+  And[
+    correctVertexCoordinatesQ[OptionValue[HypergraphPlot, opts, VertexCoordinates]],
+    correctHighlightQ[OptionValue[HypergraphPlot, opts, GraphHighlight]],
+    correctSizeQ["Vertex size", OptionValue[HypergraphPlot, opts, VertexSize], {}],
+    correctSizeQ["Arrowhead length", OptionValue[HypergraphPlot, opts, "ArrowheadLength"], {Automatic}],
+    correctPlotStyleQ[OptionValue[HypergraphPlot, opts, PlotStyle]],
+    correctStyleLengthQ[
+      "vertices",
+      MatchQ[edges, {$hypergraphPattern..}],
+      Length[vertexList[edges]],
+      OptionValue[HypergraphPlot, opts, VertexStyle]],
+    And @@ (correctStyleLengthQ[
+      "edges",
+      MatchQ[edges, {$hypergraphPattern..}],
+      Length[edges],
+      OptionValue[HypergraphPlot, opts, #]] & /@ {EdgeStyle, "EdgePolygonStyle"})]
+);
 
 declareMessage[General::invalidCoordinates,
                "Coordinates `coordinates` should be a list of rules from vertices to pairs of numbers."];

--- a/Kernel/HypergraphPlot.m
+++ b/Kernel/HypergraphPlot.m
@@ -203,8 +203,8 @@ hypergraphPlot[___] := $Failed;
 correctHypergraphPlotOptionsQ[head_, edges_, opts_] := (
   assertKnownOptions[head, opts];
   assertEnumOptionValue[head, "HyperedgeRendering", $hyperedgeRenderings, opts];
+  assertCorrectVertexCoordinates[OptionValue[HypergraphPlot, opts, VertexCoordinates]];
   And[
-    correctVertexCoordinatesQ[OptionValue[HypergraphPlot, opts, VertexCoordinates]],
     correctHighlightQ[OptionValue[HypergraphPlot, opts, GraphHighlight]],
     correctSizeQ["Vertex size", OptionValue[HypergraphPlot, opts, VertexSize], {}],
     correctSizeQ["Arrowhead length", OptionValue[HypergraphPlot, opts, "ArrowheadLength"], {Automatic}],
@@ -224,10 +224,8 @@ correctHypergraphPlotOptionsQ[head_, edges_, opts_] := (
 declareMessage[General::invalidCoordinates,
                "Coordinates `coordinates` should be a list of rules from vertices to pairs of numbers."];
 
-correctVertexCoordinatesQ[vertexCoordinates_] :=
-  If[MatchQ[vertexCoordinates, Automatic | {(_ -> {Repeated[_ ? NumericQ, {2}]})...}],
-    True
-  ,
+assertCorrectVertexCoordinates[vertexCoordinates_] :=
+  If[!MatchQ[vertexCoordinates, Automatic | {(_ -> {Repeated[_ ? NumericQ, {2}]})...}],
     throw[Failure["invalidCoordinates", <|"coordinates" -> vertexCoordinates|>]]
   ];
 

--- a/Kernel/RulePlot.m
+++ b/Kernel/RulePlot.m
@@ -90,8 +90,8 @@ hypergraphRulesSpecQ[rulesSpec_Association ? wolframModelRulesSpecQ] :=
 hypergraphRulesSpecQ[rulesSpec_] := throw[Failure["invalidRules", <|"rules" -> rulesSpec|>]];
 
 correctOptionsQ[opts___] := (
-  assertKnownOptions[RulePlot, {opts}, $allowedOptions];
-  assertEnumOptionValue[RulePlot, Frame, {True, False, Automatic}, {opts}];
+  checkKnownOptions[RulePlot, {opts}, $allowedOptions];
+  checkEnumOptionValue[RulePlot, Frame, {True, False, Automatic}, {opts}];
   And[
     correctEdgeTypeQ[OptionValue[RulePlot, {opts}, "EdgeType"]],
     correctSpacingsQ[{opts}],

--- a/Kernel/RulePlot.m
+++ b/Kernel/RulePlot.m
@@ -90,14 +90,14 @@ hypergraphRulesSpecQ[rulesSpec_Association ? wolframModelRulesSpecQ] :=
 hypergraphRulesSpecQ[rulesSpec_] := throw[Failure["invalidRules", <|"rules" -> rulesSpec|>]];
 
 correctOptionsQ[opts___] := (
-  checkKnownOptions[RulePlot, {opts}, $allowedOptions];
+  checkIfKnownOptions[RulePlot, {opts}, $allowedOptions];
   checkEnumOptionValue[RulePlot, Frame, {True, False, Automatic}, {opts}];
+  checkHypergraphPlotOptions[RulePlot, Automatic, FilterRules[{opts}, Options[HypergraphPlot]]];
   And[
     correctEdgeTypeQ[OptionValue[RulePlot, {opts}, "EdgeType"]],
     correctSpacingsQ[{opts}],
     correctRulePartsAspectRatioQ[OptionValue[RulePlot, {opts}, "RulePartsAspectRatio"]],
-    And @@ (styleNotListQ[OptionValue[RulePlot, {opts}, #]] & /@ {VertexStyle, EdgeStyle, "EdgePolygonStyle"}),
-    correctHypergraphPlotOptionsQ[RulePlot, Automatic, FilterRules[{opts}, Options[HypergraphPlot]]]]
+    And @@ (styleNotListQ[OptionValue[RulePlot, {opts}, #]] & /@ {VertexStyle, EdgeStyle, "EdgePolygonStyle"})]
 );
 
 correctEdgeTypeQ[edgeType_] := If[MatchQ[edgeType, Alternatives @@ $edgeTypes],

--- a/Kernel/RulePlot.m
+++ b/Kernel/RulePlot.m
@@ -89,14 +89,16 @@ hypergraphRulesSpecQ[rulesSpec_Association ? wolframModelRulesSpecQ] :=
 
 hypergraphRulesSpecQ[rulesSpec_] := throw[Failure["invalidRules", <|"rules" -> rulesSpec|>]];
 
-correctOptionsQ[opts___] :=
-  knownOptionsQ[RulePlot, {opts}, $allowedOptions] &&
-  supportedOptionQ[RulePlot, Frame, {True, False, Automatic}, {opts}] &&
-  correctEdgeTypeQ[OptionValue[RulePlot, {opts}, "EdgeType"]] &&
-  correctSpacingsQ[{opts}] &&
-  correctRulePartsAspectRatioQ[OptionValue[RulePlot, {opts}, "RulePartsAspectRatio"]] &&
-  And @@ (styleNotListQ[OptionValue[RulePlot, {opts}, #]] & /@ {VertexStyle, EdgeStyle, "EdgePolygonStyle"}) &&
-  correctHypergraphPlotOptionsQ[RulePlot, Automatic, FilterRules[{opts}, Options[HypergraphPlot]]];
+correctOptionsQ[opts___] := (
+  assertKnownOptions[RulePlot, {opts}, $allowedOptions];
+  assertEnumOptionValue[RulePlot, Frame, {True, False, Automatic}, {opts}];
+  And[
+    correctEdgeTypeQ[OptionValue[RulePlot, {opts}, "EdgeType"]],
+    correctSpacingsQ[{opts}],
+    correctRulePartsAspectRatioQ[OptionValue[RulePlot, {opts}, "RulePartsAspectRatio"]],
+    And @@ (styleNotListQ[OptionValue[RulePlot, {opts}, #]] & /@ {VertexStyle, EdgeStyle, "EdgePolygonStyle"}),
+    correctHypergraphPlotOptionsQ[RulePlot, Automatic, FilterRules[{opts}, Options[HypergraphPlot]]]]
+);
 
 correctEdgeTypeQ[edgeType_] := If[MatchQ[edgeType, Alternatives @@ $edgeTypes],
   True

--- a/Kernel/TokenEventGraph.m
+++ b/Kernel/TokenEventGraph.m
@@ -19,16 +19,15 @@ SyntaxInformation[TokenEventGraph] = {
 
 declareRawProperty[tokenEventGraph, SetReplaceType[MultisetSubstitutionSystem, 0], TokenEventGraph];
 
-(* TODO: check option correctness *)
-tokenEventGraph[opts : OptionsPattern[]][Multihistory[_, data_]] /;
-    knownOptionsQ[TokenEventGraph, {opts}] := ModuleScope[
+tokenEventGraph[opts : OptionsPattern[]][Multihistory[_, data_]] := ModuleScope[
+  checkIfKnownOptions[tokenEventGraph, {opts}];
   inputsToEvents = Catenate[Thread /@ Thread[
     Map[MultihistoryToken, Rest @ Normal[data["EventInputs"]], {2}] ->
       MultihistoryEvent /@ Range[data["EventInputs"]["Length"] - 1]]];
   eventsToOutputs = Catenate[Thread /@ Thread[
     MultihistoryEvent /@ Range[data["EventOutputs"]["Length"] - 1] ->
       Map[MultihistoryToken, Rest @ Normal[data["EventOutputs"]], {2}]]];
-  Graph[
+  result = Graph[
     (* TODO: add a list of vertices *)
     Join[inputsToEvents, eventsToOutputs],
     (* TODO: rename styles in SetReplaceStyleData *)
@@ -36,7 +35,9 @@ tokenEventGraph[opts : OptionsPattern[]][Multihistory[_, data_]] /;
     VertexStyle -> parseVertexStyleRules[data][OptionValue[VertexStyle]],
     EdgeStyle -> style[$lightTheme][$causalGraphEdgeStyle],
     VertexLabels -> parseLabelRules[data][OptionValue[VertexLabels]],
-    opts]
+    opts];
+  If[!GraphQ[result], throw[Failure[None, <||>]]];
+  result
 ];
 
 declareMessage[TokenEventGraph::unexpectedArguments,

--- a/Kernel/TokenEventGraph.m
+++ b/Kernel/TokenEventGraph.m
@@ -7,28 +7,36 @@ PackageExport["MultihistoryToken"]
 PackageExport["MultihistoryEvent"]
 
 SetUsage @ "
-TokenEventGraph[multihistory$] yields the token-event graph of multihistory$.
+TokenEventGraph[multihistory$] yields the token-event graph of a multihistory$.
+* Token-event graph is a bipartite graph showing input and output tokens of every event.
 ";
 
+(* TODO: automatically create tooltip labels *)
+(* TODO: Automatic labels should do Placed[#, After] & *)
 Options[TokenEventGraph] = Options[tokenEventGraph] = Options[Graph];
 
 SyntaxInformation[TokenEventGraph] = {
   "ArgumentsPattern" -> {multihistory_, OptionsPattern[]},
   "OptionNames" -> Options[TokenEventGraph][[All, 1]]};
 
-declareRawProperty[tokenEventGraph, {MultisetSubstitutionSystem, 0}, TokenEventGraph];
+declareRawProperty[tokenEventGraph, SetReplaceType[MultisetSubstitutionSystem, 0], TokenEventGraph];
 
-tokenEventGraph[opts : OptionsPattern[]][multihistory_] /;
-    recognizedOptionsQ[TokenEventGraph[opts], TokenEventGraph, {opts}] || throw[Failure[None, <||>]] := ModuleScope[
-  (* TODO: needs to be implemented directly *)
-  wolframModelObject = SetReplaceTypeConvert[{WolframModelEvolutionObject, 2}] @ multihistory;
-  data = multihistory[[2]];
-  Switch[data["Scope"],
-    "Histories",
-      wolframModelObject["ExpressionsEventsGraph", opts],
-    "EventSet",
-      wolframModelObject["ExpressionsEventsGraph",
-                         GraphLayout -> Replace[OptionValue[GraphLayout], Automatic -> "SpringElectricalEmbedding"],
-                         opts]
-  ]
+(* TODO: check arguments count *)
+(* TODO: check option correctness *)
+tokenEventGraph[opts : OptionsPattern[]][Multihistory[_, data_]] := ModuleScope[
+  inputsToEvents = Catenate[Thread /@ Thread[
+    Map[MultihistoryToken, Rest @ Normal[data["EventInputs"]], {2}] ->
+      MultihistoryEvent /@ Range[data["EventInputs"]["Length"] - 1]]];
+  eventsToOutputs = Catenate[Thread /@ Thread[
+    MultihistoryEvent /@ Range[data["EventOutputs"]["Length"] - 1] ->
+      Map[MultihistoryToken, Rest @ Normal[data["EventOutputs"]], {2}]]];
+  Graph[
+    Join[inputsToEvents, eventsToOutputs],
+    opts,
+    (* TODO: rename styles in SetReplaceStyleData *)
+    (* TODO: implement layout *)
+    VertexStyle -> Replace[OptionValue[VertexStyle], Automatic -> {
+      _MultihistoryToken -> style[$lightTheme][$expressionVertexStyle],
+      _MultihistoryEvent -> style[$lightTheme][$causalGraphVertexStyle]}],
+    EdgeStyle -> Replace[OptionValue[EdgeStyle], Automatic -> style[$lightTheme][$causalGraphEdgeStyle]]]
 ];

--- a/Kernel/TokenEventGraph.m
+++ b/Kernel/TokenEventGraph.m
@@ -20,7 +20,8 @@ SyntaxInformation[TokenEventGraph] = {
 declareRawProperty[tokenEventGraph, SetReplaceType[MultisetSubstitutionSystem, 0], TokenEventGraph];
 
 (* TODO: check option correctness *)
-tokenEventGraph[opts : OptionsPattern[]][Multihistory[_, data_]] := ModuleScope[
+tokenEventGraph[opts : OptionsPattern[]][Multihistory[_, data_]] /;
+    knownOptionsQ[TokenEventGraph, {opts}] := ModuleScope[
   inputsToEvents = Catenate[Thread /@ Thread[
     Map[MultihistoryToken, Rest @ Normal[data["EventInputs"]], {2}] ->
       MultihistoryEvent /@ Range[data["EventInputs"]["Length"] - 1]]];

--- a/Kernel/TokenEventGraph.m
+++ b/Kernel/TokenEventGraph.m
@@ -13,6 +13,7 @@ TokenEventGraph[multihistory$] yields the token-event graph of a multihistory$.
 
 (* TODO: automatically create tooltip labels *)
 (* TODO: Automatic labels should do Placed[#, After] & *)
+(* TODO: disable Placed[After] for non-automatic layouts *)
 Options[TokenEventGraph] = Options[tokenEventGraph] = Options[Graph];
 
 SyntaxInformation[TokenEventGraph] = {
@@ -20,6 +21,12 @@ SyntaxInformation[TokenEventGraph] = {
   "OptionNames" -> Options[TokenEventGraph][[All, 1]]};
 
 declareRawProperty[tokenEventGraph, SetReplaceType[MultisetSubstitutionSystem, 0], TokenEventGraph];
+
+(*
+VertexLabels -> Replace[OptionValue[VertexLabels], Automatic -> {
+      MultihistoryToken[n_] :> Placed[{data["Expressions"]["Part", n], Row[{"Index: ", n}]}, {After, Tooltip}],
+      If[Length[data["Rules"]] > 1, MultihistoryEvent[n_] :> data["EventRuleIndices"]["Part", n + 1]]}]
+*)
 
 (* TODO: check arguments count *)
 (* TODO: check option correctness *)
@@ -31,12 +38,38 @@ tokenEventGraph[opts : OptionsPattern[]][Multihistory[_, data_]] := ModuleScope[
     MultihistoryEvent /@ Range[data["EventOutputs"]["Length"] - 1] ->
       Map[MultihistoryToken, Rest @ Normal[data["EventOutputs"]], {2}]]];
   Graph[
+    (* TODO: add a list of vertices *)
     Join[inputsToEvents, eventsToOutputs],
-    opts,
     (* TODO: rename styles in SetReplaceStyleData *)
     (* TODO: implement layout *)
     VertexStyle -> Replace[OptionValue[VertexStyle], Automatic -> {
       _MultihistoryToken -> style[$lightTheme][$expressionVertexStyle],
       _MultihistoryEvent -> style[$lightTheme][$causalGraphVertexStyle]}],
-    EdgeStyle -> Replace[OptionValue[EdgeStyle], Automatic -> style[$lightTheme][$causalGraphEdgeStyle]]]
+    EdgeStyle -> Replace[OptionValue[EdgeStyle], Automatic -> style[$lightTheme][$causalGraphEdgeStyle]],
+    VertexLabels -> parseVertexLabels[data][OptionValue[VertexLabels]],
+    opts]
 ];
+
+parseVertexLabels[data_][Automatic] := {
+  MultihistoryToken[n_] :> Placed[{data["Expressions"]["Part", n], Row[{"Index: ", n}]}, {After, Tooltip}],
+  If[Length[data["Rules"]] > 1, MultihistoryEvent[n_] :> data["EventRuleIndices"]["Part", n + 1]]};
+
+parseVertexLabels[data_][rules_List] := parseVertexLabels[data] /@ rules;
+
+parseVertexLabels[data_][func_Function] := parseVertexLabels[data][_ -> func];
+
+parseVertexLabels[data_][(ruleSymbol : Rule | RuleDelayed)[pattern_, func_Function]] := ruleSymbol[
+  Pattern[vertex, pattern],
+  generateLabel[data, func][vertex]];
+
+generateLabel[data_, func_][MultihistoryToken[n_]] := func[<|
+  "Index" :> n,
+  "TokenContents" :> data["Expressions"]["Part", n],
+  "RuleIndex" :> ""|>];
+
+generateLabel[data_, func_][MultihistoryEvent[n_]] := func[<|
+  "Index" :> n,
+  "TokenContents" :> "",
+  "RuleIndex" :> data["EventRuleIndices"]["Part", n + 1]|>];
+
+parseVertexLabels[data_][arg_] := arg;

--- a/Kernel/TokenEventGraph.m
+++ b/Kernel/TokenEventGraph.m
@@ -1,0 +1,34 @@
+Package["SetReplace`"]
+
+PackageImport["GeneralUtilities`"]
+
+PackageExport["TokenEventGraph"]
+PackageExport["MultihistoryToken"]
+PackageExport["MultihistoryEvent"]
+
+SetUsage @ "
+TokenEventGraph[multihistory$] yields the token-event graph of multihistory$.
+";
+
+Options[TokenEventGraph] = Options[tokenEventGraph] = Options[Graph];
+
+SyntaxInformation[TokenEventGraph] = {
+  "ArgumentsPattern" -> {multihistory_, OptionsPattern[]},
+  "OptionNames" -> Options[TokenEventGraph][[All, 1]]};
+
+declareRawProperty[tokenEventGraph, {MultisetSubstitutionSystem, 0}, TokenEventGraph];
+
+tokenEventGraph[opts : OptionsPattern[]][multihistory_] /;
+    recognizedOptionsQ[TokenEventGraph[opts], TokenEventGraph, {opts}] || throw[Failure[None, <||>]] := ModuleScope[
+  (* TODO: needs to be implemented directly *)
+  wolframModelObject = SetReplaceTypeConvert[{WolframModelEvolutionObject, 2}] @ multihistory;
+  data = multihistory[[2]];
+  Switch[data["Scope"],
+    "Histories",
+      wolframModelObject["ExpressionsEventsGraph", opts],
+    "EventSet",
+      wolframModelObject["ExpressionsEventsGraph",
+                         GraphLayout -> Replace[OptionValue[GraphLayout], Automatic -> "SpringElectricalEmbedding"],
+                         opts]
+  ]
+];

--- a/Kernel/TokenEventGraph.m
+++ b/Kernel/TokenEventGraph.m
@@ -31,10 +31,9 @@ tokenEventGraph[opts : OptionsPattern[]][Multihistory[_, data_]] := ModuleScope[
     Join[MultihistoryToken /@ Range @ data["Expressions"]["Length"],
          MultihistoryEvent /@ Range[data["EventInputs"]["Length"] - 1]], (* {} -> {} causes isolated events *)
     Join[inputsToEvents, eventsToOutputs],
-    (* TODO: rename styles in SetReplaceStyleData *)
     (* TODO: implement layout *)
     VertexStyle -> parseVertexStyleRules[data][OptionValue[VertexStyle]],
-    EdgeStyle -> style[$lightTheme][$causalGraphEdgeStyle],
+    EdgeStyle -> style[$lightTheme][$causalEdgeStyle],
     VertexLabels -> parseLabelRules[data][OptionValue[VertexLabels]],
     opts];
   If[!GraphQ[result], throw[Failure[None, <||>]]];
@@ -46,8 +45,8 @@ declareMessage[TokenEventGraph::unexpectedArguments,
 tokenEventGraph[___][_] := throw[Failure["unexpectedArguments", <||>]];
 
 parseVertexStyleRules[data_][Automatic] := parseElementRules[data] @ {
-  _MultihistoryToken -> style[$lightTheme][$expressionVertexStyle],
-  _MultihistoryEvent -> style[$lightTheme][$causalGraphVertexStyle]
+  _MultihistoryToken -> style[$lightTheme][$tokenVertexStyle],
+  _MultihistoryEvent -> style[$lightTheme][$eventVertexStyle]
 };
 parseVertexStyleRules[data_][arg_] := parseElementRules[data][arg];
 

--- a/Kernel/TokenEventGraph.m
+++ b/Kernel/TokenEventGraph.m
@@ -65,11 +65,13 @@ parseVertexLabels[data_][(ruleSymbol : Rule | RuleDelayed)[pattern_, func_Functi
 generateLabel[data_, func_][MultihistoryToken[n_]] := func[<|
   "Index" :> n,
   "TokenContents" :> data["Expressions"]["Part", n],
-  "RuleIndex" :> ""|>];
+  "RuleIndex" :> "",
+  "Generation" :> data["EventGenerations"]["Part", data["ExpressionCreatorEvents"]["Part", n]]|>];
 
 generateLabel[data_, func_][MultihistoryEvent[n_]] := func[<|
   "Index" :> n,
   "TokenContents" :> "",
-  "RuleIndex" :> data["EventRuleIndices"]["Part", n + 1]|>];
+  "RuleIndex" :> data["EventRuleIndices"]["Part", n + 1],
+  "Generation" :> data["EventGenerations"]["Part", n + 1]|>];
 
 parseVertexLabels[data_][arg_] := arg;

--- a/Kernel/TokenEventGraph.m
+++ b/Kernel/TokenEventGraph.m
@@ -28,7 +28,8 @@ tokenEventGraph[opts : OptionsPattern[]][Multihistory[_, data_]] := ModuleScope[
     MultihistoryEvent /@ Range[data["EventOutputs"]["Length"] - 1] ->
       Map[MultihistoryToken, Rest @ Normal[data["EventOutputs"]], {2}]]];
   result = Graph[
-    (* TODO: add a list of vertices *)
+    Join[MultihistoryToken /@ Range @ data["Expressions"]["Length"],
+         MultihistoryEvent /@ Range[data["EventInputs"]["Length"] - 1]], (* {} -> {} causes isolated events *)
     Join[inputsToEvents, eventsToOutputs],
     (* TODO: rename styles in SetReplaceStyleData *)
     (* TODO: implement layout *)

--- a/Kernel/TokenEventGraph.m
+++ b/Kernel/TokenEventGraph.m
@@ -11,7 +11,7 @@ TokenEventGraph[multihistory$] yields the token-event graph of a multihistory$.
 * Token-event graph is a bipartite graph showing input and output tokens of every event.
 ";
 
-Options[TokenEventGraph] = Options[tokenEventGraph] = Options[Graph];
+Options[TokenEventGraph] = Options[tokenEventGraph] = Normal @ Merge[{Options[Graph], {Background -> Automatic}}, Last];
 
 SyntaxInformation[TokenEventGraph] = {
   "ArgumentsPattern" -> {multihistory_, OptionsPattern[]},
@@ -33,8 +33,9 @@ tokenEventGraph[opts : OptionsPattern[]][Multihistory[_, data_]] := ModuleScope[
     Join[inputsToEvents, eventsToOutputs],
     (* TODO: implement layout *)
     VertexStyle -> parseVertexStyleRules[data][OptionValue[VertexStyle]],
-    EdgeStyle -> style[$lightTheme][$causalEdgeStyle],
+    EdgeStyle -> Replace[OptionValue[EdgeStyle], Automatic -> style[$lightTheme][$causalEdgeStyle]],
     VertexLabels -> parseLabelRules[data][OptionValue[VertexLabels]],
+    Background -> Replace[OptionValue[Background], Automatic -> style[$lightTheme][$tokenEventGraphBackground]],
     opts];
   If[!GraphQ[result], throw[Failure[None, <||>]]];
   result

--- a/Kernel/TokenEventGraph.m
+++ b/Kernel/TokenEventGraph.m
@@ -38,8 +38,11 @@ tokenEventGraph[opts : OptionsPattern[]][Multihistory[_, data_]] := ModuleScope[
       OptionValue[GraphLayout],
       Automatic :> {
         "LayeredDigraphEmbedding",
-        "VertexLayerPosition" ->
-          (vertexList /. parseElementRules[data][-(2 * "Generation" + Boole["Type" == MultihistoryEvent])])}],
+        "VertexLayerPosition" -> Replace[
+          vertexList,
+          parseElementRules[data][
+            {_MultihistoryToken -> -(2 * "Generation"), _MultihistoryEvent -> -(2 * "Generation" - 1)}],
+          {1}]}],
     Background -> Replace[OptionValue[Background], Automatic -> style[$lightTheme][$tokenEventGraphBackground]],
     opts];
   If[!GraphQ[result], throw[Failure[None, <||>]]];
@@ -68,7 +71,6 @@ parseElementRules[data_][arg_] := parseElementRules[data][_ -> arg];
 parseElementRules[data_][rule : _Rule | _RuleDelayed] := parseElementRules[data][{rule}];
 
 tokenPropertyRules[data_, n_] := <|
-  "Type" -> MultihistoryToken,
   "Index" -> n,
   "Content" :> data["Expressions"]["Part", n],
   "RuleIndex" -> "",
@@ -76,7 +78,6 @@ tokenPropertyRules[data_, n_] := <|
 |>;
 
 eventPropertyRules[data_, n_] := <|
-  "Type" -> MultihistoryEvent,
   "Index" -> n,
   "Content" :>
     Rule @@ (data["Expressions"]["Part", #] & /@ data[#]["Part", n + 1] & /@ {"EventInputs", "EventOutputs"}),

--- a/Kernel/TokenEventGraph.m
+++ b/Kernel/TokenEventGraph.m
@@ -11,9 +11,6 @@ TokenEventGraph[multihistory$] yields the token-event graph of a multihistory$.
 * Token-event graph is a bipartite graph showing input and output tokens of every event.
 ";
 
-(* TODO: automatically create tooltip labels *)
-(* TODO: Automatic labels should do Placed[#, After] & *)
-(* TODO: disable Placed[After] for non-automatic layouts *)
 Options[TokenEventGraph] = Options[tokenEventGraph] = Options[Graph];
 
 SyntaxInformation[TokenEventGraph] = {
@@ -21,12 +18,6 @@ SyntaxInformation[TokenEventGraph] = {
   "OptionNames" -> Options[TokenEventGraph][[All, 1]]};
 
 declareRawProperty[tokenEventGraph, SetReplaceType[MultisetSubstitutionSystem, 0], TokenEventGraph];
-
-(*
-VertexLabels -> Replace[OptionValue[VertexLabels], Automatic -> {
-      MultihistoryToken[n_] :> Placed[{data["Expressions"]["Part", n], Row[{"Index: ", n}]}, {After, Tooltip}],
-      If[Length[data["Rules"]] > 1, MultihistoryEvent[n_] :> data["EventRuleIndices"]["Part", n + 1]]}]
-*)
 
 (* TODO: check arguments count *)
 (* TODO: check option correctness *)
@@ -42,36 +33,44 @@ tokenEventGraph[opts : OptionsPattern[]][Multihistory[_, data_]] := ModuleScope[
     Join[inputsToEvents, eventsToOutputs],
     (* TODO: rename styles in SetReplaceStyleData *)
     (* TODO: implement layout *)
-    VertexStyle -> Replace[OptionValue[VertexStyle], Automatic -> {
-      _MultihistoryToken -> style[$lightTheme][$expressionVertexStyle],
-      _MultihistoryEvent -> style[$lightTheme][$causalGraphVertexStyle]}],
-    EdgeStyle -> Replace[OptionValue[EdgeStyle], Automatic -> style[$lightTheme][$causalGraphEdgeStyle]],
-    VertexLabels -> parseVertexLabels[data][OptionValue[VertexLabels]],
+    VertexStyle -> parseVertexStyleRules[data][OptionValue[VertexStyle]],
+    EdgeStyle -> style[$lightTheme][$causalGraphEdgeStyle],
+    VertexLabels -> parseLabelRules[data][OptionValue[VertexLabels]],
     opts]
 ];
 
-parseVertexLabels[data_][Automatic] := {
-  MultihistoryToken[n_] :> Placed[{data["Expressions"]["Part", n], Row[{"Index: ", n}]}, {After, Tooltip}],
-  If[Length[data["Rules"]] > 1, MultihistoryEvent[n_] :> data["EventRuleIndices"]["Part", n + 1]]};
+parseVertexStyleRules[data_][Automatic] := parseElementRules[data] @ {
+  _MultihistoryToken -> style[$lightTheme][$expressionVertexStyle],
+  _MultihistoryEvent -> style[$lightTheme][$causalGraphVertexStyle]
+};
+parseVertexStyleRules[data_][arg_] := parseElementRules[data][arg];
 
-parseVertexLabels[data_][rules_List] := parseVertexLabels[data] /@ rules;
+parseLabelRules[data_][Automatic] := parseElementRules[data] @ {
+  _MultihistoryToken -> Placed[{"Content", Row[{"Index: ", "Index"}]}, {After, Tooltip}],
+  _MultihistoryEvent ->
+    Placed[{If[Length[data["Rules"]] > 1, "RuleIndex", ""], Row[{"Index: ", "Index"}]}, {After, Tooltip}]
+};
+parseLabelRules[data_][arg_] := parseElementRules[data][arg];
 
-parseVertexLabels[data_][func_Function] := parseVertexLabels[data][_ -> func];
+parseElementRules[data_][arg_] := parseElementRules[data][_ -> arg];
 
-parseVertexLabels[data_][(ruleSymbol : Rule | RuleDelayed)[pattern_, func_Function]] := ruleSymbol[
-  Pattern[vertex, pattern],
-  generateLabel[data, func][vertex]];
+parseElementRules[data_][rule : _Rule | _RuleDelayed] := parseElementRules[data][{rule}];
 
-generateLabel[data_, func_][MultihistoryToken[n_]] := func[<|
-  "Index" :> n,
-  "TokenContents" :> data["Expressions"]["Part", n],
-  "RuleIndex" :> "",
-  "Generation" :> data["EventGenerations"]["Part", data["ExpressionCreatorEvents"]["Part", n]]|>];
+tokenPropertyRules[data_, n_] := <|
+  "Index" -> n,
+  "Content" :> data["Expressions"]["Part", n],
+  "RuleIndex" -> "",
+  "Generation" :> data["EventGenerations"]["Part", data["ExpressionCreatorEvents"]["Part", n]]
+|>;
 
-generateLabel[data_, func_][MultihistoryEvent[n_]] := func[<|
-  "Index" :> n,
-  "TokenContents" :> "",
+eventPropertyRules[data_, n_] := <|
+  "Index" -> n,
+  "Content" :>
+    Rule @@ (data["Expressions"]["Part", #] & /@ data[#]["Part", n + 1] & /@ {"EventInputs", "EventOutputs"}),
   "RuleIndex" :> data["EventRuleIndices"]["Part", n + 1],
-  "Generation" :> data["EventGenerations"]["Part", n + 1]|>];
+  "Generation" :> data["EventGenerations"]["Part", n + 1]
+|>;
 
-parseVertexLabels[data_][arg_] := arg;
+parseElementRules[data_][rules : {(_Rule | _RuleDelayed)..}] :=
+  #1[n_] :> Replace[#1[n], Append[rules /. #2[data, n], _ -> ""]] & @@@
+    {{MultihistoryToken, tokenPropertyRules}, {MultihistoryEvent, eventPropertyRules}};

--- a/Kernel/TokenEventGraph.m
+++ b/Kernel/TokenEventGraph.m
@@ -19,7 +19,6 @@ SyntaxInformation[TokenEventGraph] = {
 
 declareRawProperty[tokenEventGraph, SetReplaceType[MultisetSubstitutionSystem, 0], TokenEventGraph];
 
-(* TODO: check arguments count *)
 (* TODO: check option correctness *)
 tokenEventGraph[opts : OptionsPattern[]][Multihistory[_, data_]] := ModuleScope[
   inputsToEvents = Catenate[Thread /@ Thread[
@@ -38,6 +37,10 @@ tokenEventGraph[opts : OptionsPattern[]][Multihistory[_, data_]] := ModuleScope[
     VertexLabels -> parseLabelRules[data][OptionValue[VertexLabels]],
     opts]
 ];
+
+declareMessage[TokenEventGraph::unexpectedArguments,
+               "Only Multihistory and options are expected as TokenEventGraph arguments in `expr`"];
+tokenEventGraph[___][_] := throw[Failure["unexpectedArguments", <||>]];
 
 parseVertexStyleRules[data_][Automatic] := parseElementRules[data] @ {
   _MultihistoryToken -> style[$lightTheme][$expressionVertexStyle],

--- a/Kernel/WolframModel.m
+++ b/Kernel/WolframModel.m
@@ -191,16 +191,10 @@ expr : WolframModel[
       modifiedEvolution,
       WolframModel,
       #] &;
-    result = Catch @ Check[
+    result = Catch[
       If[modifiedEvolution =!= $Failed,
         If[ListQ[property],
-          Catch[
-            Check[propertyEvaluateWithOptions[#], Throw[$Failed, $propertyMessages]] & /@ property
-          ,
-            $propertyMessages
-          ,
-            $Failed &
-          ]
+          propertyEvaluateWithOptions /@ property
         ,
           propertyEvaluateWithOptions @ property
         ] /.
@@ -208,11 +202,10 @@ expr : WolframModel[
             WolframModelEvolutionObject[Join[data, <|$rules -> rulesSpec|>]]
       ,
         $Failed
-      ]
-    ,
-      $Failed
-    ];
-    result /; result =!= $Failed
+      ],
+      _ ? FailureQ,
+      message[WolframModel, #, <|"expr" -> HoldForm[expr]|>] &];
+    result /; !FailureQ[result]
   ];
 
 (* Operator form *)

--- a/Kernel/WolframModel.m
+++ b/Kernel/WolframModel.m
@@ -189,7 +189,6 @@ expr : WolframModel[
       overridenOptionValue["IncludePartialGenerations"],
       overridenOptionValue["IncludeBoundaryEvents"]][
       modifiedEvolution,
-      WolframModel,
       #] &;
     result = Catch[
       If[modifiedEvolution =!= $Failed,

--- a/Kernel/argumentsChecking.m
+++ b/Kernel/argumentsChecking.m
@@ -2,11 +2,11 @@ Package["SetReplace`"]
 
 PackageImport["GeneralUtilities`"]
 
-PackageScope["assertEnumOptionValue"]
-PackageScope["assertKnownOptions"]
+PackageScope["checkEnumOptionValue"]
+PackageScope["checkKnownOptions"]
 
 declareMessage[General::invalidFiniteOption, "Value `value` of option `opt` should be one of `choices` in `expr`."];
-assertEnumOptionValue[func_, optionToCheck_, validValues_, opts_] := ModuleScope[
+checkEnumOptionValue[func_, optionToCheck_, validValues_, opts_] := ModuleScope[
   value = OptionValue[func, {opts}, optionToCheck];
   supportedQ = MemberQ[validValues, value];
   If[!supportedQ,
@@ -15,7 +15,7 @@ assertEnumOptionValue[func_, optionToCheck_, validValues_, opts_] := ModuleScope
 ];
 
 declareMessage[General::optx, StringTemplate[General::optx]["`opt`", "`expr`"]];
-assertKnownOptions[func_, opts_, allowedOptions_ : Automatic] := With[{
+checkKnownOptions[func_, opts_, allowedOptions_ : Automatic] := With[{
     unknownOptions = Complement @@
       {Flatten[{opts}][[All, 1]], If[allowedOptions === Automatic, Options[func][[All, 1]], allowedOptions]}},
   If[Length[unknownOptions] > 0, throw[Failure["optx", <|"opt" -> unknownOptions[[1]]|>]]];

--- a/Kernel/argumentsChecking.m
+++ b/Kernel/argumentsChecking.m
@@ -2,27 +2,21 @@ Package["SetReplace`"]
 
 PackageImport["GeneralUtilities`"]
 
-PackageScope["supportedOptionQ"]
-PackageScope["knownOptionsQ"]
+PackageScope["assertEnumOptionValue"]
+PackageScope["assertKnownOptions"]
 
 declareMessage[General::invalidFiniteOption, "Value `value` of option `opt` should be one of `choices` in `expr`."];
-supportedOptionQ[func_, optionToCheck_, validValues_, opts_] := ModuleScope[
+assertEnumOptionValue[func_, optionToCheck_, validValues_, opts_] := ModuleScope[
   value = OptionValue[func, {opts}, optionToCheck];
   supportedQ = MemberQ[validValues, value];
   If[!supportedQ,
     throw[Failure["invalidFiniteOption", <|"value" -> value, "opt" -> optionToCheck, "choices" -> validValues|>]]
-  ,
-    True
-  ]
+  ];
 ];
 
 declareMessage[General::optx, StringTemplate[General::optx]["`opt`", "`expr`"]];
-knownOptionsQ[func_, opts_, allowedOptions_ : Automatic] := With[{
+assertKnownOptions[func_, opts_, allowedOptions_ : Automatic] := With[{
     unknownOptions = Complement @@
       {Flatten[{opts}][[All, 1]], If[allowedOptions === Automatic, Options[func][[All, 1]], allowedOptions]}},
-  If[Length[unknownOptions] > 0,
-    throw[Failure["optx", <|"opt" -> unknownOptions[[1]]|>]]
-  ,
-    True
-  ]
+  If[Length[unknownOptions] > 0, throw[Failure["optx", <|"opt" -> unknownOptions[[1]]|>]]];
 ];

--- a/Kernel/argumentsChecking.m
+++ b/Kernel/argumentsChecking.m
@@ -16,10 +16,10 @@ supportedOptionQ[func_, optionToCheck_, validValues_, opts_] := ModuleScope[
   ]
 ];
 
-declareMessage[General::optx, StringTemplate[General::optx]["`opt`, `expr`"]];
+declareMessage[General::optx, StringTemplate[General::optx]["`opt`", "`expr`"]];
 knownOptionsQ[func_, opts_, allowedOptions_ : Automatic] := With[{
     unknownOptions = Complement @@
-      {Flatten[opts][[All, 1]], If[allowedOptions === Automatic, Options[func][[All, 1]], allowedOptions]}},
+      {Flatten[{opts}][[All, 1]], If[allowedOptions === Automatic, Options[func][[All, 1]], allowedOptions]}},
   If[Length[unknownOptions] > 0,
     throw[Failure["optx", <|"opt" -> unknownOptions[[1]]|>]]
   ,

--- a/Kernel/argumentsChecking.m
+++ b/Kernel/argumentsChecking.m
@@ -5,23 +5,24 @@ PackageImport["GeneralUtilities`"]
 PackageScope["supportedOptionQ"]
 PackageScope["knownOptionsQ"]
 
-General::invalidFiniteOption =
-  "Value `2` of option `1` should be one of `3`.";
-
+declareMessage[General::invalidFiniteOption, "Value `value` of option `opt` should be one of `choices` in `expr`."];
 supportedOptionQ[func_, optionToCheck_, validValues_, opts_] := ModuleScope[
   value = OptionValue[func, {opts}, optionToCheck];
   supportedQ = MemberQ[validValues, value];
   If[!supportedQ,
-    Message[func::invalidFiniteOption, optionToCheck, value, validValues]
-  ];
-  supportedQ
+    throw[Failure["invalidFiniteOption", <|"value" -> value, "opt" -> optionToCheck, "choices" -> validValues|>]]
+  ,
+    True
+  ]
 ];
 
-knownOptionsQ[func_, funcCall_, opts_, allowedOptions_ : Automatic] := With[{
-    unknownOptions =
-      Complement @@ {opts[[All, 1]], If[allowedOptions === Automatic, Options[func][[All, 1]], allowedOptions]}},
+declareMessage[General::optx, StringTemplate[General::optx]["`opt`, `expr`"]];
+knownOptionsQ[func_, opts_, allowedOptions_ : Automatic] := With[{
+    unknownOptions = Complement @@
+      {Flatten[opts][[All, 1]], If[allowedOptions === Automatic, Options[func][[All, 1]], allowedOptions]}},
   If[Length[unknownOptions] > 0,
-    Message[func::optx, unknownOptions[[1]], funcCall]
-  ];
-  Length[unknownOptions] == 0
+    throw[Failure["optx", <|"opt" -> unknownOptions[[1]]|>]]
+  ,
+    True
+  ]
 ];

--- a/Kernel/argumentsChecking.m
+++ b/Kernel/argumentsChecking.m
@@ -3,7 +3,7 @@ Package["SetReplace`"]
 PackageImport["GeneralUtilities`"]
 
 PackageScope["checkEnumOptionValue"]
-PackageScope["checkKnownOptions"]
+PackageScope["checkIfKnownOptions"]
 
 declareMessage[General::invalidFiniteOption, "Value `value` of option `opt` should be one of `choices` in `expr`."];
 checkEnumOptionValue[func_, optionToCheck_, validValues_, opts_] := ModuleScope[
@@ -15,7 +15,7 @@ checkEnumOptionValue[func_, optionToCheck_, validValues_, opts_] := ModuleScope[
 ];
 
 declareMessage[General::optx, StringTemplate[General::optx]["`opt`", "`expr`"]];
-checkKnownOptions[func_, opts_, allowedOptions_ : Automatic] := With[{
+checkIfKnownOptions[func_, opts_, allowedOptions_ : Automatic] := With[{
     unknownOptions = Complement @@
       {Flatten[{opts}][[All, 1]], If[allowedOptions === Automatic, Options[func][[All, 1]], allowedOptions]}},
   If[Length[unknownOptions] > 0, throw[Failure["optx", <|"opt" -> unknownOptions[[1]]|>]]];

--- a/Kernel/setSubstitutionSystem.m
+++ b/Kernel/setSubstitutionSystem.m
@@ -73,9 +73,8 @@ setSubstitutionSystem[
 setReplaceRulesQ[rules_] :=
   MatchQ[rules, {(_Rule | _RuleDelayed)..} | _Rule | _RuleDelayed];
 
-General::invalidRules =
-  "The rule specification `1` should be either a Rule, RuleDelayed, or " ~~
-  "a List of them.";
+declareMessage[
+  General::invalidRules, "The rule specification `rules` should be either a Rule, RuleDelayed, or a List of them."];
 
 setSubstitutionSystem[
     rules_, set_, stepSpec_, caller_, returnOnAbortQ_, o : OptionsPattern[]] := 0 /;

--- a/Tests/TokenEventGraph.wlt
+++ b/Tests/TokenEventGraph.wlt
@@ -1,0 +1,414 @@
+<|
+  "TokenEventGraph" -> <|
+    "init" -> (
+      Attributes[Global`testUnevaluated] = Attributes[Global`testSymbolLeak] = {HoldAllComplete};
+      Global`testUnevaluated[args___] := SetReplace`PackageScope`testUnevaluated[VerificationTest, args];
+      Global`testSymbolLeak[args___] := SetReplace`PackageScope`testSymbolLeak[VerificationTest, args];
+
+      $sumsMultihistory = GenerateMultihistory[MultisetSubstitutionSystem[{a_, b_} /; a < b :> {a + b}]][Range[4]];
+
+      $largeHistory = GenerateSingleHistory[
+        MultisetSubstitutionSystem[{{x_, y_}, {x_, z_}} :> Module[{w}, {{x, y}, {x, w}, {y, w}, {z, w}}]],
+        MaxGeneration -> 6] @ {{0, 0}, {0, 0}, {0, 0}};
+    ),
+    "tests" -> With[{sumsMultihistory = $sumsMultihistory, largeHistory = $largeHistory}, {
+      testUnevaluated[TokenEventGraph[##] @ sumsMultihistory, {TokenEventGraph::unexpectedArguments}] & @@@
+        {{1}, {1, opt -> 2}},
+
+      testUnevaluated[TokenEventGraph[opt -> 2] @ sumsMultihistory, {TokenEventGraph::optx}],
+
+      VerificationTest @ AcyclicGraphQ @ TokenEventGraph @ largeHistory,
+      VerificationTest @ LoopFreeGraphQ @ TokenEventGraph @ largeHistory,
+
+      (* TODO: compare TEGs for equivalent hypergraph and multiset systems once implemented. *)
+
+      VerificationTest[
+        Length @ Cases[GraphPlot @ TokenEventGraph[VertexLabels -> 186173] @ sumsMultihistory, Text[186173, ___], All],
+        VertexCount @ TokenEventGraph @ sumsMultihistory],
+
+      (* TODO: test the rest of VertexLabels and VertexStyle functionality. *)
+
+      VerificationTest[
+        Options[TokenEventGraph[EdgeStyle -> Automatic, VertexStyle -> Automatic] @ sumsMultihistory,
+                {EdgeStyle, VertexStyle}],
+        Options[TokenEventGraph @ sumsMultihistory, {EdgeStyle, VertexStyle}]]
+    }]
+  |>
+|>
+
+(* TODO: go through the code in TokenEventGraph.m and tests all features there. *)
+
+(* TODO: adapt tests below to new syntax/functionality. *)
+
+(*        VerificationTest[
+          Options[
+            WolframModel[{{1, 2}} -> {{1, 3}, {3, 2}}, {{1, 1}}, 4][
+              type, EdgeStyle -> RGBColor[0.2, 0.3, 0.4], VertexStyle -> RGBColor[0.5, 0.6, 0.7]],
+            {EdgeStyle, VertexStyle}],
+          Options[
+            Graph[{1 -> 2}, EdgeStyle -> RGBColor[0.2, 0.3, 0.4], VertexStyle -> RGBColor[0.5, 0.6, 0.7]],
+            {EdgeStyle, VertexStyle}]
+        ],
+
+        VerificationTest[
+          Options[
+            WolframModel[{{1, 2}} -> {{1, 3}, {3, 2}}, {{1, 1}}, 4][type, GraphLayout -> Automatic],
+            GraphLayout],
+          Options[WolframModel[{{1, 2}} -> {{1, 3}, {3, 2}}, {{1, 1}}, 4][type], GraphLayout]
+        ],
+
+        VerificationTest[
+          Options[
+            WolframModel[{{1, 2}} -> {{1, 3}, {3, 2}}, {{1, 1}}, 4][
+              type, GraphLayout -> {"Dimension" -> 2, "VertexLayout" -> "CircularEmbedding"}],
+            GraphLayout
+          ],
+          Options[
+            Graph[
+              WolframModel[{{1, 2}} -> {{1, 3}, {3, 2}}, {{1, 1}}, 4, type],
+              GraphLayout -> {"Dimension" -> 2, "VertexLayout" -> "CircularEmbedding"}],
+            GraphLayout]
+        ]
+      }],
+
+      Table[With[{type = type}, {
+        With[{largeEvolution = $largeEvolution}, {
+          VerificationTest[
+            VertexCount[ReleaseHold[largeEvolution[type]]],
+            ReleaseHold[largeEvolution["EventsCount"]]
+          ],
+
+          VerificationTest[
+            GraphDistance[ReleaseHold[largeEvolution[type]], 1, ReleaseHold[largeEvolution["EventsCount"]]],
+            ReleaseHold[largeEvolution["TotalGenerationsCount"]] - 1
+          ],
+
+          VerificationTest[
+            Count[VertexInDegree[ReleaseHold[largeEvolution[type]]], 3],
+            ReleaseHold[largeEvolution["EventsCount"]] - 1
+          ]
+        }] /. HoldPattern[ReleaseHold[Hold[expr_]]] :> expr,
+
+        VerificationTest[
+          Through[{VertexList, Rule @@@ EdgeList[#] &}[WolframModel[
+            {{1, 2}, {2, 3}} -> {{1, 3}},
+            pathGraph17,
+            4][type]]],
+          {Range[15],
+            {1 -> 9, 2 -> 9, 3 -> 10, 4 -> 10, 5 -> 11, 6 -> 11, 7 -> 12, 8 -> 12, 9 -> 13, 10 -> 13, 11 -> 14,
+              12 -> 14, 13 -> 15, 14 -> 15}}
+        ],
+
+        VerificationTest[
+          Through[{VertexList, EdgeList}[WolframModel[
+            {{1, 2}, {2, 3}} -> {{1, 3}},
+            pathGraph17,
+            1][type]]],
+          {Range[8], {}}
+        ],
+
+        VerificationTest[
+          Through[{VertexList, Rule @@@ EdgeList[#] &}[WolframModel[
+            {{1, 2}, {2, 3}} -> {{1, 3}},
+            Partition[Range[17], 2, 1],
+            2][type]]],
+          {Range[12], {1 -> 9, 2 -> 9, 3 -> 10, 4 -> 10, 5 -> 11, 6 -> 11, 7 -> 12, 8 -> 12}}
+        ],
+
+        VerificationTest[
+          Through[{VertexList, Rule @@@ EdgeList[#] &}[WolframModel[
+            {{1, 2}} -> {},
+            {{1, 2}, {2, 3}},
+            2][type]]],
+          {{1, 2}, {}}
+        ],
+
+        VerificationTest[
+          Through[{VertexList, Rule @@@ EdgeList[#] &}[WolframModel[
+            {{1, 2}, {2, 3}} -> {{1, 3}},
+            {{1, 2}, {2, 3}, {3, 4}, {4, 5}},
+            2][type, "IncludeBoundaryEvents" -> #1]]],
+          {#2, #3}
+        ] & @@@ {
+          {None, {1, 2, 3}, {1 -> 3, 2 -> 3}},
+          {"Initial", {0, 1, 2, 3}, {0 -> 1, 0 -> 1, 0 -> 2, 0 -> 2, 1 -> 3, 2 -> 3}},
+          {"Final", {1, 2, 3, Infinity}, {1 -> 3, 2 -> 3, 3 -> Infinity}},
+          {All, {0, 1, 2, 3, Infinity}, {0 -> 1, 0 -> 1, 0 -> 2, 0 -> 2, 1 -> 3, 2 -> 3, 3 -> Infinity}}},
+
+        VerificationTest[
+          Through[{VertexList, Rule @@@ EdgeList[#] &}[WolframModel[
+            {{1, 2}} -> {{1, 3}, {3, 2}},
+            {{1, 2}},
+            2][type, "IncludeBoundaryEvents" -> #1]]],
+          {#2, #3}
+        ] & @@@ {
+          {None, {1, 2, 3}, {1 -> 2, 1 -> 3}},
+          {"Initial", {0, 1, 2, 3}, {0 -> 1, 1 -> 2, 1 -> 3}},
+          {"Final", {1, 2, 3, Infinity}, {1 -> 2, 1 -> 3, 2 -> Infinity, 2 -> Infinity, 3 -> Infinity, 3 -> Infinity}},
+          {All,
+            {0, 1, 2, 3, Infinity},
+            {0 -> 1, 1 -> 2, 1 -> 3, 2 -> Infinity, 2 -> Infinity, 3 -> Infinity, 3 -> Infinity}}},
+
+        VerificationTest[
+          Through[{VertexList, Rule @@@ EdgeList[#] &}[WolframModel[
+            {{1, 2}} -> {{1, 2}},
+            {{1, 2}},
+            0][type, "IncludeBoundaryEvents" -> #1]]],
+          {#2, #3}
+        ] & @@@ {
+          {None, {}, {}},
+          {"Initial", {0}, {}},
+          {"Final", {Infinity}, {}},
+          {All, {0, Infinity}, {0 -> Infinity}}}
+      }], {type, {"CausalGraph", "LayeredCausalGraph"}}],
+
+      VerificationTest[
+        Round[Replace[VertexCoordinates, FilterRules[AbsoluteOptions[WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4]["LayeredCausalGraph"]], VertexCoordinates]][[All, 2]]],
+        Floor[Log2[16 - Range[15]]]
+      ],
+
+      VerificationTest[
+        Round[Replace[VertexCoordinates, FilterRules[AbsoluteOptions[WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4]["LayeredCausalGraph", "IncludeBoundaryEvents" -> All]], VertexCoordinates]][[All, 2]]],
+        Join[{5}, Floor[Log2[16 - Range[15]]] + 1, {0}]
+      ],
+
+      VerificationTest[
+        Cases[VertexStyle /. Options[
+          WolframModel[{{1, 2}} -> {{1, 3}, {3, 2}}, {{1, 1}}, 4, #, "IncludeBoundaryEvents" -> "Initial"],
+          VertexStyle][[1]], _Rule, {1}],
+        {0 -> _},
+        SameTest -> MatchQ
+      ] & /@ {"CausalGraph", "LayeredCausalGraph"},
+
+      VerificationTest[
+        Sort[Cases[VertexStyle /. Options[
+          WolframModel[{{1, 2}} -> {{1, 3}, {3, 2}}, {{1, 1}}, 4, "CausalGraph", "IncludeBoundaryEvents" -> #],
+          VertexStyle][[1]], _Rule, {1}]],
+        #2,
+        SameTest -> MatchQ
+      ] & @@@ {{None, {}}, {"Final", {Infinity -> _}}, {All, {0 -> _, Infinity -> _}}},
+
+      With[{largeEvolution = $largeEvolution}, {
+        VerificationTest[
+          Count[VertexInDegree[ReleaseHold[largeEvolution["ExpressionsEventsGraph"]]], 1],
+          ReleaseHold[largeEvolution["ExpressionsCountTotal"]] - 3
+        ],
+
+        VerificationTest[
+          VertexCount[ReleaseHold[largeEvolution["ExpressionsEventsGraph"]]],
+          ReleaseHold[largeEvolution["EventsCount"] + largeEvolution["ExpressionsCountTotal"]]
+        ],
+
+        VerificationTest[
+          GraphDistance[
+            ReleaseHold[largeEvolution["ExpressionsEventsGraph"]],
+            {"Expression", 1},
+            {"Expression", ReleaseHold[largeEvolution["ExpressionsCountTotal"]]}],
+          2 ReleaseHold[largeEvolution["TotalGenerationsCount"]]
+        ],
+
+        VerificationTest[
+          Count[VertexInDegree[ReleaseHold[largeEvolution["ExpressionsEventsGraph"]]], 3],
+          ReleaseHold[largeEvolution["EventsCount"]]
+        ]
+      }] /. HoldPattern[ReleaseHold[Hold[expr_]]] :> expr,
+
+      VerificationTest[
+        Through[{VertexList, Rule @@@ EdgeList[#] &}[WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4]["ExpressionsEventsGraph"]]],
+        {Join[Thread[{"Event", Range[15]}], Thread[{"Expression", Range[31]}]],
+         Join[
+          Thread[Thread[{"Event", Range[15]}] -> Thread[{"Expression", Range[17, 31]}]],
+          Thread[Thread[{"Expression", Range[30]}] -> Thread[{"Event", Quotient[Range[30] + 1, 2]}]]]}
+      ],
+
+      VerificationTest[
+        Through[{VertexList, Rule @@@ EdgeList[#] &}[WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          1]["ExpressionsEventsGraph"]]],
+        {Join[Thread[{"Event", Range[8]}], Thread[{"Expression", Range[24]}]],
+         Join[
+          Thread[Thread[{"Event", Range[8]}] -> Thread[{"Expression", Range[17, 24]}]],
+          Thread[Thread[{"Expression", Range[16]}] -> Thread[{"Event", Quotient[Range[16] + 1, 2]}]]]}
+      ],
+
+      VerificationTest[
+        Through[{VertexList, Rule @@@ EdgeList[#] &}[WolframModel[
+          {{1, 2}} -> {},
+          {{1, 2}, {2, 3}},
+          2]["ExpressionsEventsGraph"]]],
+        {{{"Event", 1}, {"Event", 2}, {"Expression", 1}, {"Expression", 2}},
+         {{"Expression", 1} -> {"Event", 1}, {"Expression", 2} -> {"Event", 2}}}
+      ],
+
+      VerificationTest[
+        Sort[VertexLabels /. FilterRules[AbsoluteOptions[WolframModel[{{1, 2}} -> {{1, 3}, {3, 2}}, {{1, 1}}, 2][
+          "ExpressionsEventsGraph", VertexLabels -> Automatic]], VertexLabels]],
+        {{"Event", 1} -> None, {"Event", 2} -> None, {"Event", 3} -> None,
+         {"Expression", 1} -> "{1, 1}", {"Expression", 2} -> "{1, 2}", {"Expression", 3} -> "{2, 1}",
+         {"Expression", 4} -> "{1, 3}", {"Expression", 5} -> "{3, 2}", {"Expression", 6} -> "{2, 4}",
+         {"Expression", 7} -> "{4, 1}"}
+      ],
+
+      VerificationTest[
+        Sort[VertexLabels /. FilterRules[AbsoluteOptions[WolframModel[
+          {{1, 2}} -> {{1, 3}, {3, 2}}, {{1, 1}}, 2][
+            "ExpressionsEventsGraph", VertexLabels -> Automatic, "IncludeBoundaryEvents" -> All]], VertexLabels]],
+        {{"Event", 0} -> "Initial event", {"Event", 1} -> None, {"Event", 2} -> None, {"Event", 3} -> None,
+         {"Event", Infinity} -> "Final event",
+         {"Expression", 1} -> "{1, 1}", {"Expression", 2} -> "{1, 2}", {"Expression", 3} -> "{2, 1}",
+         {"Expression", 4} -> "{1, 3}", {"Expression", 5} -> "{3, 2}", {"Expression", 6} -> "{2, 4}",
+         {"Expression", 7} -> "{4, 1}"}
+      ],
+
+      VerificationTest[
+        Sort[VertexLabels /. FilterRules[AbsoluteOptions[WolframModel[
+          {{{1, 2}} -> {{1, 2, 3}}, {{1, 2, 3}} -> {{1, 2}, {2, 3}}}, {{1, 1}}, 2][
+            "ExpressionsEventsGraph", VertexLabels -> Automatic]], VertexLabels]],
+        {{"Event", 1} -> "Rule 1", {"Event", 2} -> "Rule 2",
+         {"Expression", 1} -> "{1, 1}", {"Expression", 2} -> "{1, 1, 2}", {"Expression", 3} -> "{1, 1}",
+         {"Expression", 4} -> "{1, 2}"}
+      ],
+
+      VerificationTest[
+        Sort[VertexLabels /. FilterRules[AbsoluteOptions[WolframModel[
+          {{{1, 2}} -> {{1, 2, 3}}, {{1, 2, 3}} -> {{1, 2}, {2, 3}}}, {{1, 1}}, 1][
+            "ExpressionsEventsGraph", VertexLabels -> Automatic]], VertexLabels]],
+        {{"Event", 1} -> "Rule 1", {"Expression", 1} -> "{1, 1}", {"Expression", 2} -> "{1, 1, 2}"}
+      ],
+
+      VerificationTest[
+        Sort[VertexLabels /. FilterRules[AbsoluteOptions[WolframModel[
+          {{{1, 2}} -> {{1, 2, 3}}, {{1, 2, 3}} -> {{1, 2}, {2, 3}}}, {{1, 1}}, 1][
+            "ExpressionsEventsGraph", VertexLabels -> Placed[Automatic, After]]], VertexLabels]],
+        {{"Event", 1} -> Placed["Rule 1", After], {"Expression", 1} -> Placed["{1, 1}", After],
+         {"Expression", 2} -> Placed["{1, 1, 2}", After]}
+      ],
+
+      VerificationTest[
+        Sort[VertexLabels /. FilterRules[AbsoluteOptions[WolframModel[
+          {{{1, 2}} -> {{1, 2, 3}}, {{1, 2, 3}} -> {{1, 2}, {2, 3}}}, {{1, 1}}, 2][
+            "ExpressionsEventsGraph", VertexLabels -> Automatic, "IncludeBoundaryEvents" -> All]], VertexLabels]],
+        {{"Event", 0} -> "Initial event", {"Event", 1} -> "Rule 1", {"Event", 2} -> "Rule 2",
+         {"Event", Infinity} -> "Final event",
+         {"Expression", 1} -> "{1, 1}", {"Expression", 2} -> "{1, 1, 2}", {"Expression", 3} -> "{1, 1}",
+         {"Expression", 4} -> "{1, 2}"}
+      ],
+
+      VerificationTest[
+        Through[{VertexList, Rule @@@ EdgeList[#] &}[WolframModel[
+          {{{1, 2}} -> {{1, 2, 3}}, {{1, 2, 3}} -> {{1, 2}, {2, 3}}}, {{1, 1}}, 2][
+            "ExpressionsEventsGraph", "IncludeBoundaryEvents" -> #1]]],
+        {#2, #3}
+      ] & @@@ {
+        {None,
+         {{"Event", 1}, {"Event", 2}, {"Expression", 1}, {"Expression", 2}, {"Expression", 3}, {"Expression", 4}},
+         {{"Event", 1} -> {"Expression", 2}, {"Event", 2} -> {"Expression", 3}, {"Event", 2} -> {"Expression", 4},
+          {"Expression", 1} -> {"Event", 1}, {"Expression", 2} -> {"Event", 2}}},
+        {"Initial",
+         {{"Event", 0}, {"Event", 1}, {"Event", 2}, {"Expression", 1}, {"Expression", 2}, {"Expression", 3},
+          {"Expression", 4}},
+         {{"Event", 0} -> {"Expression", 1}, {"Event", 1} -> {"Expression", 2}, {"Event", 2} -> {"Expression", 3},
+          {"Event", 2} -> {"Expression", 4}, {"Expression", 1} -> {"Event", 1},
+          {"Expression", 2} -> {"Event", 2}}},
+        {"Final",
+         {{"Event", 1}, {"Event", 2}, {"Event", Infinity}, {"Expression", 1}, {"Expression", 2}, {"Expression", 3},
+          {"Expression", 4}},
+         {{"Event", 1} -> {"Expression", 2}, {"Event", 2} -> {"Expression", 3}, {"Event", 2} -> {"Expression", 4},
+          {"Expression", 1} -> {"Event", 1}, {"Expression", 2} -> {"Event", 2},
+          {"Expression", 3} -> {"Event", Infinity}, {"Expression", 4} -> {"Event", Infinity}}},
+        {All,
+         {{"Event", 0}, {"Event", 1}, {"Event", 2}, {"Event", Infinity}, {"Expression", 1}, {"Expression", 2},
+          {"Expression", 3}, {"Expression", 4}},
+         {{"Event", 0} -> {"Expression", 1}, {"Event", 1} -> {"Expression", 2}, {"Event", 2} -> {"Expression", 3},
+          {"Event", 2} -> {"Expression", 4}, {"Expression", 1} -> {"Event", 1}, {"Expression", 2} -> {"Event", 2},
+          {"Expression", 3} -> {"Event", Infinity}, {"Expression", 4} -> {"Event", Infinity}}}},
+
+      VerificationTest[
+        Through[{VertexList, Rule @@@ EdgeList[#] &}[WolframModel[{{1, 2}} -> {{1, 2}}, {{1, 2}}, 0][
+          "ExpressionsEventsGraph", "IncludeBoundaryEvents" -> #1]]],
+        {#2, #3}
+      ] & @@@ {
+        {None, {{"Expression", 1}}, {}},
+        {"Initial", {{"Event", 0}, {"Expression", 1}}, {{"Event", 0} -> {"Expression", 1}}},
+        {"Final", {{"Event", Infinity}, {"Expression", 1}}, {{"Expression", 1} -> {"Event", Infinity}}},
+        {All,
+         {{"Event", 0}, {"Event", Infinity}, {"Expression", 1}},
+         {{"Event", 0} -> {"Expression", 1}, {"Expression", 1} -> {"Event", Infinity}}}},
+
+      VerificationTest[
+        Round[Replace[VertexCoordinates, FilterRules[AbsoluteOptions[WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4]["ExpressionsEventsGraph"]], VertexCoordinates]][[All, 2]]],
+        Join[2 Floor[Log2[16 - Range[15]]] + 1, 2 Floor[Log2[32 - Range[31]]]]
+      ],
+
+      VerificationTest[
+        Round[Replace[VertexCoordinates, FilterRules[AbsoluteOptions[WolframModel[
+          {{1, 2}, {2, 3}} -> {{1, 3}},
+          pathGraph17,
+          4]["ExpressionsEventsGraph", "IncludeBoundaryEvents" -> All]], VertexCoordinates]][[All, 2]]],
+        Join[Join[{10}, 2 Floor[Log2[16 - Range[15]]] + 2, {0}], 2 Floor[Log2[32 - Range[31]]] + 1]
+      ],
+
+      Function[{events, sameStyleQ},
+        VerificationTest[
+          SameQ @@ (events /. (VertexStyle /. Options[
+            WolframModel[
+              {{1, 2}} -> {{1, 3}, {3, 2}}, {{1, 1}}, 2, "ExpressionsEventsGraph", "IncludeBoundaryEvents" -> All],
+            VertexStyle])),
+          sameStyleQ
+        ]
+      ] @@@ {
+        {{{"Event", 1}, {"Event", 2}}, True},
+        {{{"Event", 0}, {"Event", 1}}, False},
+        {{{"Event", 0}, {"Event", Infinity}}, False},
+        {{{"Event", 1}, {"Event", Infinity}}, False}},
+
+      VerificationTest[
+        WolframModel[{{{1, 2}, {2, 3}} -> {{1, 3}}, {{1, 2}, {1, 2}} -> {}},
+                     {{1, 2}, {2, 3}, {3, 4}, {2, 5}},
+                     Infinity,
+                     "EventSelectionFunction" -> None]["CausalGraph"],
+        Graph[Range[7], {1 -> 4, 2 -> 5, 4 -> 6, 4 -> 7, 5 -> 6, 5 -> 7}],
+        SameTest -> sameGraphQ
+      ],
+
+      VerificationTest[
+        WolframModel[{{{1, 2}, {2, 3}} -> {{1, 3}}, {{1, 2}, {1, 2}} -> {}},
+                     {{1, 2}, {2, 3}, {3, 4}, {2, 5}},
+                     Infinity,
+                     "EventSelectionFunction" -> None]["CausalGraph", "IncludeBoundaryEvents" -> All],
+        Graph[Append[Range[0, 7], Infinity],
+              {0 -> 1, 0 -> 1, 0 -> 2, 0 -> 2, 0 -> 3, 0 -> 3, 0 -> 4, 0 -> 5, 1 -> 4, 2 -> 5, 4 -> 6, 4 -> 7, 5 -> 6,
+               5 -> 7, 3 -> Infinity}],
+        SameTest -> sameGraphQ
+      ],
+
+      VerificationTest[
+        WolframModel[{{{1, 2}, {2, 3}} -> {{1, 3}}, {{1, 2}, {1, 2}} -> {}},
+                     {{1, 2}, {2, 3}, {3, 4}, {2, 5}},
+                     Infinity,
+                     "EventSelectionFunction" -> None]["ExpressionsEventsGraph"],
+        Graph[
+          Join[Thread[{"Event", Range[7]}], Thread[{"Expression", Range[9]}]],
+          {{"Expression", 1} -> {"Event", 1}, {"Expression", 1} -> {"Event", 3}, {"Expression", 1} -> {"Event", 5},
+           {"Expression", 2} -> {"Event", 1}, {"Expression", 2} -> {"Event", 2}, {"Expression", 3} -> {"Event", 2},
+           {"Expression", 3} -> {"Event", 4}, {"Expression", 4} -> {"Event", 3}, {"Event", 1} -> {"Expression", 5},
+           {"Event", 2} -> {"Expression", 6}, {"Event", 3} -> {"Expression", 7}, {"Expression", 5} -> {"Event", 4},
+           {"Expression", 6} -> {"Event", 5}, {"Event", 4} -> {"Expression", 8}, {"Event", 5} -> {"Expression", 9},
+           {"Expression", 8} -> {"Event", 6}, {"Expression", 8} -> {"Event", 7}, {"Expression", 9} -> {"Event", 6},
+           {"Expression", 9} -> {"Event", 7}}],
+        SameTest -> sameGraphQ
+      ]
+    }*)

--- a/Tests/WolframModelEvolutionObject.wlt
+++ b/Tests/WolframModelEvolutionObject.wlt
@@ -2109,7 +2109,7 @@
 
       With[{evo = WolframModel[{{1, 2}} -> {{1, 3}, {3, 2}}, {{1, 1}}, <|"MaxEvents" -> 30|>]}, testUnevaluated[
         evo["FinalStatePlot", VertexSize -> x],
-        {HypergraphPlot::invalidSize}
+        {WolframModelEvolutionObject::invalidSize}
       ]],
 
       With[{evolution = WolframModel[{{{1, 2}, {2, 3}} -> {{1, 3}}, {{1, 2}, {1, 2}} -> {}},
@@ -2153,7 +2153,7 @@
 
       With[{evo = WolframModel[{{1, 2}} -> {{1, 3}, {3, 2}}, {{1, 1}}, <|"MaxEvents" -> 30|>]}, testUnevaluated[
         evo["StatesPlotsList", VertexSize -> x],
-        {HypergraphPlot::invalidSize}
+        {WolframModelEvolutionObject::invalidSize}
       ]],
 
       With[{evolution = WolframModel[{{{1, 2}, {2, 3}} -> {{1, 3}}, {{1, 2}, {1, 2}} -> {}},
@@ -2209,7 +2209,7 @@
 
       With[{evo = WolframModel[{{1, 2}} -> {{1, 3}, {3, 2}}, {{1, 1}}, <|"MaxEvents" -> 30|>]}, testUnevaluated[
         evo["EventsStatesPlotsList", VertexSize -> x],
-        {HypergraphPlot::invalidSize}
+        {WolframModelEvolutionObject::invalidSize}
       ]],
 
       VerificationTest[


### PR DESCRIPTION
## Changes

* Implements `TokenEventGraph` property for `MultisetSubstitutionSystem`.
* Strings in `VertexStyle` and `VertexLabels` automatically get replaced with their values for a specific token. This works on both sides of the rules. Currently supported are `"Index"`, `"Content"`, `"RuleIndex"` and `"Generation"`.
* `Automatic` labels now place tooltips with the token/event index.

## Comments

* There are no tests or documentation yet.
* Any thoughts on how `parseElementRules` can be optimized without loss of generality?
* This currently contains both #666 and #667. It will need to be rebased to remove both before merging.

## Examples

* Use token/event properties in the style & labels:

```wl
In[] := TokenEventGraph[
    VertexStyle -> GrayLevel["Generation" / 2], VertexLabels -> "Content", ImageSize -> 600] @
  GenerateMultihistory[MultisetSubstitutionSystem[{a_, b_} /; a <= b :> {a + b}]] @ {1, 2, 3}
```

<img width="766.2" alt="image" src="https://user-images.githubusercontent.com/1479325/127358586-151058bd-f8c6-4042-911e-22aec051ff3b.png">

* Only label some events & tokens based on their properties:

```wl
In[] := TokenEventGraph[VertexLabels -> (_ /; "Generation" === 1 -> "Index"), ImageSize -> 600] @
  GenerateMultihistory[MultisetSubstitutionSystem[{a_, b_} /; a <= b :> {a + b}]] @ {1, 2, 3}
```

<img width="766.2" alt="image" src="https://user-images.githubusercontent.com/1479325/127358817-bee76766-e2d0-4627-ae35-4748e1ce739e.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/659)
<!-- Reviewable:end -->
