### PR TITLE
Fix for disappearing Around

### DIFF
--- a/performanceTest.wls
+++ b/performanceTest.wls
@@ -106,6 +106,7 @@ Check[
     result
   ];
 
+  speedupDelta[0, new_] := Infinity;
   speedupDelta[old_, new_] := (old - new) / old;
 
   $gitRepo = GitOpen[$SetReplaceRoot];

--- a/performanceTest.wls
+++ b/performanceTest.wls
@@ -155,11 +155,9 @@ Check[
     magnitudeMean = If[Head[magnitude] === Around, magnitude["Value"], magnitude];
     magnitudeUncertainty = If[Head[magnitude] === Around, magnitude["Uncertainty"], 0];
     If[5 * magnitudeUncertainty < Abs[magnitudeMean], If[magnitudeMean > 0, $greenColor, $redColor], $whiteColor] <>
-    Replace[
-      FirstCase[
-        MakeBoxes[magnitude, StandardForm],
-        TemplateBox[{value_, error_}, "Around", ___] :> value <> " \[PlusMinus] " <> error <> " %"],
-      _ ? MissingQ :> ToString[magnitudeMean] <> " \[PlusMinus] 0 %"] <>
+    FirstCase[MakeBoxes[magnitude, StandardForm],
+              TemplateBox[{value_, error_}, "Around", ___] :> value <> " \[PlusMinus] " <> error <> " %",
+              ToString[magnitudeMean] <> " \[PlusMinus] 0 %"] <>
     $endColor
   ];
 

--- a/performanceTest.wls
+++ b/performanceTest.wls
@@ -151,10 +151,15 @@ Check[
 
   differenceString[meanAround_] := With[{
       magnitude = QuantityMagnitude[meanAround, "Percent"]},
-    If[5 * magnitude[[2]] < Abs[magnitude[[1]]], If[magnitude[[1]] > 0, $greenColor, $redColor], $whiteColor] <>
-    FirstCase[
-      MakeBoxes[magnitude, StandardForm],
-      TemplateBox[{value_, error_}, "Around", ___] :> value <> " \[PlusMinus] " <> error <> " %"] <>
+    (* Due to a weed in WL, MeanAround does not return Around if all values in the list are the same. *)
+    magnitudeMean = If[Head[magnitude] === Around, magnitude["Value"], magnitude];
+    magnitudeUncertainty = If[Head[magnitude] === Around, magnitude["Uncertainty"], 0];
+    If[5 * magnitudeUncertainty < Abs[magnitudeMean], If[magnitudeMean > 0, $greenColor, $redColor], $whiteColor] <>
+    Replace[
+      FirstCase[
+        MakeBoxes[magnitude, StandardForm],
+        TemplateBox[{value_, error_}, "Around", ___] :> value <> " \[PlusMinus] " <> error <> " %"],
+      _ ? MissingQ :> ToString[magnitudeMean] <> " \[PlusMinus] 0 %"] <>
     $endColor
   ];
 


### PR DESCRIPTION
## Changes

* Due to a weed in Wolfram Language, `MeanAround` sometimes returns a single number instead of `Around`:

  ```wl
  In[] := MeanAround[{1, 1}]
  Out[] = 1
  ```

* This [sometimes breaks](https://app.circleci.com/pipelines/github/maxitg/SetReplace/2018/workflows/77fc408b-d297-4efd-a01c-517ad52ccb54/jobs/4997) `./performanceTest.wls`, which assumes `Around` objects.
* This PR implements a workaround for this case.

## Examples

* This case happens rarely, but manually assigning `magnitude = 1` in `differenceString` does work:

```console
$ ./performanceTest.wls master HEAD 2
Testing 811551cb72de921652430003f56fcf25e4a8f185

Testing 19264e2884d6d3cc6831c1fcce2941225f7d217c

Single-input rule                       1 ± 0 %
Medium rule                             1 ± 0 %
Sequential rule                         1 ± 0 %
Large rule                              1 ± 0 %
Exponential-match-count rule            1 ± 0 %
CA emulator                             1 ± 0 %
Multiset addition                       1 ± 0 %
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/663)
<!-- Reviewable:end -->
