### PR TITLE
Throw exceptions in argumentsChecking, HypergraphPlot, WolframModel and GeneralizedGridGraph

### DIFF
--- a/Kernel/GeneralizedGridGraph.m
+++ b/Kernel/GeneralizedGridGraph.m
@@ -32,8 +32,8 @@ expr : GeneralizedGridGraph[args___] /; Developer`CheckArgumentCount[expr, 1, 1]
 ];
 
 generalizedGridGraph[dimensionSpecs_List, opts___] := (
-  assertKnownOptions[GeneralizedGridGraph, {opts}];
-  assertEnumOptionValue[GeneralizedGridGraph, "VertexNamingFunction", $vertexNamingFunctions, {opts}];
+  checkKnownOptions[GeneralizedGridGraph, {opts}];
+  checkEnumOptionValue[GeneralizedGridGraph, "VertexNamingFunction", $vertexNamingFunctions, {opts}];
   generalizedGridGraphExplicit[toExplicitDimSpec /@ dimensionSpecs, opts]
 );
 

--- a/Kernel/GeneralizedGridGraph.m
+++ b/Kernel/GeneralizedGridGraph.m
@@ -34,13 +34,11 @@ expr : GeneralizedGridGraph[args___] := ModuleScope[
 generalizedGridGraph[args___] /; !Developer`CheckArgumentCount[GeneralizedGridGraph[args], 1, 1] :=
   throw[Failure[None, <||>]];
 
-generalizedGridGraph[args_, opts___] /; !knownOptionsQ[GeneralizedGridGraph, {opts}] := 0;
-
-generalizedGridGraph[args_, opts___] /;
-    !supportedOptionQ[GeneralizedGridGraph, "VertexNamingFunction", $vertexNamingFunctions, {opts}] := 0;
-
-generalizedGridGraph[dimensionSpecs_List, opts___] :=
-  generalizedGridGraphExplicit[toExplicitDimSpec /@ dimensionSpecs, opts];
+generalizedGridGraph[dimensionSpecs_List, opts___] := (
+  assertKnownOptions[GeneralizedGridGraph, {opts}];
+  assertEnumOptionValue[GeneralizedGridGraph, "VertexNamingFunction", $vertexNamingFunctions, {opts}];
+  generalizedGridGraphExplicit[toExplicitDimSpec /@ dimensionSpecs, opts]
+);
 
 declareMessage[GeneralizedGridGraph::dimsNotList, "Dimensions specification `dimSpec` should be a list."];
 

--- a/Kernel/GeneralizedGridGraph.m
+++ b/Kernel/GeneralizedGridGraph.m
@@ -25,14 +25,11 @@ FE`Evaluate[FEPrivate`AddSpecialArgCompletion["GeneralizedGridGraph" -> {{"Circu
 
 (* Implementation *)
 
-expr : GeneralizedGridGraph[args___] := ModuleScope[
+expr : GeneralizedGridGraph[args___] /; Developer`CheckArgumentCount[expr, 1, 1] := ModuleScope[
   result = Catch[
     generalizedGridGraph[args], _ ? FailureQ, message[GeneralizedGridGraph, #, <|"expr" -> HoldForm[expr]|>] &];
   result /; !FailureQ[result]
 ];
-
-generalizedGridGraph[args___] /; !Developer`CheckArgumentCount[GeneralizedGridGraph[args], 1, 1] :=
-  throw[Failure[None, <||>]];
 
 generalizedGridGraph[dimensionSpecs_List, opts___] := (
   assertKnownOptions[GeneralizedGridGraph, {opts}];

--- a/Kernel/GeneralizedGridGraph.m
+++ b/Kernel/GeneralizedGridGraph.m
@@ -25,21 +25,21 @@ FE`Evaluate[FEPrivate`AddSpecialArgCompletion["GeneralizedGridGraph" -> {{"Circu
 
 (* Implementation *)
 
-expr : GeneralizedGridGraph[args___] /; Developer`CheckArgumentCount[expr, 1, 1] := ModuleScope[
+expr : GeneralizedGridGraph[args___] /; CheckArguments[expr, 1] := ModuleScope[
   result = Catch[
     generalizedGridGraph[args], _ ? FailureQ, message[GeneralizedGridGraph, #, <|"expr" -> HoldForm[expr]|>] &];
   result /; !FailureQ[result]
 ];
 
-generalizedGridGraph[dimensionSpecs_List, opts___] := (
-  checkIfKnownOptions[GeneralizedGridGraph, {opts}];
-  checkEnumOptionValue[GeneralizedGridGraph, "VertexNamingFunction", $vertexNamingFunctions, {opts}];
-  generalizedGridGraphExplicit[toExplicitDimSpec /@ dimensionSpecs, opts]
+generalizedGridGraph[dimensionSpecs_List, options___] := (
+  checkIfKnownOptions[GeneralizedGridGraph, {options}];
+  checkEnumOptionValue[GeneralizedGridGraph, "VertexNamingFunction", $vertexNamingFunctions, {options}];
+  generalizedGridGraphExplicit[toExplicitDimSpec /@ dimensionSpecs, options]
 );
 
 declareMessage[GeneralizedGridGraph::dimsNotList, "Dimensions specification `dimSpec` should be a list."];
 
-generalizedGridGraph[dimensionSpecs : Except[_List], opts___] :=
+generalizedGridGraph[dimensionSpecs : Except[_List], options___] :=
   throw[Failure["dimsNotList", <|"dimSpec" -> dimensionSpecs|>]];
 
 toExplicitDimSpec[spec_] := toExplicitDimSpec[spec, spec];
@@ -60,8 +60,8 @@ declareMessage[GeneralizedGridGraph::invalidDimSpec, "Dimension specification `d
 
 toExplicitDimSpec[originalSpec_, _ -> _List] := throw[Failure["invalidDimSpec", <|"dimSpec" -> originalSpec|>]];
 
-generalizedGridGraphExplicit[dimensionSpecs_, opts___] := ModuleScope[
-  {edgeStyle, vertexNamingFunction} = OptionValue[GeneralizedGridGraph, {opts}, {EdgeStyle, "VertexNamingFunction"}];
+generalizedGridGraphExplicit[dimensionSpecs_, options___] := ModuleScope[
+  {edgeStyle, vertexNamingFunction} = OptionValue[GeneralizedGridGraph, {options}, {EdgeStyle, "VertexNamingFunction"}];
   edges = singleDimensionEdges[dimensionSpecs, #] & /@ Range[Length[dimensionSpecs]];
   directionalEdgeStyle = EdgeStyle -> If[
       ListQ[edgeStyle] && Length[edgeStyle] == Length[dimensionSpecs] && AllTrue[edgeStyle, Head[#] =!= Rule &],
@@ -76,7 +76,7 @@ generalizedGridGraphExplicit[dimensionSpecs_, opts___] := ModuleScope[
       Catenate[edges],
       GraphLayout -> graphLayout[dimensionSpecs],
       directionalEdgeStyle],
-    If[directionalEdgeStyle[[2]] === Nothing, {opts}, FilterRules[{opts}, Except[EdgeStyle]]]]
+    If[directionalEdgeStyle[[2]] === Nothing, {options}, FilterRules[{options}, Except[EdgeStyle]]]]
 ];
 
 renameVertices[Automatic][graph_] := IndexGraph[graph];

--- a/Kernel/GeneralizedGridGraph.m
+++ b/Kernel/GeneralizedGridGraph.m
@@ -32,7 +32,7 @@ expr : GeneralizedGridGraph[args___] /; Developer`CheckArgumentCount[expr, 1, 1]
 ];
 
 generalizedGridGraph[dimensionSpecs_List, opts___] := (
-  checkKnownOptions[GeneralizedGridGraph, {opts}];
+  checkIfKnownOptions[GeneralizedGridGraph, {opts}];
   checkEnumOptionValue[GeneralizedGridGraph, "VertexNamingFunction", $vertexNamingFunctions, {opts}];
   generalizedGridGraphExplicit[toExplicitDimSpec /@ dimensionSpecs, opts]
 );

--- a/Kernel/HypergraphPlot.m
+++ b/Kernel/HypergraphPlot.m
@@ -201,9 +201,9 @@ parseStyles[newSpec_, elements_, oldSpec_, oldToNewTransform_] /;
 hypergraphPlot[___] := $Failed;
 
 correctHypergraphPlotOptionsQ[head_, edges_, opts_] := (
-  assertKnownOptions[head, opts];
-  assertEnumOptionValue[head, "HyperedgeRendering", $hyperedgeRenderings, opts];
-  assertCorrectVertexCoordinates[OptionValue[HypergraphPlot, opts, VertexCoordinates]];
+  checkKnownOptions[head, opts];
+  checkEnumOptionValue[head, "HyperedgeRendering", $hyperedgeRenderings, opts];
+  checkCorrectVertexCoordinates[OptionValue[HypergraphPlot, opts, VertexCoordinates]];
   And[
     correctHighlightQ[OptionValue[HypergraphPlot, opts, GraphHighlight]],
     correctSizeQ["Vertex size", OptionValue[HypergraphPlot, opts, VertexSize], {}],
@@ -224,7 +224,7 @@ correctHypergraphPlotOptionsQ[head_, edges_, opts_] := (
 declareMessage[General::invalidCoordinates,
                "Coordinates `coordinates` should be a list of rules from vertices to pairs of numbers."];
 
-assertCorrectVertexCoordinates[vertexCoordinates_] :=
+checkCorrectVertexCoordinates[vertexCoordinates_] :=
   If[!MatchQ[vertexCoordinates, Automatic | {(_ -> {Repeated[_ ? NumericQ, {2}]})...}],
     throw[Failure["invalidCoordinates", <|"coordinates" -> vertexCoordinates|>]]
   ];

--- a/Kernel/HypergraphPlot.m
+++ b/Kernel/HypergraphPlot.m
@@ -200,25 +200,26 @@ parseStyles[newSpec_, elements_, oldSpec_, oldToNewTransform_] /;
 
 hypergraphPlot[___] := $Failed;
 
-correctHypergraphPlotOptionsQ[head_, edges_, opts_] :=
-  knownOptionsQ[head, opts] &&
-  (And @@ (supportedOptionQ[head, ##, opts] & @@@ {
-      {"HyperedgeRendering", $hyperedgeRenderings}})) &&
-  correctVertexCoordinatesQ[OptionValue[HypergraphPlot, opts, VertexCoordinates]] &&
-  correctHighlightQ[OptionValue[HypergraphPlot, opts, GraphHighlight]] &&
-  correctSizeQ["Vertex size", OptionValue[HypergraphPlot, opts, VertexSize], {}] &&
-  correctSizeQ["Arrowhead length", OptionValue[HypergraphPlot, opts, "ArrowheadLength"], {Automatic}] &&
-  correctPlotStyleQ[OptionValue[HypergraphPlot, opts, PlotStyle]] &&
-  correctStyleLengthQ[
-    "vertices",
-    MatchQ[edges, {$hypergraphPattern..}],
-    Length[vertexList[edges]],
-    OptionValue[HypergraphPlot, opts, VertexStyle]] &&
-  And @@ (correctStyleLengthQ[
-    "edges",
-    MatchQ[edges, {$hypergraphPattern..}],
-    Length[edges],
-    OptionValue[HypergraphPlot, opts, #]] & /@ {EdgeStyle, "EdgePolygonStyle"});
+correctHypergraphPlotOptionsQ[head_, edges_, opts_] := (
+  assertKnownOptions[head, opts];
+  assertEnumOptionValue[head, "HyperedgeRendering", $hyperedgeRenderings, opts];
+  And[
+    correctVertexCoordinatesQ[OptionValue[HypergraphPlot, opts, VertexCoordinates]],
+    correctHighlightQ[OptionValue[HypergraphPlot, opts, GraphHighlight]],
+    correctSizeQ["Vertex size", OptionValue[HypergraphPlot, opts, VertexSize], {}],
+    correctSizeQ["Arrowhead length", OptionValue[HypergraphPlot, opts, "ArrowheadLength"], {Automatic}],
+    correctPlotStyleQ[OptionValue[HypergraphPlot, opts, PlotStyle]],
+    correctStyleLengthQ[
+      "vertices",
+      MatchQ[edges, {$hypergraphPattern..}],
+      Length[vertexList[edges]],
+      OptionValue[HypergraphPlot, opts, VertexStyle]],
+    And @@ (correctStyleLengthQ[
+      "edges",
+      MatchQ[edges, {$hypergraphPattern..}],
+      Length[edges],
+      OptionValue[HypergraphPlot, opts, #]] & /@ {EdgeStyle, "EdgePolygonStyle"})]
+);
 
 declareMessage[General::invalidCoordinates,
                "Coordinates `coordinates` should be a list of rules from vertices to pairs of numbers."];

--- a/Kernel/HypergraphPlot.m
+++ b/Kernel/HypergraphPlot.m
@@ -203,8 +203,8 @@ hypergraphPlot[___] := $Failed;
 correctHypergraphPlotOptionsQ[head_, edges_, opts_] := (
   assertKnownOptions[head, opts];
   assertEnumOptionValue[head, "HyperedgeRendering", $hyperedgeRenderings, opts];
+  assertCorrectVertexCoordinates[OptionValue[HypergraphPlot, opts, VertexCoordinates]];
   And[
-    correctVertexCoordinatesQ[OptionValue[HypergraphPlot, opts, VertexCoordinates]],
     correctHighlightQ[OptionValue[HypergraphPlot, opts, GraphHighlight]],
     correctSizeQ["Vertex size", OptionValue[HypergraphPlot, opts, VertexSize], {}],
     correctSizeQ["Arrowhead length", OptionValue[HypergraphPlot, opts, "ArrowheadLength"], {Automatic}],
@@ -224,10 +224,8 @@ correctHypergraphPlotOptionsQ[head_, edges_, opts_] := (
 declareMessage[General::invalidCoordinates,
                "Coordinates `coordinates` should be a list of rules from vertices to pairs of numbers."];
 
-correctVertexCoordinatesQ[vertexCoordinates_] :=
-  If[MatchQ[vertexCoordinates, Automatic | {(_ -> {Repeated[_ ? NumericQ, {2}]})...}],
-    True
-  ,
+assertCorrectVertexCoordinates[vertexCoordinates_] :=
+  If[!MatchQ[vertexCoordinates, Automatic | {(_ -> {Repeated[_ ? NumericQ, {2}]})...}],
     throw[Failure["invalidCoordinates", <|"coordinates" -> vertexCoordinates|>]]
   ];
 

--- a/Kernel/HypergraphPlot.m
+++ b/Kernel/HypergraphPlot.m
@@ -14,8 +14,8 @@ PackageScope["hypergraphEmbedding"]
 (* Documentation *)
 
 SetUsage @ "
-HypergraphPlot[hypergraph$, opts$] plots an ordered hypergraph$ represented as a list of vertex lists.
-HypergraphPlot[hypergraph$, 'Cyclic', opts$] plots a 'Cyclic' hypergraph$ instead.
+HypergraphPlot[hypergraph$, options$] plots an ordered hypergraph$ represented as a list of vertex lists.
+HypergraphPlot[hypergraph$, 'Cyclic', options$] plots a 'Cyclic' hypergraph$ instead.
 ";
 
 $plotStyleAutomatic = <|
@@ -127,7 +127,7 @@ hypergraphPlot[edges : $hypergraphPattern,
                o : OptionsPattern[]] := ModuleScope[
   checkHypergraphPlotOptions[HypergraphPlot, edges, {o}];
   ScopeVariable[optionValue];
-  optionValue[opt_] := OptionValue[HypergraphPlot, {o}, opt];
+  optionValue[option_] := OptionValue[HypergraphPlot, {o}, option];
   vertices = vertexList[edges];
   (* these are either single styles or lists, one style for each element *)
   {highlightedVertexStyles, highlightedEdgeLineStyles, highlightedEdgePolygonStyles} =
@@ -202,20 +202,20 @@ parseStyles[newSpec_, elements_, oldSpec_, oldToNewTransform_] /;
 
 hypergraphPlot[___] := $Failed;
 
-checkHypergraphPlotOptions[head_, edges_, opts_] := (
-  checkIfKnownOptions[head, opts];
-  checkEnumOptionValue[head, "HyperedgeRendering", $hyperedgeRenderings, opts];
-  checkVertexCoordinates[OptionValue[HypergraphPlot, opts, VertexCoordinates]];
-  checkHighlight[OptionValue[HypergraphPlot, opts, GraphHighlight]];
-  checkSize["Vertex size", OptionValue[HypergraphPlot, opts, VertexSize], {}];
-  checkSize["Arrowhead length", OptionValue[HypergraphPlot, opts, "ArrowheadLength"], {Automatic}];
-  checkPlotStyle[OptionValue[HypergraphPlot, opts, PlotStyle]];
+checkHypergraphPlotOptions[head_, edges_, options_] := (
+  checkIfKnownOptions[head, options];
+  checkEnumOptionValue[head, "HyperedgeRendering", $hyperedgeRenderings, options];
+  checkVertexCoordinates[OptionValue[HypergraphPlot, options, VertexCoordinates]];
+  checkHighlight[OptionValue[HypergraphPlot, options, GraphHighlight]];
+  checkSize["Vertex size", OptionValue[HypergraphPlot, options, VertexSize], {}];
+  checkSize["Arrowhead length", OptionValue[HypergraphPlot, options, "ArrowheadLength"], {Automatic}];
+  checkPlotStyle[OptionValue[HypergraphPlot, options, PlotStyle]];
   checkStyleLength["vertices",
                    MatchQ[edges, {$hypergraphPattern..}],
                    Length[vertexList[edges]],
-                   OptionValue[HypergraphPlot, opts, VertexStyle]];
+                   OptionValue[HypergraphPlot, options, VertexStyle]];
   checkStyleLength[
-      "edges", MatchQ[edges, {$hypergraphPattern..}], Length[edges], OptionValue[HypergraphPlot, opts, #]] & /@
+      "edges", MatchQ[edges, {$hypergraphPattern..}], Length[edges], OptionValue[HypergraphPlot, options, #]] & /@
     {EdgeStyle, "EdgePolygonStyle"};
 );
 

--- a/Kernel/RulePlot.m
+++ b/Kernel/RulePlot.m
@@ -90,8 +90,8 @@ hypergraphRulesSpecQ[rulesSpec_Association ? wolframModelRulesSpecQ] :=
 hypergraphRulesSpecQ[rulesSpec_] := throw[Failure["invalidRules", <|"rules" -> rulesSpec|>]];
 
 correctOptionsQ[opts___] := (
-  assertKnownOptions[RulePlot, {opts}, $allowedOptions];
-  assertEnumOptionValue[RulePlot, Frame, {True, False, Automatic}, {opts}];
+  checkKnownOptions[RulePlot, {opts}, $allowedOptions];
+  checkEnumOptionValue[RulePlot, Frame, {True, False, Automatic}, {opts}];
   And[
     correctEdgeTypeQ[OptionValue[RulePlot, {opts}, "EdgeType"]],
     correctSpacingsQ[{opts}],

--- a/Kernel/RulePlot.m
+++ b/Kernel/RulePlot.m
@@ -39,8 +39,8 @@ Protect[RulePlot];
 (* Evaluation *)
 
 WolframModel /: expr : RulePlot[
-    wm : WolframModel[args___] /; Quiet[Developer`CheckArgumentCount[wm, 1, 1]], opts___] := ModuleScope[
-  result = Catch[rulePlot$parse[{args}, {opts}],
+    wm : WolframModel[args___] /; Quiet[CheckArguments[wm, 1]], options___] := ModuleScope[
+  result = Catch[rulePlot$parse[{args}, {options}],
                  _ ? FailureQ,
                  message[RulePlot, #, <|"expr" -> HoldForm[expr]|>] &];
   result /; !FailureQ[result]
@@ -49,8 +49,8 @@ WolframModel /: expr : RulePlot[
 (* Evolution object *)
 
 WolframModelEvolutionObject /:
-    expr : RulePlot[evo : WolframModelEvolutionObject[_ ? evolutionDataQ], opts___] := ModuleScope[
-  result = Catch[rulePlot$parse[{evo["Rules"]}, {opts}],
+    expr : RulePlot[evo : WolframModelEvolutionObject[_ ? evolutionDataQ], options___] := ModuleScope[
+  result = Catch[rulePlot$parse[{evo["Rules"]}, {options}],
                  _ ? FailureQ,
                  message[RulePlot, #, <|"expr" -> HoldForm[expr]|>] &];
   result /; !FailureQ[result]
@@ -61,13 +61,13 @@ WolframModelEvolutionObject /:
 rulePlot$parse[{
     rulesSpec_,
     o : OptionsPattern[]},
-    {opts : OptionsPattern[]}] /; recognizedOptionsQ[RulePlot[rulesSpec, o], WolframModel, {o}] := (
+    {options : OptionsPattern[]}] /; recognizedOptionsQ[RulePlot[rulesSpec, o], WolframModel, {o}] := (
   checkHypergraphRulesSpec[rulesSpec];
-  checkOptions[opts];
-  rulePlot[rulesSpec, ##, FilterRules[{opts}, $defaultBehaviorGraphicsOptions]] & @@
+  checkOptions[options];
+  rulePlot[rulesSpec, ##, FilterRules[{options}, $defaultBehaviorGraphicsOptions]] & @@
     OptionValue[
       RulePlot,
-      {opts},
+      {options},
       {"EdgeType", GraphHighlightStyle, "HyperedgeRendering", VertexCoordinates, VertexLabels, Frame, FrameStyle,
         PlotLegends, Spacings, "RulePartsAspectRatio", PlotStyle, VertexStyle, EdgeStyle, "EdgePolygonStyle",
         VertexSize, "ArrowheadLength", Background}]
@@ -88,14 +88,14 @@ checkHypergraphRulesSpec[rulesSpec_Association ? wolframModelRulesSpecQ] :=
 
 checkHypergraphRulesSpec[rulesSpec_] := throw[Failure["invalidRules", <|"rules" -> rulesSpec|>]];
 
-checkOptions[opts___] := (
-  checkIfKnownOptions[RulePlot, {opts}, $allowedOptions];
-  checkEnumOptionValue[RulePlot, Frame, {True, False, Automatic}, {opts}];
-  checkEdgeType[OptionValue[RulePlot, {opts}, "EdgeType"]];
-  checkSpacings[{opts}];
-  checkRulePartsAspectRatio[OptionValue[RulePlot, {opts}, "RulePartsAspectRatio"]];
-  checkStyleIsList[OptionValue[RulePlot, {opts}, #]] & /@ {VertexStyle, EdgeStyle, "EdgePolygonStyle"};
-  checkHypergraphPlotOptions[RulePlot, Automatic, FilterRules[{opts}, Options[HypergraphPlot]]];
+checkOptions[options___] := (
+  checkIfKnownOptions[RulePlot, {options}, $allowedOptions];
+  checkEnumOptionValue[RulePlot, Frame, {True, False, Automatic}, {options}];
+  checkEdgeType[OptionValue[RulePlot, {options}, "EdgeType"]];
+  checkSpacings[{options}];
+  checkRulePartsAspectRatio[OptionValue[RulePlot, {options}, "RulePartsAspectRatio"]];
+  checkStyleIsList[OptionValue[RulePlot, {options}, #]] & /@ {VertexStyle, EdgeStyle, "EdgePolygonStyle"};
+  checkHypergraphPlotOptions[RulePlot, Automatic, FilterRules[{options}, Options[HypergraphPlot]]];
 );
 
 checkEdgeType[edgeType_] := If[!MatchQ[edgeType, Alternatives @@ $edgeTypes],
@@ -105,8 +105,8 @@ checkEdgeType[edgeType_] := If[!MatchQ[edgeType, Alternatives @@ $edgeTypes],
 declareMessage[
   RulePlot::invalidSpacings, "Spacings `spacings` should be either a single number, or a two-by-two list."];
 
-checkSpacings[opts_] := ModuleScope[
-  spacings = OptionValue[RulePlot, opts, Spacings];
+checkSpacings[options_] := ModuleScope[
+  spacings = OptionValue[RulePlot, options, Spacings];
   correctQ = MatchQ[spacings, Automatic | (_ ? NumericQ) | {Repeated[{Repeated[_ ? NumericQ, {2}]}, {2}]}];
   If[!correctQ, throw[Failure["invalidSpacings", <|"spacings" -> spacings|>]]];
 ];
@@ -142,12 +142,12 @@ rulePlot[
     vertexSize_,
     arrowheadLength_,
     background_,
-    graphicsOpts_] :=
+    graphicsOptions_] :=
   If[PlotLegends === None, Identity, Legended[#, Replace[plotLegends, "Text" -> Placed[StandardForm[rules], Below]]] &][
     rulePlot[
       rules, edgeType, graphHighlightStyle, hyperedgeRendering, vertexCoordinates, vertexLabels, frameQ, frameStyle,
         spacings, rulePartsAspectRatio, plotStyle, vertexStyle, edgeStyle, edgePolygonStyle, vertexSize,
-        arrowheadLength, background, graphicsOpts]
+        arrowheadLength, background, graphicsOptions]
   ];
 
 rulePlot[
@@ -168,11 +168,11 @@ rulePlot[
     vertexSize_,
     arrowheadLength_,
     background_,
-    graphicsOpts_] :=
+    graphicsOptions_] :=
   rulePlot[
     {rule}, edgeType, graphHighlightStyle, hyperedgeRendering, vertexCoordinates, vertexLabels, frameQ, frameStyle,
       spacings, rulePartsAspectRatio, plotStyle, vertexStyle, edgeStyle, edgePolygonStyle, vertexSize, arrowheadLength,
-      background, graphicsOpts];
+      background, graphicsOptions];
 
 rulePlot[
     rules_List,
@@ -192,7 +192,7 @@ rulePlot[
     vertexSize_,
     arrowheadLength_,
     background_,
-    graphicsOpts_] := ModuleScope[
+    graphicsOptions_] := ModuleScope[
   explicitSpacings = toListSpacings[Replace[spacings, Automatic -> style[$lightTheme][$ruleSidesSpacing]]];
   hypergraphPlots =
     rulePartsPlots[
@@ -212,7 +212,7 @@ rulePlot[
     If[frameQ === True || (frameQ === Automatic && Length[rules] > 1), frameStyle, None]];
   Graphics[
     shapes,
-    graphicsOpts,
+    graphicsOptions,
     Background -> Replace[background, Automatic -> style[$lightTheme][$ruleBackground]],
     PlotRange -> plotRange,
     ImageSizeRaw -> style[$lightTheme][$ruleImageSizePerPlotRange] (plotRange[[1, 2]] - plotRange[[1, 1]])]

--- a/Kernel/RulePlot.m
+++ b/Kernel/RulePlot.m
@@ -90,14 +90,14 @@ hypergraphRulesSpecQ[rulesSpec_Association ? wolframModelRulesSpecQ] :=
 hypergraphRulesSpecQ[rulesSpec_] := throw[Failure["invalidRules", <|"rules" -> rulesSpec|>]];
 
 correctOptionsQ[opts___] := (
-  checkKnownOptions[RulePlot, {opts}, $allowedOptions];
+  checkIfKnownOptions[RulePlot, {opts}, $allowedOptions];
   checkEnumOptionValue[RulePlot, Frame, {True, False, Automatic}, {opts}];
+  checkHypergraphPlotOptions[RulePlot, Automatic, FilterRules[{opts}, Options[HypergraphPlot]]];
   And[
     correctEdgeTypeQ[OptionValue[RulePlot, {opts}, "EdgeType"]],
     correctSpacingsQ[{opts}],
     correctRulePartsAspectRatioQ[OptionValue[RulePlot, {opts}, "RulePartsAspectRatio"]],
-    And @@ (styleNotListQ[OptionValue[RulePlot, {opts}, #]] & /@ {VertexStyle, EdgeStyle, "EdgePolygonStyle"}),
-    correctHypergraphPlotOptionsQ[RulePlot, Automatic, FilterRules[{opts}, Options[HypergraphPlot]]]]
+    And @@ (styleNotListQ[OptionValue[RulePlot, {opts}, #]] & /@ {VertexStyle, EdgeStyle, "EdgePolygonStyle"})]
 );
 
 correctEdgeTypeQ[edgeType_] := If[MatchQ[edgeType, Alternatives @@ $edgeTypes],

--- a/Kernel/RulePlot.m
+++ b/Kernel/RulePlot.m
@@ -89,14 +89,16 @@ hypergraphRulesSpecQ[rulesSpec_Association ? wolframModelRulesSpecQ] :=
 
 hypergraphRulesSpecQ[rulesSpec_] := throw[Failure["invalidRules", <|"rules" -> rulesSpec|>]];
 
-correctOptionsQ[opts___] :=
-  knownOptionsQ[RulePlot, {opts}, $allowedOptions] &&
-  supportedOptionQ[RulePlot, Frame, {True, False, Automatic}, {opts}] &&
-  correctEdgeTypeQ[OptionValue[RulePlot, {opts}, "EdgeType"]] &&
-  correctSpacingsQ[{opts}] &&
-  correctRulePartsAspectRatioQ[OptionValue[RulePlot, {opts}, "RulePartsAspectRatio"]] &&
-  And @@ (styleNotListQ[OptionValue[RulePlot, {opts}, #]] & /@ {VertexStyle, EdgeStyle, "EdgePolygonStyle"}) &&
-  correctHypergraphPlotOptionsQ[RulePlot, Automatic, FilterRules[{opts}, Options[HypergraphPlot]]];
+correctOptionsQ[opts___] := (
+  assertKnownOptions[RulePlot, {opts}, $allowedOptions];
+  assertEnumOptionValue[RulePlot, Frame, {True, False, Automatic}, {opts}];
+  And[
+    correctEdgeTypeQ[OptionValue[RulePlot, {opts}, "EdgeType"]],
+    correctSpacingsQ[{opts}],
+    correctRulePartsAspectRatioQ[OptionValue[RulePlot, {opts}, "RulePartsAspectRatio"]],
+    And @@ (styleNotListQ[OptionValue[RulePlot, {opts}, #]] & /@ {VertexStyle, EdgeStyle, "EdgePolygonStyle"}),
+    correctHypergraphPlotOptionsQ[RulePlot, Automatic, FilterRules[{opts}, Options[HypergraphPlot]]]]
+);
 
 correctEdgeTypeQ[edgeType_] := If[MatchQ[edgeType, Alternatives @@ $edgeTypes],
   True

--- a/Kernel/WolframModel.m
+++ b/Kernel/WolframModel.m
@@ -287,15 +287,15 @@ wolframModelOperator[rulesSpec_ ? wolframModelRulesSpecQ, o : OptionsPattern[]][
 (* Rules *)
 
 declareMessage[
-  General::invalidRules,
-  "The rule specification `ruleSpec` should be either a Rule, a List of rules, or <|\"PatternRules\" -> rules|>, " <>
+  General::invalidWolframModelRules,
+  "The rule specification `rules` should be either a Rule, a List of rules, or <|\"PatternRules\" -> rules|>, " <>
   "where rules is either a Rule, RuleDelayed, or a List of them."];
 
 expr : wolframModel[rulesSpec_ ? (Not @* wolframModelRulesSpecQ), args___] :=
-  throw[Failure["invalidRules", <|"ruleSpec" -> rulesSpec|>]];
+  throw[Failure["invalidWolframModelRules", <|"rules" -> rulesSpec|>]];
 
 expr : wolframModelOperator[rulesSpec_ ? (Not @* wolframModelRulesSpecQ), args___] :=
-  throw[Failure["invalidRules", <|"ruleSpec" -> rulesSpec|>]];
+  throw[Failure["invalidWolframModelRules", <|"rules" -> rulesSpec|>]];
 
 (* Steps *)
 

--- a/Kernel/WolframModel.m
+++ b/Kernel/WolframModel.m
@@ -229,7 +229,7 @@ $WolframModelProperties =
 (* Argument count *)
 
 WolframModel[args___] := 0 /;
-  !Developer`CheckArgumentCount[WolframModel[args], 1, 4] && False;
+  !CheckArguments[WolframModel[args], {1, 4}] && False;
 
 WolframModel[args0___][args1___] := 0 /;
   Length[{args1}] != 1 &&
@@ -285,7 +285,7 @@ WolframModel::invalidState =
 expr : WolframModel[
     rulesSpec_ ? wolframModelRulesSpecQ,
     initSpec : Except[OptionsPattern[]] ? (Not[wolframModelInitSpecQ[#]] &),
-    args___] /; Quiet[Developer`CheckArgumentCount[expr, 1, 4]] := 0 /;
+    args___] /; Quiet[CheckArguments[expr, {1, 4}]] := 0 /;
   Message[WolframModel::invalidState, initSpec];
 
 WolframModel[
@@ -303,7 +303,7 @@ General::invalidRules =
 
 expr : WolframModel[
     rulesSpec_ ? (Not @* wolframModelRulesSpecQ),
-    args___] /; Quiet[Developer`CheckArgumentCount[expr, 2, 4]] := 0 /;
+    args___] /; Quiet[CheckArguments[expr, {2, 4}]] := 0 /;
   Message[WolframModel::invalidRules, rulesSpec];
 
 (* Steps *)
@@ -316,7 +316,7 @@ expr : WolframModel[
     rulesSpec_ ? wolframModelRulesSpecQ,
     initSpec_ ? wolframModelInitSpecQ,
     stepsSpec : Except[OptionsPattern[]] ? (Not[wolframModelStepsSpecQ[#]] &),
-    args___] /; Quiet[Developer`CheckArgumentCount[expr, 1, 4]] := 0 /;
+    args___] /; Quiet[CheckArguments[expr, {1, 4}]] := 0 /;
   Message[WolframModel::invalidSteps, stepsSpec, Values[$stepSpecKeys]];
 
 (* Property *)

--- a/Kernel/WolframModel.m
+++ b/Kernel/WolframModel.m
@@ -191,16 +191,10 @@ expr : WolframModel[
       modifiedEvolution,
       WolframModel,
       #] &;
-    result = Catch @ Check[
+    result = Catch[
       If[modifiedEvolution =!= $Failed,
         If[ListQ[property],
-          Catch[
-            Check[propertyEvaluateWithOptions[#], Throw[$Failed, $propertyMessages]] & /@ property
-          ,
-            $propertyMessages
-          ,
-            $Failed &
-          ]
+          propertyEvaluateWithOptions /@ property
         ,
           propertyEvaluateWithOptions @ property
         ] /.
@@ -208,11 +202,10 @@ expr : WolframModel[
             WolframModelEvolutionObject[Join[data, <|$rules -> rulesSpec|>]]
       ,
         $Failed
-      ]
-    ,
-      $Failed
-    ];
-    result /; result =!= $Failed
+      ],
+      _ ? FailureQ,
+      message[WolframModel, #, <|"expr" -> HoldForm[expr]|>] &];
+    result /; !FailureQ[result]
   ];
 
 (* Operator form *)

--- a/Kernel/WolframModel.m
+++ b/Kernel/WolframModel.m
@@ -56,12 +56,10 @@ fromInitSpec[rulesSpec_List, Automatic] := Catenate[
   If[#2 === 0, ConstantArray[1, #1], ConstantArray[1, {##}]] & @@@
     Reverse /@ Sort[Normal[Merge[Counts /@ Map[Length, If[ListQ[#], #, {#}] & /@ rulesSpec[[All, 1]], {2}], Max]]]];
 
-WolframModel::noPatternAutomatic = "Automatic initial state is not supported for pattern rules ``";
+declareMessage[
+  WolframModel::noPatternAutomatic, "Automatic initial state is not supported for pattern rules `rulesSpec`"];
 
-fromInitSpec[rulesSpec_Association, Automatic] := (
-  Message[WolframModel::noPatternAutomatic, rulesSpec];
-  Throw[$Failed];
-);
+fromInitSpec[rulesSpec_Association, Automatic] := throw[Failure["noPatternAutomatic", <|"rulesSpec" -> rulesSpec|>]];
 
 (* Steps *)
 
@@ -125,13 +123,11 @@ renameNodes[evolution_, True, Automatic] := renameNodes[evolution, True, None];
 renameNodes[evolution_, False, Automatic] :=
   renameNodesExceptExisting[evolution, False, evolution[0]];
 
-WolframModel::unknownVertexNamingFunction =
-  "VertexNamingFunction `1` should be one of `2`.";
+declareMessage[
+  WolframModel::unknownVertexNamingFunction, "VertexNamingFunction `namingFunction` should be one of `choices`."];
 
-renameNodes[evolution_, _, func_] := (
-  Message[WolframModel::unknownVertexNamingFunction, func, $vertexNamingFunctions];
-  $Failed
-);
+renameNodes[evolution_, _, func_] :=
+  throw[Failure["unknownVertexNamingFunction", <|"namingFunction" -> func, "choices" -> $vertexNamingFunctions|>]];
 
 (* Overriding termination reason (i.e., Automatic steps) *)
 
@@ -142,82 +138,83 @@ overrideTerminationReason[newReason_][evolution_] :=
 
 (* Normal form *)
 
-expr : WolframModel[
-      rulesSpec_ ? wolframModelRulesSpecQ,
-      initSpec_ ? wolframModelInitSpecQ,
-      stepsSpec : _ ? wolframModelStepsSpecQ : 1,
-      property : _ ? wolframModelPropertyQ : "EvolutionObject",
-      o : OptionsPattern[]] /; recognizedOptionsQ[expr, WolframModel, {o}] :=
-  ModuleScope[
-    patternRules = fromRulesSpec[rulesSpec];
-    initialSet = Catch[fromInitSpec[rulesSpec, initSpec]];
-    {steps, terminationReasonOverride, optionsOverride, abortBehavior} =
-      fromStepsSpec[initialSet, stepsSpec, OptionValue[TimeConstraint], OptionValue["EventSelectionFunction"]];
-    overridenOptionValue = OptionValue[WolframModel, Join[optionsOverride, {o}], #] &;
-    evolution = If[initialSet =!= $Failed,
-      Check[
-        setSubstitutionSystem[
-          patternRules,
-          initialSet,
-          steps,
-          WolframModel,
-          Switch[abortBehavior,
-            $$nonEvolutionOutputAbort, property === "EvolutionObject",
-            $$noAbort, True,
-            _, False],
-          Method -> overridenOptionValue[Method],
-          TimeConstraint -> overridenOptionValue[TimeConstraint],
-          "EventOrderingFunction" -> overridenOptionValue["EventOrderingFunction"],
-          "EventSelectionFunction" -> overridenOptionValue["EventSelectionFunction"],
-          "EventDeduplication" -> overridenOptionValue["EventDeduplication"]],
-        $Failed]
-    ,
-      $Failed
-    ];
-    If[evolution === $Aborted, Return[$Aborted]];
-    modifiedEvolution = If[evolution =!= $Failed,
-      Check[
-        overrideTerminationReason[terminationReasonOverride] @ renameNodes[
-          evolution,
-          AssociationQ[rulesSpec],
-          overridenOptionValue["VertexNamingFunction"]],
-        $Failed]
-    ,
-      $Failed
-    ];
-    propertyEvaluateWithOptions = propertyEvaluate[
-      overridenOptionValue["IncludePartialGenerations"],
-      overridenOptionValue["IncludeBoundaryEvents"]][
-      modifiedEvolution,
-      #] &;
-    result = Catch[
-      If[modifiedEvolution =!= $Failed,
-        If[ListQ[property],
-          propertyEvaluateWithOptions /@ property
-        ,
-          propertyEvaluateWithOptions @ property
-        ] /.
-          HoldPattern[WolframModelEvolutionObject[data_Association]] :>
-            WolframModelEvolutionObject[Join[data, <|$rules -> rulesSpec|>]]
-      ,
-        $Failed
-      ],
-      _ ? FailureQ,
-      message[WolframModel, #, <|"expr" -> HoldForm[expr]|>] &];
-    result /; !FailureQ[result]
+Options[wolframModel] = Options[WolframModel];
+
+expr : WolframModel[args___] /; Quiet[!CheckArguments[expr, 1]] && CheckArguments[expr, {1, 4}] := ModuleScope[
+  result = Catch[
+    wolframModel[args], _ ? FailureQ, message[WolframModel, #, <|"expr" -> HoldForm[expr]|>] &];
+  result /; result === $Aborted || !FailureQ[result]
+];
+
+expr : (operator : WolframModel[args1___])[args2___] /; Quiet[CheckArguments[operator, 1]] := ModuleScope[
+  result = Catch[
+    wolframModelOperator[args1][args2], _ ? FailureQ, message[WolframModel, #, <|"expr" -> HoldForm[expr]|>] &];
+  result /; result === $Aborted || !FailureQ[result]
+];
+
+expr : wolframModel[rulesSpec_ ? wolframModelRulesSpecQ,
+                    initSpec_ ? wolframModelInitSpecQ,
+                    stepsSpec : _ ? wolframModelStepsSpecQ : 1,
+                    property : _ ? wolframModelPropertyQ : "EvolutionObject",
+                    o : OptionsPattern[]] := ModuleScope[
+  patternRules = fromRulesSpec[rulesSpec];
+  initialSet = fromInitSpec[rulesSpec, initSpec];
+  {steps, terminationReasonOverride, optionsOverride, abortBehavior} =
+    fromStepsSpec[initialSet, stepsSpec, OptionValue[TimeConstraint], OptionValue["EventSelectionFunction"]];
+  overridenOptionValue = OptionValue[WolframModel, Join[optionsOverride, {o}], #] &;
+  evolution = If[initialSet =!= $Failed,
+    Check[
+      setSubstitutionSystem[
+        patternRules,
+        initialSet,
+        steps,
+        WolframModel,
+        Switch[abortBehavior,
+          $$nonEvolutionOutputAbort, property === "EvolutionObject",
+          $$noAbort, True,
+          _, False],
+        Method -> overridenOptionValue[Method],
+        TimeConstraint -> overridenOptionValue[TimeConstraint],
+        "EventOrderingFunction" -> overridenOptionValue["EventOrderingFunction"],
+        "EventSelectionFunction" -> overridenOptionValue["EventSelectionFunction"],
+        "EventDeduplication" -> overridenOptionValue["EventDeduplication"]],
+      $Failed]
+  ,
+    $Failed
   ];
+  If[evolution === $Aborted, Return[$Aborted]];
+  modifiedEvolution = If[evolution =!= $Failed,
+    Check[
+      overrideTerminationReason[terminationReasonOverride] @ renameNodes[
+        evolution,
+        AssociationQ[rulesSpec],
+        overridenOptionValue["VertexNamingFunction"]],
+      $Failed]
+  ,
+    $Failed
+  ];
+  propertyEvaluateWithOptions = propertyEvaluate[
+    overridenOptionValue["IncludePartialGenerations"],
+    overridenOptionValue["IncludeBoundaryEvents"]][
+    modifiedEvolution,
+    #] &;
+  If[modifiedEvolution =!= $Failed,
+    If[ListQ[property],
+      propertyEvaluateWithOptions /@ property
+    ,
+      propertyEvaluateWithOptions @ property
+    ] /.
+      HoldPattern[WolframModelEvolutionObject[data_Association]] :>
+        WolframModelEvolutionObject[Join[data, <|$rules -> rulesSpec|>]]
+  ,
+    $Failed
+  ]
+];
 
 (* Operator form *)
 
-expr : WolframModel[rulesSpec_ ? wolframModelRulesSpecQ, o : OptionsPattern[]] := 0 /;
-  recognizedOptionsQ[expr, WolframModel, {o}] && False;
-
-WolframModel[
-    rulesSpec_ ? wolframModelRulesSpecQ,
-    o : OptionsPattern[] /; Quiet[recognizedOptionsQ[None, WolframModel, {o}]]][
-    initSpec_ ? wolframModelInitSpecQ] := ModuleScope[
-  result = Check[WolframModel[rulesSpec, initSpec, 1, "FinalState", o], $Failed];
-  result /; result =!= $Failed];
+wolframModelOperator[rulesSpec_ ? wolframModelRulesSpecQ, o : OptionsPattern[]][initSpec_ ? wolframModelInitSpecQ] :=
+  wolframModel[rulesSpec, initSpec, 1, "FinalState", o];
 
 (* $WolframModelProperties *)
 
@@ -225,15 +222,6 @@ $WolframModelProperties =
   Complement[$propertiesParameterless, {"Properties", "Rules"}];
 
 (* Argument Checks *)
-
-(* Argument count *)
-
-WolframModel[args___] := 0 /;
-  !CheckArguments[WolframModel[args], {1, 4}] && False;
-
-WolframModel[args0___][args1___] := 0 /;
-  Length[{args1}] != 1 &&
-  Message[WolframModel::argx, "WolframModel[\[Ellipsis]]", Length[{args1}], 1];
 
 (* Rules *)
 
@@ -277,58 +265,58 @@ wolframModelPropertyQ[_] := False;
 
 (* Incorrect arguments messages *)
 
+(* Arguments count *)
+
+expr : (operator : wolframModelOperator[args1___])[init_, args2__] /; Quiet[CheckArguments[operator, 1]] := ModuleScope[
+  Message[WolframModel::argx, Defer[WolframModel[args1][init, args2]], Length[{init, args2}]];
+  throw[Failure[None, <||>]]
+];
+
 (* Init *)
 
-WolframModel::invalidState =
-  "The initial state specification `1` should be a List.";
+declareMessage[WolframModel::invalidState, "The initial state specification `init` should be a List."];
 
-expr : WolframModel[
-    rulesSpec_ ? wolframModelRulesSpecQ,
-    initSpec : Except[OptionsPattern[]] ? (Not[wolframModelInitSpecQ[#]] &),
-    args___] /; Quiet[CheckArguments[expr, {1, 4}]] := 0 /;
-  Message[WolframModel::invalidState, initSpec];
+wolframModel[rulesSpec_ ? wolframModelRulesSpecQ,
+             initSpec : Except[OptionsPattern[]] ? (Not[wolframModelInitSpecQ[#]] &),
+             args___] := throw[Failure["invalidState", <|"init" -> initSpec|>]];
 
-WolframModel[
-    rulesSpec_ ? wolframModelRulesSpecQ,
-    o : OptionsPattern[] /; Quiet[recognizedOptionsQ[None, WolframModel, {o}]]][
-    initSpec_ ? (Not @* wolframModelInitSpecQ)] := 0 /;
-  Message[WolframModel::invalidState, initSpec];
+wolframModelOperator[rulesSpec_ ? wolframModelRulesSpecQ, o : OptionsPattern[]][
+    initSpec_ ? (Not @* wolframModelInitSpecQ)] :=
+  throw[Failure["invalidState", <|"init" -> initSpec|>]];
 
 (* Rules *)
 
-General::invalidRules =
-  "The rule specification `1` should be either a Rule, " ~~
-  "a List of rules, or <|\"PatternRules\" -> rules|>, where " ~~
-  "rules is either a Rule, RuleDelayed, or a List of them.";
+declareMessage[
+  General::invalidRules,
+  "The rule specification `ruleSpec` should be either a Rule, a List of rules, or <|\"PatternRules\" -> rules|>, " <>
+  "where rules is either a Rule, RuleDelayed, or a List of them."];
 
-expr : WolframModel[
-    rulesSpec_ ? (Not @* wolframModelRulesSpecQ),
-    args___] /; Quiet[CheckArguments[expr, {2, 4}]] := 0 /;
-  Message[WolframModel::invalidRules, rulesSpec];
+expr : wolframModel[rulesSpec_ ? (Not @* wolframModelRulesSpecQ), args___] :=
+  throw[Failure["invalidRules", <|"ruleSpec" -> rulesSpec|>]];
+
+expr : wolframModelOperator[rulesSpec_ ? (Not @* wolframModelRulesSpecQ), args___] :=
+  throw[Failure["invalidRules", <|"ruleSpec" -> rulesSpec|>]];
 
 (* Steps *)
 
-WolframModel::invalidSteps =
-  "The steps specification `1` should be an Integer, Infinity, Automatic, " <>
-  "or an association with one or more keys from `2`.";
+declareMessage[
+  WolframModel::invalidSteps,
+  "The steps specification `stepSpec` should be an Integer, Infinity, Automatic, or an association with one or more " <>
+  "keys from `choices`."];
 
-expr : WolframModel[
-    rulesSpec_ ? wolframModelRulesSpecQ,
-    initSpec_ ? wolframModelInitSpecQ,
-    stepsSpec : Except[OptionsPattern[]] ? (Not[wolframModelStepsSpecQ[#]] &),
-    args___] /; Quiet[CheckArguments[expr, {1, 4}]] := 0 /;
-  Message[WolframModel::invalidSteps, stepsSpec, Values[$stepSpecKeys]];
+expr : wolframModel[rulesSpec_ ? wolframModelRulesSpecQ,
+                    initSpec_ ? wolframModelInitSpecQ,
+                    stepsSpec : Except[OptionsPattern[]] ? (Not[wolframModelStepsSpecQ[#]] &),
+                    args___] :=
+  throw[Failure["invalidSteps", <|"stepSpec" -> stepsSpec, "choices" -> Values[$stepSpecKeys]|>]];
 
 (* Property *)
 
-WolframModel::invalidProperty =
-  "Property specification `1` should be one of $WolframModelProperties " <>
-  "or a List of them.";
+declareMessage[WolframModel::invalidProperty,
+               "Property specification `property` should be one of $WolframModelProperties or a List of them."];
 
-expr : WolframModel[
-    rulesSpec_ ? wolframModelRulesSpecQ,
-    initSpec_ ? wolframModelInitSpecQ,
-    stepsSpec_ ? wolframModelStepsSpecQ,
-    property : Except[OptionsPattern[]] ? (Not[wolframModelPropertyQ[#]] &),
-    o : OptionsPattern[] /; recognizedOptionsQ[expr, WolframModel, {o}]] := 0 /;
-  Message[WolframModel::invalidProperty, property];
+expr : wolframModel[rulesSpec_ ? wolframModelRulesSpecQ,
+                    initSpec_ ? wolframModelInitSpecQ,
+                    stepsSpec_ ? wolframModelStepsSpecQ,
+                    property : Except[OptionsPattern[]] ? (Not[wolframModelPropertyQ[#]] &),
+                    o : OptionsPattern[]] := throw[Failure["invalidProperty", <|"property" -> property|>]];

--- a/Kernel/WolframModel.m
+++ b/Kernel/WolframModel.m
@@ -189,7 +189,6 @@ expr : WolframModel[
       overridenOptionValue["IncludePartialGenerations"],
       overridenOptionValue["IncludeBoundaryEvents"]][
       modifiedEvolution,
-      WolframModel,
       #] &;
     result = Catch[
       If[modifiedEvolution =!= $Failed,

--- a/Kernel/WolframModelEvolutionObject.m
+++ b/Kernel/WolframModelEvolutionObject.m
@@ -815,7 +815,7 @@ getNumericObjectProperties[obj_, boundary_] := <|# -> propertyEvaluate[True, bou
 declareMessage[General::invalidFeatureSpec,
                "Feature specification `featureSpec` should be one of `choices`, a list of them, or All."];
 
-declareMessage[General::unknownFeatureGroup, "Feature group `featureGroup` should be one of `choices`"];
+declareMessage[General::unknownFeatureGroup, "Feature group `featureGroup` should be one of `choices`."];
 
 fromFeaturesSpec[All] := {"StructurePreservingFinalStateGraph", "ObjectProperties"}
 fromFeaturesSpec[featuresSpecs_List] := featuresSpecs

--- a/Kernel/WolframModelEvolutionObject.m
+++ b/Kernel/WolframModelEvolutionObject.m
@@ -179,14 +179,14 @@ propertyEvaluate[False, boundary_][evolution_, rest___] :=
   propertyEvaluate[True, boundary][deleteIncompleteGenerations[evolution], rest];
 
 propertyEvaluate[includePartialGenerations : Except[True | False], _][__] := throw[Failure[
-  "invalidFiniteOption",
-  <|"opt" -> "IncludePartialGenerations", "value" -> includePartialGenerations, "choices" -> {True, False}|>]];
+  "invalidOptionChoice",
+  <|"option" -> "IncludePartialGenerations", "value" -> includePartialGenerations, "choices" -> {True, False}|>]];
 
 includeBoundaryEventsPattern = None | "Initial" | "Final" | All;
 
 propertyEvaluate[_, boundary : Except[includeBoundaryEventsPattern]][__] := throw[Failure[
-  "invalidFiniteOption",
-  <|"opt" -> "IncludeBoundaryEvents", "value" -> boundary, "choices" -> {None, "Initial", "Final", All}|>]];
+  "invalidOptionChoice",
+  <|"option" -> "IncludeBoundaryEvents", "value" -> boundary, "choices" -> {None, "Initial", "Final", All}|>]];
 
 deleteIncompleteGenerations[WolframModelEvolutionObject[data_]] := ModuleScope[
   maxCompleteGeneration = data[$maxCompleteGeneration];
@@ -876,16 +876,16 @@ $masterOptions = {
 };
 
 expr : WolframModelEvolutionObject[data_ ? evolutionDataQ][args__] := ModuleScope[
-  {property, opts} = Replace[
+  {property, options} = Replace[
     {args},
-    {property__, opts : Longest[$nonEmptyOptionsPattern]} :>
-      {{property}, {opts}}];
+    {property__, options : Longest[$nonEmptyOptionsPattern]} :>
+      {{property}, {options}}];
   result = Catch[
     (propertyEvaluate @@
-        (OptionValue[Join[opts, $masterOptions], #] & /@ {"IncludePartialGenerations", "IncludeBoundaryEvents"}))[
+        (OptionValue[Join[options, $masterOptions], #] & /@ {"IncludePartialGenerations", "IncludeBoundaryEvents"}))[
       WolframModelEvolutionObject[data],
       Sequence @@ property,
-      ##] & @@ Flatten[FilterRules[opts, Except[$masterOptions]]],
+      ##] & @@ Flatten[FilterRules[options, Except[$masterOptions]]],
     _ ? FailureQ,
     message[WolframModelEvolutionObject, #, <|"expr" -> HoldForm[expr]|>] &];
   result /; !FailureQ[result]
@@ -898,7 +898,7 @@ expr : WolframModelEvolutionObject[data_ ? evolutionDataQ][args__] := ModuleScop
 (* Argument count *)
 
 WolframModelEvolutionObject[args___] := 0 /;
-  !Developer`CheckArgumentCount[WolframModelEvolutionObject[args], 1, 1] && False;
+  !CheckArguments[WolframModelEvolutionObject[args], 1] && False;
 
 WolframModelEvolutionObject[data_][] := 0 /;
   Message[WolframModelEvolutionObject::argm, Defer[WolframModelEvolutionObject[data][]], 0, 1];

--- a/Kernel/WolframModelEvolutionObject.m
+++ b/Kernel/WolframModelEvolutionObject.m
@@ -168,15 +168,15 @@ $newParameterlessProperties = Intersection[$propertiesParameterless, Keys[$prope
 declareMessage[
   General::missingMaxCompleteGeneration, "Cannot drop incomplete generations in an object with missing information."];
 
-propertyEvaluate[False, boundary_][evolution_, caller_, rest___] :=
+propertyEvaluate[False, boundary_][evolution_, rest___] :=
   If[MissingQ[evolution["CompleteGenerationsCount"]],
     throw[Failure["missingMaxCompleteGeneration", <||>]];
   ,
-    propertyEvaluate[True, boundary][deleteIncompleteGenerations[evolution], caller, rest]
+    propertyEvaluate[True, boundary][deleteIncompleteGenerations[evolution], rest]
   ];
 
-propertyEvaluate[False, boundary_][evolution_, caller_, rest___] :=
-  propertyEvaluate[True, boundary][deleteIncompleteGenerations[evolution], caller, rest];
+propertyEvaluate[False, boundary_][evolution_, rest___] :=
+  propertyEvaluate[True, boundary][deleteIncompleteGenerations[evolution], rest];
 
 propertyEvaluate[includePartialGenerations : Except[True | False], _][__] := throw[Failure[
   "invalidFiniteOption",
@@ -207,19 +207,16 @@ deleteIncompleteGenerations[WolframModelEvolutionObject[data_]] := ModuleScope[
 
 (* Unknown property *)
 
-(* TODO: remove caller from everywhere if not needed *)
-
 propertyEvaluate[masterOptions___][
-    obj_WolframModelEvolutionObject, caller_, property : Alternatives @@ Keys[$oldToNewPropertyNames], args___] :=
-  propertyEvaluate[masterOptions][obj, caller, $oldToNewPropertyNames[property], args];
+    obj_WolframModelEvolutionObject, property : Alternatives @@ Keys[$oldToNewPropertyNames], args___] :=
+  propertyEvaluate[masterOptions][obj, $oldToNewPropertyNames[property], args];
 
 declareMessage[General::unknownProperty, "Property \"`property`\" should be one of \"Properties\"."];
 
 propertyEvaluate[___][
-    WolframModelEvolutionObject[data_ ? evolutionDataQ],
-    caller_,
-    s : Except[_Integer],
-    ___] /; !MemberQ[Keys[$propertyArgumentCounts], s] := throw[Failure["unknownProperty", <|"property" -> s|>]];
+      WolframModelEvolutionObject[_ ? evolutionDataQ], property : Except[_Integer], ___] /;
+    !MemberQ[Keys[$propertyArgumentCounts], property] :=
+  throw[Failure["unknownProperty", <|"property" -> property|>]];
 
 (* Check property argument counts *)
 
@@ -242,10 +239,7 @@ throwPargxFailure[property_, givenArgs_, expectedArgs_] := throw[Failure[
 ]];
 
 propertyEvaluate[___][
-    WolframModelEvolutionObject[data_ ? evolutionDataQ],
-    caller_,
-    s_String,
-    args___] /;
+    WolframModelEvolutionObject[_ ? evolutionDataQ], s_String, args___] /;
       With[{argumentsCountRange = $propertyArgumentCounts[s]},
         Not[MissingQ[argumentsCountRange]] &&
         Not[argumentsCountRange[[1]] <= Length[{args}] <= argumentsCountRange[[2]]]] :=
@@ -256,11 +250,8 @@ declareMessage[
   "`expr` is called with `argCount` arguments. Either 1 argument is expected for implicit \"Generation\", or a " <>
   "property name is expected as the first argument."];
 
-propertyEvaluate[___][
-    WolframModelEvolutionObject[data_ ? evolutionDataQ],
-    caller_,
-    g_Integer,
-    args__] := throw[Failure["invalidNargs", <|"argCount" -> Length @ {g, args}|>]];
+propertyEvaluate[___][WolframModelEvolutionObject[_ ? evolutionDataQ], g_Integer, args__] :=
+  throw[Failure["invalidNargs", <|"argCount" -> Length @ {g, args}|>]];
 
 (* Check options *)
 
@@ -290,7 +281,6 @@ $nonEmptyOptionsPattern = OptionsPattern[] ? (AllTrue[{##}, Length[Flatten[{#}, 
 
 propertyEvaluate[True, includeBoundaryEventsPattern][
     WolframModelEvolutionObject[_ ? evolutionDataQ],
-    caller_,
     property : Alternatives @@ Keys[$propertyOptions],
     o : $nonEmptyOptionsPattern] := throw[Failure[
   "optx", <|"opt" -> First[Last[Complement[{o}, FilterRules[{o}, Options[$propertyOptions[property]]]]]]|>]];
@@ -298,7 +288,7 @@ propertyEvaluate[True, includeBoundaryEventsPattern][
 declareMessage[General::nonopt, StringTemplate[General::nonopt]["`arg`", "`nonoptArgCount`", "`expr`"]];
 
 propertyEvaluate[True, includeBoundaryEventsPattern][
-    WolframModelEvolutionObject[_ ? evolutionDataQ], caller_, Alternatives @@ Keys[$propertyOptions], o___] :=
+    WolframModelEvolutionObject[_ ? evolutionDataQ], Alternatives @@ Keys[$propertyOptions], o___] :=
   throw[Failure["nonopt", <|"arg" -> Last[{o}], "nonoptArgCount" -> 1|>]];
 
 (* Convert to positive parameter (i.e., generation) number, similar to, e.g., expr[[-1]] *)
@@ -309,7 +299,7 @@ declareMessage[General::parameterTooLarge, "`name` `value` requested out of `max
 
 declareMessage[General::parameterTooSmall, "`name` `value` cannot be smaller than `minValue`."];
 
-toPositiveParameter[min_ : 0, total_, requested_, caller_, name_] := Switch[requested,
+toPositiveParameter[min_ : 0, total_, requested_, name_] := Switch[requested,
   Except[_Integer],
     throw[Failure["parameterNotInteger", <|"name" -> name, "value" -> requested|>]],
   _ ? (# > total || # < - total - 1 + min &),
@@ -324,36 +314,26 @@ toPositiveParameter[min_ : 0, total_, requested_, caller_, name_] := Switch[requ
 
 (** Properties **)
 
-propertyEvaluate[___][
-    WolframModelEvolutionObject[data_ ? evolutionDataQ], caller_, "Properties"] :=
-  Keys[$propertyArgumentCounts];
+propertyEvaluate[___][WolframModelEvolutionObject[_ ? evolutionDataQ], "Properties"] := Keys[$propertyArgumentCounts];
 
 (* EvolutionObject *)
 
 propertyEvaluate[True, includeBoundaryEventsPattern][
-    WolframModelEvolutionObject[data_ ? evolutionDataQ],
-    caller_,
-    "EvolutionObject"] := WolframModelEvolutionObject[data];
+    WolframModelEvolutionObject[data_ ? evolutionDataQ], "EvolutionObject"] := WolframModelEvolutionObject[data];
 
 (* Rules *)
 
-propertyEvaluate[___][
-    WolframModelEvolutionObject[data_ ? evolutionDataQ], caller_, "Rules"] :=
-  data[$rules];
+propertyEvaluate[___][WolframModelEvolutionObject[data_ ? evolutionDataQ], "Rules"] := data[$rules];
 
 (* TotalGenerationsCount *)
 
 propertyEvaluate[True, includeBoundaryEventsPattern][
-    WolframModelEvolutionObject[data_ ? evolutionDataQ],
-    caller_,
-    "TotalGenerationsCount"] := Max[data[$eventGenerations]];
+    WolframModelEvolutionObject[data_ ? evolutionDataQ], "TotalGenerationsCount"] := Max[data[$eventGenerations]];
 
 (* PartialGenerationsCount *)
 
 propertyEvaluate[True, includeBoundaryEventsPattern][
-    obj : WolframModelEvolutionObject[_ ? evolutionDataQ],
-    caller_,
-    "PartialGenerationsCount"] :=
+    obj : WolframModelEvolutionObject[_ ? evolutionDataQ], "PartialGenerationsCount"] :=
   If[MissingQ[obj["CompleteGenerationsCount"]],
     obj["CompleteGenerationsCount"]
   ,
@@ -364,52 +344,45 @@ propertyEvaluate[True, includeBoundaryEventsPattern][
 
 propertyEvaluate[True, includeBoundaryEventsPattern][
     obj : WolframModelEvolutionObject[_ ? evolutionDataQ],
-    caller_,
     "GenerationsCount"] := obj /@ {"CompleteGenerationsCount", "PartialGenerationsCount"};
 
 (* GenerationComplete *)
 
 propertyEvaluate[True, includeBoundaryEventsPattern][
     obj : WolframModelEvolutionObject[_ ? evolutionDataQ],
-    caller_,
     "GenerationComplete",
     generation_Integer] /; generation >= 0 := generation <= obj["CompleteGenerationsCount"];
 
 propertyEvaluate[True, includeBoundaryEventsPattern][
-    obj : WolframModelEvolutionObject[_ ? evolutionDataQ],
-    caller_,
-    "GenerationComplete",
-    generation_ : -1] :=
+    obj : WolframModelEvolutionObject[_ ? evolutionDataQ], "GenerationComplete", generation_ : -1] :=
   toPositiveParameter[
-      propertyEvaluate[True, None][obj, caller, "TotalGenerationsCount"], generation, caller, "Generation"] <=
+      propertyEvaluate[True, None][obj, "TotalGenerationsCount"], generation, "Generation"] <=
     obj["CompleteGenerationsCount"];
 
 (* AllEventsCount *)
 
 propertyEvaluate[True, includeBoundaryEvents : includeBoundaryEventsPattern][
-    WolframModelEvolutionObject[data_ ? evolutionDataQ], caller_, "AllEventsCount"] :=
+    WolframModelEvolutionObject[data_ ? evolutionDataQ], "AllEventsCount"] :=
   Length[data[$eventRuleIDs]] + Switch[includeBoundaryEvents, None, -1, "Initial" | "Final", 0, All, 1];
 
 (* GenerationEventsCountList *)
 
 propertyEvaluate[True, includeBoundaryEvents : includeBoundaryEventsPattern][
-    obj : WolframModelEvolutionObject[_ ? evolutionDataQ], caller_, "GenerationEventsCountList"] :=
-  Length /@ Split[propertyEvaluate[True, includeBoundaryEvents][obj, caller, "AllEventsGenerationsList"]];
+    obj : WolframModelEvolutionObject[_ ? evolutionDataQ], "GenerationEventsCountList"] :=
+  Length /@ Split[propertyEvaluate[True, includeBoundaryEvents][obj, "AllEventsGenerationsList"]];
 
 (* GenerationEventsList *)
 
 propertyEvaluate[True, includeBoundaryEvents : includeBoundaryEventsPattern][
-    obj : WolframModelEvolutionObject[_ ? evolutionDataQ], caller_, "GenerationEventsList"] :=
+    obj : WolframModelEvolutionObject[_ ? evolutionDataQ], "GenerationEventsList"] :=
   TakeList[
-    propertyEvaluate[True, includeBoundaryEvents][obj, caller, "AllEventsList"],
-    propertyEvaluate[True, includeBoundaryEvents][obj, caller, "GenerationEventsCountList"]];
+    propertyEvaluate[True, includeBoundaryEvents][obj, "AllEventsList"],
+    propertyEvaluate[True, includeBoundaryEvents][obj, "GenerationEventsCountList"]];
 
 (* Direct Accessors of object properties *)
 
 propertyEvaluate[True, includeBoundaryEventsPattern][
-    WolframModelEvolutionObject[data_ ? evolutionDataQ],
-    caller_,
-    property_ ? (MemberQ[Keys[$accessorProperties], #] &)] :=
+    WolframModelEvolutionObject[data_ ? evolutionDataQ], property_ ? (MemberQ[Keys[$accessorProperties], #] &)] :=
   Lookup[data, $accessorProperties[property], Missing["NotAvailable"]];
 
 (* StateEdgeIndicesAfterEvents (not a property yet) *)
@@ -418,7 +391,7 @@ declareMessage[
   General::multiwayState,
   "Multiple destroyer events found for edge index `edgeIndex`. States are not supported for multiway systems."];
 
-stateEdgeIndicesAfterEvents[WolframModelEvolutionObject[data_], caller_, events_] := ModuleScope[
+stateEdgeIndicesAfterEvents[WolframModelEvolutionObject[data_], events_] := ModuleScope[
   createdExpressions = Catenate[data[$eventOutputs][[events + 1]]];
   destroyedExpressions = Catenate[data[$eventInputs][[events + 1]]];
   If[DuplicateFreeQ[destroyedExpressions],
@@ -432,28 +405,23 @@ stateEdgeIndicesAfterEvents[WolframModelEvolutionObject[data_], caller_, events_
 
 propertyEvaluate[True, includeBoundaryEventsPattern][
       obj : WolframModelEvolutionObject[data_ ? evolutionDataQ],
-      caller_,
       "StateEdgeIndicesAfterEvent",
       s_] := With[{
-    positiveEvent =
-      toPositiveParameter[propertyEvaluate[True, None][obj, caller, "AllEventsCount"], s, caller, "Event"]},
-  stateEdgeIndicesAfterEvents[obj, caller, Range[0, positiveEvent]]
+    positiveEvent = toPositiveParameter[propertyEvaluate[True, None][obj, "AllEventsCount"], s, "Event"]},
+  stateEdgeIndicesAfterEvents[obj, Range[0, positiveEvent]]
 ];
 
 (* StateAfterEvent *)
 
 propertyEvaluate[True, boundary : includeBoundaryEventsPattern][
-      obj : WolframModelEvolutionObject[data_ ? evolutionDataQ],
-      caller_,
-      "StateAfterEvent",
-      s_] := data[$atomLists][[propertyEvaluate[True, boundary][obj, caller, "StateEdgeIndicesAfterEvent", s]]];
+    obj : WolframModelEvolutionObject[data_ ? evolutionDataQ], "StateAfterEvent", s_] :=
+  data[$atomLists][[propertyEvaluate[True, boundary][obj, "StateEdgeIndicesAfterEvent", s]]];
 
 (* FinalState *)
 
 propertyEvaluate[True, boundary: includeBoundaryEventsPattern][
-    obj : WolframModelEvolutionObject[data_ ? evolutionDataQ],
-    caller_,
-    "FinalState"] := propertyEvaluate[True, boundary][obj, caller, "StateAfterEvent", -1];
+    obj : WolframModelEvolutionObject[_ ? evolutionDataQ], "FinalState"] :=
+  propertyEvaluate[True, boundary][obj, "StateAfterEvent", -1];
 
 (* FinalStatePlot *)
 
@@ -461,11 +429,10 @@ declareMessage[General::nonHypergraphPlot, "`property` is only supported for sta
 
 propertyEvaluate[True, boundary : includeBoundaryEventsPattern][
     obj : WolframModelEvolutionObject[_ ? evolutionDataQ],
-    caller_,
     property : "FinalStatePlot",
     o : $nonEmptyOptionsPattern /; (Complement[{o}, FilterRules[{o}, Options[HypergraphPlot]]] == {})] :=
   Catch[
-    hypergraphPlot[propertyEvaluate[True, boundary][obj, caller, "FinalState"], o],
+    hypergraphPlot[propertyEvaluate[True, boundary][obj, "FinalState"], o],
     Failure["invalidEdges", _],
     throw[Failure["nonHypergraphPlot", <|"property" -> property|>]] &];
 
@@ -473,28 +440,23 @@ propertyEvaluate[True, boundary : includeBoundaryEventsPattern][
 
 propertyEvaluate[True, boundary : includeBoundaryEventsPattern][
     evolution : WolframModelEvolutionObject[data_ ? evolutionDataQ],
-    caller_,
     property : "AllEventsStatesList" | "AllEventsStatesEdgeIndicesList"] :=
   propertyEvaluate[True, boundary][
       evolution,
-      caller,
       Replace[
         property,
         {"AllEventsStatesList" -> "StateAfterEvent", "AllEventsStatesEdgeIndicesList" -> "StateEdgeIndicesAfterEvent"}],
       #] & /@
-    Range[0, propertyEvaluate[True, None][WolframModelEvolutionObject[data], caller, "AllEventsCount"]];
+    Range[0, propertyEvaluate[True, None][WolframModelEvolutionObject[data], "AllEventsCount"]];
 
 (* GenerationEdgeIndices *)
 
 propertyEvaluate[True, includeBoundaryEventsPattern][
-      obj : WolframModelEvolutionObject[data_ ? evolutionDataQ],
-      caller_,
-      "GenerationEdgeIndices",
-      g_] := ModuleScope[
+    obj : WolframModelEvolutionObject[data_ ? evolutionDataQ], "GenerationEdgeIndices", g_] := ModuleScope[
   positiveGeneration = toPositiveParameter[
-    propertyEvaluate[True, None][obj, caller, "TotalGenerationsCount"], g, caller, "Generation"];
+    propertyEvaluate[True, None][obj, "TotalGenerationsCount"], g, "Generation"];
   eventsUpToGeneration = First /@ Position[_ ? (# <= positiveGeneration &)] @ data[$eventGenerations] - 1;
-  stateEdgeIndicesAfterEvents[obj, caller, eventsUpToGeneration]
+  stateEdgeIndicesAfterEvents[obj, eventsUpToGeneration]
 ];
 
 (* Generation *)
@@ -504,35 +466,29 @@ propertyEvaluate[True, includeBoundaryEventsPattern][
    be used instead. That, however, should never happen if the evolution object is produced with WolframModel. *)
 
 propertyEvaluate[True, includeBoundaryEventsPattern][
-      obj : WolframModelEvolutionObject[data_ ? evolutionDataQ],
-      caller_,
-      "Generation",
-      g_] := data[$atomLists][[propertyEvaluate[True, None][obj, caller, "GenerationEdgeIndices", g]]];
+    obj : WolframModelEvolutionObject[data_ ? evolutionDataQ], "Generation", g_] :=
+  data[$atomLists][[propertyEvaluate[True, None][obj, "GenerationEdgeIndices", g]]];
 
 (* Implicit generation, e.g., object[2] *)
 
-propertyEvaluate[True, includeBoundaryEventsPattern][
-    WolframModelEvolutionObject[data_ ? evolutionDataQ], caller_, g_Integer] :=
-  propertyEvaluate[True, None][WolframModelEvolutionObject[data], caller, "Generation", g];
+propertyEvaluate[True, includeBoundaryEventsPattern][WolframModelEvolutionObject[data_ ? evolutionDataQ], g_Integer] :=
+  propertyEvaluate[True, None][WolframModelEvolutionObject[data], "Generation", g];
 
 (* StatesList *)
 
 propertyEvaluate[True, boundary : includeBoundaryEventsPattern][
-    obj : WolframModelEvolutionObject[data_ ? evolutionDataQ],
-    caller_,
-    "StatesList"] :=
-  propertyEvaluate[True, boundary][obj, caller, "Generation", #] & /@
-    Range[0, propertyEvaluate[True, boundary][obj, caller, "TotalGenerationsCount"]];
+    obj : WolframModelEvolutionObject[_ ? evolutionDataQ], "StatesList"] :=
+  propertyEvaluate[True, boundary][obj, "Generation", #] & /@
+    Range[0, propertyEvaluate[True, boundary][obj, "TotalGenerationsCount"]];
 
 (* StatesPlotsList *)
 
 propertyEvaluate[True, boundary : includeBoundaryEventsPattern][
     obj : WolframModelEvolutionObject[_ ? evolutionDataQ],
-    caller_,
     property : "StatesPlotsList",
     o : $nonEmptyOptionsPattern /; (Complement[{o}, FilterRules[{o}, Options[HypergraphPlot]]] == {})] :=
   Catch[
-    hypergraphPlot[#, o] & /@ propertyEvaluate[True, boundary][obj, caller, "StatesList"],
+    hypergraphPlot[#, o] & /@ propertyEvaluate[True, boundary][obj, "StatesList"],
     Failure["invalidEdges", _],
     throw[Failure["nonHypergraphPlot", <|"property" -> property|>]] &];
 
@@ -540,10 +496,9 @@ propertyEvaluate[True, boundary : includeBoundaryEventsPattern][
 
 propertyEvaluate[True, boundary : includeBoundaryEventsPattern][
       obj : WolframModelEvolutionObject[_ ? evolutionDataQ],
-      caller_,
       property : "EventsStatesPlotsList",
       o : $nonEmptyOptionsPattern /; (Complement[{o}, FilterRules[{o}, Options[HypergraphPlot]]] == {})] := ModuleScope[
-  events = propertyEvaluate[True, boundary][obj, caller, "AllEventsList"][[All, 2]];
+  events = propertyEvaluate[True, boundary][obj, "AllEventsList"][[All, 2]];
   stateIndices = FoldList[
     Function[{currentState, newEvent}, Module[{alreadyDeletedExpressions},
       alreadyDeletedExpressions = Complement[newEvent[[1]], currentState];
@@ -554,13 +509,13 @@ propertyEvaluate[True, boundary : includeBoundaryEventsPattern][
     If[MatchQ[boundary, "Initial" | All],
       {}
     ,
-      propertyEvaluate[True, None][obj, caller, "StateEdgeIndicesAfterEvent", 0]
+      propertyEvaluate[True, None][obj, "StateEdgeIndicesAfterEvent", 0]
     ],
     events];
   {destroyedOnlyIndices, createdOnlyIndices, destroyedAndCreatedIndices} = Transpose[MapThread[
     {Complement[##], Complement[#2, #1], Intersection[##]} &,
     {Append[events[[All, 1]], {}], Prepend[events[[All, 2]], {}]}]];
-  allEdges = propertyEvaluate[True, None][obj, caller, "AllEventsEdgesList"];
+  allEdges = propertyEvaluate[True, None][obj, "AllEventsEdgesList"];
 
   Catch[
     MapThread[
@@ -584,62 +539,46 @@ propertyEvaluate[True, boundary : includeBoundaryEventsPattern][
 (* FinalDistinctElementsCount *)
 
 propertyEvaluate[True, includeBoundaryEventsPattern][
-    WolframModelEvolutionObject[data_ ? evolutionDataQ],
-    caller_,
-    "FinalDistinctElementsCount"] :=
+    WolframModelEvolutionObject[data_ ? evolutionDataQ], "FinalDistinctElementsCount"] :=
   Length[Union @ Cases[
-    propertyEvaluate[True, None][
-      WolframModelEvolutionObject[data], caller, "StateAfterEvent", -1],
+    propertyEvaluate[True, None][WolframModelEvolutionObject[data], "StateAfterEvent", -1],
     _ ? AtomQ,
     All]];
 
 (* AllEventsDistinctElementsCount *)
 
 propertyEvaluate[True, includeBoundaryEventsPattern][
-    WolframModelEvolutionObject[data_ ? evolutionDataQ],
-    caller_,
-    "AllEventsDistinctElementsCount"] :=
+    WolframModelEvolutionObject[data_ ? evolutionDataQ], "AllEventsDistinctElementsCount"] :=
   Length[Union @ Cases[data[$atomLists], _ ? AtomQ, All]];
 
 (* VertexCountList *)
 
 propertyEvaluate[True, boundary : includeBoundaryEventsPattern][
-    obj : WolframModelEvolutionObject[_ ? evolutionDataQ],
-    caller_,
-    "VertexCountList"] :=
-  Length /@ Union /@ Catenate /@ propertyEvaluate[True, boundary][obj, caller, "StatesList"];
+    obj : WolframModelEvolutionObject[_ ? evolutionDataQ], "VertexCountList"] :=
+  Length /@ Union /@ Catenate /@ propertyEvaluate[True, boundary][obj, "StatesList"];
 
 (* EdgeCountList *)
 
 propertyEvaluate[True, boundary : includeBoundaryEventsPattern][
-    obj : WolframModelEvolutionObject[_ ? evolutionDataQ],
-    caller_,
-    "EdgeCountList"] :=
-  Length /@ propertyEvaluate[True, boundary][obj, caller, "StatesList"];
+    obj : WolframModelEvolutionObject[_ ? evolutionDataQ], "EdgeCountList"] :=
+  Length /@ propertyEvaluate[True, boundary][obj, "StatesList"];
 
 (* FinalEdgeCount *)
 
 propertyEvaluate[True, includeBoundaryEventsPattern][
-    WolframModelEvolutionObject[data_ ? evolutionDataQ],
-    caller_,
-    "FinalEdgeCount"] :=
-  Length[propertyEvaluate[True, None][
-    WolframModelEvolutionObject[data], caller, "StateAfterEvent", -1]];
+    WolframModelEvolutionObject[data_ ? evolutionDataQ], "FinalEdgeCount"] :=
+  Length[propertyEvaluate[True, None][WolframModelEvolutionObject[data], "StateAfterEvent", -1]];
 
 (* AllEventsEdgesCount *)
 
 propertyEvaluate[True, includeBoundaryEventsPattern][
-    WolframModelEvolutionObject[data_ ? evolutionDataQ],
-    caller_,
-    "AllEventsEdgesCount"] :=
+    WolframModelEvolutionObject[data_ ? evolutionDataQ], "AllEventsEdgesCount"] :=
   Length[data[$atomLists]];
 
 (* AllEventsGenerationsList *)
 
 propertyEvaluate[True, includeBoundaryEvents : includeBoundaryEventsPattern][
-    evolution : WolframModelEvolutionObject[data_ ? evolutionDataQ],
-    caller_,
-    "AllEventsGenerationsList"] :=
+    evolution : WolframModelEvolutionObject[data_ ? evolutionDataQ], "AllEventsGenerationsList"] :=
   If[MatchQ[includeBoundaryEvents, All | "Final"], Append[evolution["TotalGenerationsCount"] + 1], Identity] @
     If[MatchQ[includeBoundaryEvents, None | "Final"], Rest, Identity] @
       data[$eventGenerations];
@@ -647,14 +586,14 @@ propertyEvaluate[True, includeBoundaryEvents : includeBoundaryEventsPattern][
 (* Event/expression causal relations, used by both expressions-events and causal graphs *)
 (* Returns {<|event -> {output expression, ...}, ...|>, <|expression -> {destroyer event, ...}|> *)
 
-eventsExpressionsRelations[obj_, caller_, boundary_] := ModuleScope[
+eventsExpressionsRelations[obj_, boundary_] := ModuleScope[
   eventIndices = If[MatchQ[boundary, "Initial" | All], Prepend[0], Identity] @
     If[MatchQ[boundary, All | "Final"], Append[Infinity], Identity] @
       Range[Length[obj[[1]][$eventRuleIDs]] - 1];
-  events = propertyEvaluate[True, boundary][obj, caller, "AllEventsList"];
+  events = propertyEvaluate[True, boundary][obj, "AllEventsList"];
   eventsToOutputs = Association[Thread[eventIndices -> events[[All, 2, 2]]]];
 
-  expressionDestroyers = propertyEvaluate[True, boundary][obj, caller, "EdgeDestroyerEventsIndices"];
+  expressionDestroyers = propertyEvaluate[True, boundary][obj, "EdgeDestroyerEventsIndices"];
   expressionsToDestroyers = Association[Thread[Range[Length[expressionDestroyers]] -> expressionDestroyers]];
 
   {eventsToOutputs, expressionsToDestroyers}
@@ -670,12 +609,11 @@ rulesList[rules_List] := rules;
 filterGraphProperties[properties_] := FilterRules[properties, Except[ImageSize]];
 
 propertyEvaluate[True, boundary : includeBoundaryEventsPattern][
-      obj : WolframModelEvolutionObject[data_ ? evolutionDataQ],
-      caller_,
+      obj : WolframModelEvolutionObject[_ ? evolutionDataQ],
       property : "ExpressionsEventsGraph",
       o : $nonEmptyOptionsPattern] /;
         (Complement[{o}, FilterRules[{o}, $propertyOptions[property]]] == {}) := ModuleScope[
-  {eventsToOutputs, expressionsToDestroyers} = eventsExpressionsRelations[obj, caller, boundary];
+  {eventsToOutputs, expressionsToDestroyers} = eventsExpressionsRelations[obj, boundary];
   {labeledEvents, labeledOutputs, labeledExpressions, labeledDestroyers} =
     Function[{list, label, level}, Map[{label, #} &, list, level]] @@@ {
       {Keys[eventsToOutputs], "Event", {1}},
@@ -689,9 +627,9 @@ propertyEvaluate[True, boundary : includeBoundaryEventsPattern][
   vertexLabelsOptionValue = OptionValue[allOptionValues, VertexLabels];
   automaticVertexLabelsPattern = Automatic | Placed[Automatic, ___];
   If[MatchQ[vertexLabelsOptionValue, automaticVertexLabelsPattern],
-    rules = rulesList[propertyEvaluate[True, None][obj, caller, "Rules"]];
-    eventRuleIDs = propertyEvaluate[True, None][obj, caller, "AllEventsRuleIndices"];
-    allExpressions = propertyEvaluate[True, None][obj, caller, "AllExpressions"];
+    rules = rulesList[propertyEvaluate[True, None][obj, "Rules"]];
+    eventRuleIDs = propertyEvaluate[True, None][obj, "AllEventsRuleIndices"];
+    allExpressions = propertyEvaluate[True, None][obj, "AllExpressions"];
     placementFunction = Replace[vertexLabelsOptionValue, {
       Automatic -> Identity,
       Placed[Automatic, args___] :> (Placed[#, args] &)
@@ -731,7 +669,7 @@ propertyEvaluate[True, boundary : includeBoundaryEventsPattern][
         "VertexLayerPosition" -> Catenate[{
           2 ("TotalGenerationsCount" - "AllEventsGenerationsList") + 1,
           2 ("TotalGenerationsCount" - "EdgeGenerationsList")} /.
-            p_String :> propertyEvaluate[True, boundary][obj, caller, p]]}],
+            p_String :> propertyEvaluate[True, boundary][obj, p]]}],
     Background -> Replace[
       OptionValue[allOptionValues, Background], Automatic :> style[$lightTheme][$causalGraphBackground]],
     allOptionValues]
@@ -743,12 +681,9 @@ propertyEvaluate[True, boundary : includeBoundaryEventsPattern][
    causally related). *)
 
 propertyEvaluate[True, boundary : includeBoundaryEventsPattern][
-      obj : WolframModelEvolutionObject[data_ ? evolutionDataQ],
-      caller_,
-      property : "CausalGraph",
-      o : $nonEmptyOptionsPattern] /;
-        (Complement[{o}, FilterRules[{o}, $propertyOptions[property]]] == {}) := ModuleScope[
-  {eventsToOutputs, expressionsToDestroyers} = eventsExpressionsRelations[obj, caller, boundary];
+    obj : WolframModelEvolutionObject[_ ? evolutionDataQ], property : "CausalGraph", o : $nonEmptyOptionsPattern] /;
+      (Complement[{o}, FilterRules[{o}, $propertyOptions[property]]] == {}) := ModuleScope[
+  {eventsToOutputs, expressionsToDestroyers} = eventsExpressionsRelations[obj, boundary];
   eventsToEvents = Catenate /@ Map[expressionsToDestroyers, eventsToOutputs, {2}];
   causalEdges = Catenate[Thread /@ Normal[eventsToEvents]];
 
@@ -772,27 +707,25 @@ propertyEvaluate[True, boundary : includeBoundaryEventsPattern][
 (* LayeredCausalGraph *)
 
 propertyEvaluate[True, includeBoundaryEvents : includeBoundaryEventsPattern][
-    evolution : WolframModelEvolutionObject[data_ ? evolutionDataQ],
-    caller_,
+    evolution : WolframModelEvolutionObject[_ ? evolutionDataQ],
     property : "LayeredCausalGraph",
     o : $nonEmptyOptionsPattern] /;
       (Complement[{o}, FilterRules[{o}, $propertyOptions[property]]] == {}) :=
   Graph[
-    propertyEvaluate[True, includeBoundaryEvents][evolution, caller, "CausalGraph", ##] & @@
+    propertyEvaluate[True, includeBoundaryEvents][evolution, "CausalGraph", ##] & @@
       FilterRules[FilterRules[{o}, $causalGraphOptions], Except[$newLayeredCausalGraphOptions]],
     GraphLayout -> Replace[
       OptionValue[Flatten[Join[{o}, $propertyOptions[property]]], GraphLayout],
       Automatic -> {
         "LayeredDigraphEmbedding",
         "VertexLayerPosition" ->
-          (propertyEvaluate[True, includeBoundaryEvents][evolution, caller, "TotalGenerationsCount"] -
-              propertyEvaluate[True, includeBoundaryEvents][evolution, caller, "AllEventsGenerationsList"])}]];
+          (propertyEvaluate[True, includeBoundaryEvents][evolution, "TotalGenerationsCount"] -
+              propertyEvaluate[True, includeBoundaryEvents][evolution, "AllEventsGenerationsList"])}]];
 
 (* TerminationReason *)
 
 propertyEvaluate[True, includeBoundaryEventsPattern][
-    evolution : WolframModelEvolutionObject[data_ ? evolutionDataQ],
-    caller_,
+    WolframModelEvolutionObject[data_ ? evolutionDataQ],
     "TerminationReason"] := Replace[data[[Key[$terminationReason]]], Join[Normal[$stepSpecKeys], {
   $fixedPoint -> "FixedPoint",
   $timeConstraint -> "TimeConstraint",
@@ -804,9 +737,8 @@ propertyEvaluate[True, includeBoundaryEventsPattern][
 (* AllEventsRuleIndices *)
 
 propertyEvaluate[True, boundary : includeBoundaryEventsPattern][
-    obj : WolframModelEvolutionObject[data_ ? evolutionDataQ],
-    caller_,
-    "AllEventsRuleIndices"] := propertyEvaluate[True, boundary][obj, caller, "AllEventsList"][[All, 1]];
+    obj : WolframModelEvolutionObject[_ ? evolutionDataQ], "AllEventsRuleIndices"] :=
+  propertyEvaluate[True, boundary][obj, "AllEventsList"][[All, 1]];
 
 (* AllEventsList *)
 
@@ -814,9 +746,7 @@ finalEvent[WolframModelEvolutionObject[data_]] :=
   {Infinity, Complement[Catenate[data[$eventOutputs]], Catenate[data[$eventInputs]]] -> {}};
 
 propertyEvaluate[True, boundary : includeBoundaryEventsPattern][
-    obj : WolframModelEvolutionObject[data_ ? evolutionDataQ],
-    caller_,
-    "AllEventsList"] :=
+    obj : WolframModelEvolutionObject[data_ ? evolutionDataQ], "AllEventsList"] :=
   If[MatchQ[boundary, "Final" | None], Rest, Identity] @
     If[MatchQ[boundary, "Final" | All], Append[finalEvent[obj]], Identity] @
       Transpose[{data[$eventRuleIDs], Thread[data[$eventInputs] -> data[$eventOutputs]]}];
@@ -824,23 +754,19 @@ propertyEvaluate[True, boundary : includeBoundaryEventsPattern][
 (* EventsStatesList *)
 
 propertyEvaluate[True, boundary : includeBoundaryEventsPattern][
-      obj : WolframModelEvolutionObject[_ ? evolutionDataQ],
-      caller_,
-      "EventsStatesList"] := With[{
-    events = propertyEvaluate[True, boundary][obj, caller, "AllEventsList"],
+      obj : WolframModelEvolutionObject[_ ? evolutionDataQ], "EventsStatesList"] := With[{
+    events = propertyEvaluate[True, boundary][obj, "AllEventsList"],
     states = If[MatchQ[boundary, None | "Final"], Rest, # &] @
       If[MatchQ[boundary, All | "Final"], Append[{}], # &] @
-      propertyEvaluate[True, boundary][obj, caller, "AllEventsStatesEdgeIndicesList"]},
+      propertyEvaluate[True, boundary][obj, "AllEventsStatesEdgeIndicesList"]},
   Transpose[{events, states}]
 ];
 
 (* EdgeCreatorEventIndices *)
 
-propertyEvaluate[True, boundary : includeBoundaryEventsPattern][
-    obj : WolframModelEvolutionObject[data_ ? evolutionDataQ],
-    caller_,
-    "EdgeCreatorEventIndices"] := ModuleScope[
-  events = propertyEvaluate[True, "Initial"][obj, caller, "AllEventsList"];
+propertyEvaluate[True, includeBoundaryEventsPattern][
+    obj : WolframModelEvolutionObject[_ ? evolutionDataQ], "EdgeCreatorEventIndices"] := ModuleScope[
+  events = propertyEvaluate[True, "Initial"][obj, "AllEventsList"];
   eventOutputs = events[[All, 2, 2]];
   Sort[Catenate[Thread /@ Thread[eventOutputs -> Range[Length[events]] - 1]]][[All, 2]]
 ];
@@ -848,10 +774,8 @@ propertyEvaluate[True, boundary : includeBoundaryEventsPattern][
 (* EdgeDestroyerEventsIndices *)
 
 propertyEvaluate[True, boundary : includeBoundaryEventsPattern][
-    obj : WolframModelEvolutionObject[data_ ? evolutionDataQ],
-    caller_,
-    "EdgeDestroyerEventsIndices"] := ModuleScope[
-  events = propertyEvaluate[True, "Final"][obj, caller, "AllEventsList"];
+    obj : WolframModelEvolutionObject[_ ? evolutionDataQ], "EdgeDestroyerEventsIndices"] := ModuleScope[
+  events = propertyEvaluate[True, "Final"][obj, "AllEventsList"];
   eventInputs = events[[All, 2, 1]];
   edgeToDestroyerRules = Sort[Catenate[Thread /@ Thread[eventInputs -> Append[Range[Length[events] - 1], Infinity]]]];
   resultWithInfinities = Map[Last, Values[GroupBy[edgeToDestroyerRules, First]], {2}];
@@ -864,22 +788,18 @@ eventListToSingleEvent[{event_}, _] := event;
 
 eventListToSingleEvent[{_, __}, expression_] := throw[Failure["multiwayState", <|"edgeIndex" -> expression|>]];
 
-propertyEvaluate[True, boundary : includeBoundaryEventsPattern][
-    obj : WolframModelEvolutionObject[data_ ? evolutionDataQ],
-    caller_,
-    "EdgeDestroyerEventIndices"] := ModuleScope[
-  eventLists = propertyEvaluate[True, "Final"][obj, caller, "EdgeDestroyerEventsIndices"];
+propertyEvaluate[True, includeBoundaryEventsPattern][
+    obj : WolframModelEvolutionObject[_ ? evolutionDataQ], "EdgeDestroyerEventIndices"] := ModuleScope[
+  eventLists = propertyEvaluate[True, "Final"][obj, "EdgeDestroyerEventsIndices"];
   MapIndexed[eventListToSingleEvent[#, #2[[1]]] &, eventLists]
 ];
 
 (* EdgeGenerationsList *)
 
 propertyEvaluate[True, includeBoundaryEventsPattern][
-    obj : WolframModelEvolutionObject[_ ? evolutionDataQ],
-    caller_,
-    "EdgeGenerationsList"] := (
-  propertyEvaluate[True, "Initial"][obj, caller, "EventGenerations"][[
-    propertyEvaluate[True, "Initial"][obj, caller, "EdgeCreatorEventIndices"] + 1]]
+    obj : WolframModelEvolutionObject[_ ? evolutionDataQ], "EdgeGenerationsList"] := (
+  propertyEvaluate[True, "Initial"][obj, "EventGenerations"][[
+    propertyEvaluate[True, "Initial"][obj, "EdgeCreatorEventIndices"] + 1]]
 );
 
 (* FeatureAssociation *)
@@ -888,7 +808,7 @@ nestedToSingleAssociation[association_] :=
   Join @@ (Function[parentKey, KeyMap[StringJoin[parentKey, #] &, association[parentKey]]] /@ Keys[association])
 nestedToSingleAssociation[<||>] := <||>
 
-getNumericObjectProperties[obj_, caller_, boundary_] := <|# -> propertyEvaluate[True, boundary][obj, caller, #] & /@
+getNumericObjectProperties[obj_, boundary_] := <|# -> propertyEvaluate[True, boundary][obj, #] & /@
   {"EventsCount", "PartialGenerationsCount", "AllEventsDistinctElementsCount", "AllEventsEdgesCount",
     "CompleteGenerationsCount", "TerminationReason", "CausalGraph"}|>
 
@@ -901,21 +821,19 @@ fromFeaturesSpec[All] := {"StructurePreservingFinalStateGraph", "ObjectPropertie
 fromFeaturesSpec[featuresSpecs_List] := featuresSpecs
 fromFeaturesSpec[featuresSpecs_String] := {featuresSpecs}
 fromFeaturesSpec[wrongInput_] :=
-  throw[Failure["invalidFeatureSpec", <|"featureSpec" -> wrongInput, "choices" -> fromFeaturesSpec[caller, All]|>]];
+  throw[Failure["invalidFeatureSpec", <|"featureSpec" -> wrongInput, "choices" -> fromFeaturesSpec[All]|>]];
 
 propertyEvaluate[True, boundary : includeBoundaryEventsPattern][
-    obj : WolframModelEvolutionObject[_ ? evolutionDataQ],
-    caller_,
-    "FeatureAssociation",
-    featuresSpecs_ : All] := With[{featureGroupList = fromFeaturesSpec[featuresSpecs]},
+      obj : WolframModelEvolutionObject[_ ? evolutionDataQ], "FeatureAssociation", featuresSpecs_ : All] := With[{
+    featureGroupList = fromFeaturesSpec[featuresSpecs]},
   nestedToSingleAssociation @ AssociationThread[featureGroupList -> Replace[featureGroupList, {
-    "StructurePreservingFinalStateGraph" -> If[!propertyEvaluate[True, boundary][obj, caller, "MultiwayQ"],
+    "StructurePreservingFinalStateGraph" -> If[!propertyEvaluate[True, boundary][obj, "MultiwayQ"],
       <|"" -> HypergraphToGraph[#, "StructurePreserving"] & @
-        propertyEvaluate[True, boundary][obj, caller, "FinalState"]|>
+        propertyEvaluate[True, boundary][obj, "FinalState"]|>
     ,
       <|"" -> Missing["NotExistent", {"MultiwaySystem", "FinalState"}]|>
     ],
-    "ObjectProperties" -> getNumericObjectProperties[obj, caller, boundary],
+    "ObjectProperties" -> getNumericObjectProperties[obj, boundary],
     other_ :> throw[Failure["unknownFeatureGroup", <|"featureGroup" -> other, "choices" -> fromFeaturesSpec[All]|>]]
   }, {1}]]
 ]
@@ -923,23 +841,18 @@ propertyEvaluate[True, boundary : includeBoundaryEventsPattern][
 (* FeatureVector *)
 
 propertyEvaluate[True, boundary : includeBoundaryEventsPattern][
-    obj : WolframModelEvolutionObject[_ ? evolutionDataQ],
-    caller_,
-    "FeatureVector",
-    featuresSpecs_ : All] := Flatten @ Values @ propertyEvaluate[True, boundary][
-      obj, caller, "FeatureAssociation", featuresSpecs]
+    obj : WolframModelEvolutionObject[_ ? evolutionDataQ], "FeatureVector", featuresSpecs_ : All] :=
+  Flatten @ Values @ propertyEvaluate[True, boundary][obj, "FeatureAssociation", featuresSpecs]
 
 (* ExpressionsSeparation *)
 
 propertyEvaluate[True, includeBoundaryEventsPattern][
     obj : WolframModelEvolutionObject[_ ? evolutionDataQ],
-    caller_,
     "ExpressionsSeparation", signedExpr1_, signedExpr2_] := ModuleScope[
   {expr1, expr2} =
-    toPositiveParameter[
-        1, propertyEvaluate[True, None][obj, caller, "ExpressionsCountTotal"], #, caller, "Expression"] & /@
+    toPositiveParameter[1, propertyEvaluate[True, None][obj, "ExpressionsCountTotal"], #, "Expression"] & /@
       {signedExpr1, signedExpr2};
-  expressionsEventsGraph = propertyEvaluate[True, "Initial"][obj, caller, "ExpressionsEventsGraph"];
+  expressionsEventsGraph = propertyEvaluate[True, "Initial"][obj, "ExpressionsEventsGraph"];
   If[expr1 === expr2, Return["Identical"]];
   causalCones = VertexInComponent[expressionsEventsGraph, {"Expression", #}] & /@ {expr1, expr2};
   intersection = Intersection @@ causalCones;
@@ -951,10 +864,8 @@ propertyEvaluate[True, includeBoundaryEventsPattern][
 ];
 
 propertyEvaluate[True, includeBoundaryEventsPattern][
-    obj : WolframModelEvolutionObject[_ ? evolutionDataQ],
-    caller_,
-    "MultiwayQ"] := ModuleScope[
-  Max[Length /@ propertyEvaluate[True, None][obj, caller, "EdgeDestroyerEventsIndices"]] > 1
+    obj : WolframModelEvolutionObject[_ ? evolutionDataQ], "MultiwayQ"] := ModuleScope[
+  Max[Length /@ propertyEvaluate[True, None][obj, "EdgeDestroyerEventsIndices"]] > 1
 ];
 
 (* Public properties call *)
@@ -973,7 +884,6 @@ expr : WolframModelEvolutionObject[data_ ? evolutionDataQ][args__] := ModuleScop
     (propertyEvaluate @@
         (OptionValue[Join[opts, $masterOptions], #] & /@ {"IncludePartialGenerations", "IncludeBoundaryEvents"}))[
       WolframModelEvolutionObject[data],
-      WolframModelEvolutionObject,
       Sequence @@ property,
       ##] & @@ Flatten[FilterRules[opts, Except[$masterOptions]]],
     _ ? FailureQ,

--- a/Kernel/argumentsChecking.m
+++ b/Kernel/argumentsChecking.m
@@ -5,18 +5,17 @@ PackageImport["GeneralUtilities`"]
 PackageScope["checkEnumOptionValue"]
 PackageScope["checkIfKnownOptions"]
 
-declareMessage[General::invalidFiniteOption, "Value `value` of option `opt` should be one of `choices` in `expr`."];
-checkEnumOptionValue[func_, optionToCheck_, validValues_, opts_] := ModuleScope[
-  value = OptionValue[func, {opts}, optionToCheck];
-  supportedQ = MemberQ[validValues, value];
-  If[!supportedQ,
-    throw[Failure["invalidFiniteOption", <|"value" -> value, "opt" -> optionToCheck, "choices" -> validValues|>]]
+declareMessage[General::invalidOptionChoice, "Option value `option` -> `value` in `expr` should be one of `choices`."];
+checkEnumOptionValue[func_, optionToCheck_, validValues_, options_] := With[{
+    value = OptionValue[func, {options}, optionToCheck]},
+  If[!MemberQ[validValues, value],
+    throw[Failure["invalidOptionChoice", <|"value" -> value, "option" -> optionToCheck, "choices" -> validValues|>]]
   ];
 ];
 
 declareMessage[General::optx, StringTemplate[General::optx]["`opt`", "`expr`"]];
-checkIfKnownOptions[func_, opts_, allowedOptions_ : Automatic] := With[{
+checkIfKnownOptions[func_, options_, allowedOptions_ : Automatic] := With[{
     unknownOptions = Complement @@
-      {Flatten[{opts}][[All, 1]], If[allowedOptions === Automatic, Options[func][[All, 1]], allowedOptions]}},
+      {Flatten[{options}][[All, 1]], If[allowedOptions === Automatic, Options[func][[All, 1]], allowedOptions]}},
   If[Length[unknownOptions] > 0, throw[Failure["optx", <|"opt" -> unknownOptions[[1]]|>]]];
 ];

--- a/Kernel/argumentsChecking.m
+++ b/Kernel/argumentsChecking.m
@@ -2,11 +2,11 @@ Package["SetReplace`"]
 
 PackageImport["GeneralUtilities`"]
 
-PackageScope["assertEnumOptionValue"]
-PackageScope["assertKnownOptions"]
+PackageScope["checkEnumOptionValue"]
+PackageScope["checkKnownOptions"]
 
 declareMessage[General::invalidFiniteOption, "Value `value` of option `opt` should be one of `choices` in `expr`."];
-assertEnumOptionValue[func_, optionToCheck_, validValues_, opts_] := ModuleScope[
+checkEnumOptionValue[func_, optionToCheck_, validValues_, opts_] := ModuleScope[
   value = OptionValue[func, {opts}, optionToCheck];
   supportedQ = MemberQ[validValues, value];
   If[!supportedQ,
@@ -15,7 +15,7 @@ assertEnumOptionValue[func_, optionToCheck_, validValues_, opts_] := ModuleScope
 ];
 
 declareMessage[General::optx, StringTemplate[General::optx]["`opt`", "`expr`"]];
-assertKnownOptions[func_, opts_, allowedOptions_ : Automatic] := With[{
+checkKnownOptions[func_, opts_, allowedOptions_ : Automatic] := With[{
     unknownOptions = Complement @@
       {Flatten[{opts}][[All, 1]], If[allowedOptions === Automatic, Options[func][[All, 1]], allowedOptions]}},
   If[Length[unknownOptions] > 0, throw[Failure["optx", <|"opt" -> unknownOptions[[1]]|>]]];

--- a/Kernel/argumentsChecking.m
+++ b/Kernel/argumentsChecking.m
@@ -2,27 +2,21 @@ Package["SetReplace`"]
 
 PackageImport["GeneralUtilities`"]
 
-PackageScope["supportedOptionQ"]
-PackageScope["knownOptionsQ"]
+PackageScope["assertEnumOptionValue"]
+PackageScope["assertKnownOptions"]
 
 declareMessage[General::invalidFiniteOption, "Value `value` of option `opt` should be one of `choices` in `expr`."];
-supportedOptionQ[func_, optionToCheck_, validValues_, opts_] := ModuleScope[
+assertEnumOptionValue[func_, optionToCheck_, validValues_, opts_] := ModuleScope[
   value = OptionValue[func, {opts}, optionToCheck];
   supportedQ = MemberQ[validValues, value];
   If[!supportedQ,
     throw[Failure["invalidFiniteOption", <|"value" -> value, "opt" -> optionToCheck, "choices" -> validValues|>]]
-  ,
-    True
-  ]
+  ];
 ];
 
 declareMessage[General::optx, StringTemplate[General::optx]["`opt`", "`expr`"]];
-knownOptionsQ[func_, opts_, allowedOptions_ : Automatic] := With[{
+assertKnownOptions[func_, opts_, allowedOptions_ : Automatic] := With[{
     unknownOptions = Complement @@
       {Flatten[{opts}][[All, 1]], If[allowedOptions === Automatic, Options[func][[All, 1]], allowedOptions]}},
-  If[Length[unknownOptions] > 0,
-    throw[Failure["optx", <|"opt" -> unknownOptions[[1]]|>]]
-  ,
-    True
-  ]
+  If[Length[unknownOptions] > 0, throw[Failure["optx", <|"opt" -> unknownOptions[[1]]|>]]];
 ];

--- a/Kernel/argumentsChecking.m
+++ b/Kernel/argumentsChecking.m
@@ -16,10 +16,10 @@ supportedOptionQ[func_, optionToCheck_, validValues_, opts_] := ModuleScope[
   ]
 ];
 
-declareMessage[General::optx, StringTemplate[General::optx]["`opt`, `expr`"]];
+declareMessage[General::optx, StringTemplate[General::optx]["`opt`", "`expr`"]];
 knownOptionsQ[func_, opts_, allowedOptions_ : Automatic] := With[{
     unknownOptions = Complement @@
-      {Flatten[opts][[All, 1]], If[allowedOptions === Automatic, Options[func][[All, 1]], allowedOptions]}},
+      {Flatten[{opts}][[All, 1]], If[allowedOptions === Automatic, Options[func][[All, 1]], allowedOptions]}},
   If[Length[unknownOptions] > 0,
     throw[Failure["optx", <|"opt" -> unknownOptions[[1]]|>]]
   ,

--- a/Kernel/argumentsChecking.m
+++ b/Kernel/argumentsChecking.m
@@ -5,23 +5,24 @@ PackageImport["GeneralUtilities`"]
 PackageScope["supportedOptionQ"]
 PackageScope["knownOptionsQ"]
 
-General::invalidFiniteOption =
-  "Value `2` of option `1` should be one of `3`.";
-
+declareMessage[General::invalidFiniteOption, "Value `value` of option `opt` should be one of `choices` in `expr`."];
 supportedOptionQ[func_, optionToCheck_, validValues_, opts_] := ModuleScope[
   value = OptionValue[func, {opts}, optionToCheck];
   supportedQ = MemberQ[validValues, value];
   If[!supportedQ,
-    Message[func::invalidFiniteOption, optionToCheck, value, validValues]
-  ];
-  supportedQ
+    throw[Failure["invalidFiniteOption", <|"value" -> value, "opt" -> optionToCheck, "choices" -> validValues|>]]
+  ,
+    True
+  ]
 ];
 
-knownOptionsQ[func_, funcCall_, opts_, allowedOptions_ : Automatic] := With[{
-    unknownOptions =
-      Complement @@ {opts[[All, 1]], If[allowedOptions === Automatic, Options[func][[All, 1]], allowedOptions]}},
+declareMessage[General::optx, StringTemplate[General::optx]["`opt`, `expr`"]];
+knownOptionsQ[func_, opts_, allowedOptions_ : Automatic] := With[{
+    unknownOptions = Complement @@
+      {Flatten[opts][[All, 1]], If[allowedOptions === Automatic, Options[func][[All, 1]], allowedOptions]}},
   If[Length[unknownOptions] > 0,
-    Message[func::optx, unknownOptions[[1]], funcCall]
-  ];
-  Length[unknownOptions] == 0
+    throw[Failure["optx", <|"opt" -> unknownOptions[[1]]|>]]
+  ,
+    True
+  ]
 ];

--- a/Kernel/argumentsChecking.m
+++ b/Kernel/argumentsChecking.m
@@ -3,7 +3,7 @@ Package["SetReplace`"]
 PackageImport["GeneralUtilities`"]
 
 PackageScope["checkEnumOptionValue"]
-PackageScope["checkKnownOptions"]
+PackageScope["checkIfKnownOptions"]
 
 declareMessage[General::invalidFiniteOption, "Value `value` of option `opt` should be one of `choices` in `expr`."];
 checkEnumOptionValue[func_, optionToCheck_, validValues_, opts_] := ModuleScope[
@@ -15,7 +15,7 @@ checkEnumOptionValue[func_, optionToCheck_, validValues_, opts_] := ModuleScope[
 ];
 
 declareMessage[General::optx, StringTemplate[General::optx]["`opt`", "`expr`"]];
-checkKnownOptions[func_, opts_, allowedOptions_ : Automatic] := With[{
+checkIfKnownOptions[func_, opts_, allowedOptions_ : Automatic] := With[{
     unknownOptions = Complement @@
       {Flatten[{opts}][[All, 1]], If[allowedOptions === Automatic, Options[func][[All, 1]], allowedOptions]}},
   If[Length[unknownOptions] > 0, throw[Failure["optx", <|"opt" -> unknownOptions[[1]]|>]]];

--- a/Kernel/setSubstitutionSystem.m
+++ b/Kernel/setSubstitutionSystem.m
@@ -73,9 +73,8 @@ setSubstitutionSystem[
 setReplaceRulesQ[rules_] :=
   MatchQ[rules, {(_Rule | _RuleDelayed)..} | _Rule | _RuleDelayed];
 
-General::invalidRules =
-  "The rule specification `1` should be either a Rule, RuleDelayed, or " ~~
-  "a List of them.";
+declareMessage[
+  General::invalidRules, "The rule specification `rules` should be either a Rule, RuleDelayed, or a List of them."];
 
 setSubstitutionSystem[
     rules_, set_, stepSpec_, caller_, returnOnAbortQ_, o : OptionsPattern[]] := 0 /;

--- a/Tests/GeneralizedGridGraph.wlt
+++ b/Tests/GeneralizedGridGraph.wlt
@@ -33,7 +33,7 @@
 
       testUnevaluated[
         GeneralizedGridGraph[{4, 5}, "VertexNamingFunction" -> "$$$invalid$$$"],
-        {GeneralizedGridGraph::invalidFiniteOption}
+        {GeneralizedGridGraph::invalidOptionChoice}
       ],
 
       testUnevaluated[

--- a/Tests/GeneralizedGridGraph.wlt
+++ b/Tests/GeneralizedGridGraph.wlt
@@ -17,7 +17,7 @@
 
       testUnevaluated[
         GeneralizedGridGraph[1, 2],
-        {GeneralizedGridGraph::argx}
+        {GeneralizedGridGraph::nonopt}
       ],
 
       testUnevaluated[

--- a/Tests/RulePlot.wlt
+++ b/Tests/RulePlot.wlt
@@ -138,12 +138,12 @@
 
       testUnevaluated[
         RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], "HyperedgeRendering" -> "Invalid"],
-        {RulePlot::invalidFiniteOption}
+        {RulePlot::invalidOptionChoice}
       ],
 
       testUnevaluated[
         RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], "HyperedgeRendering" -> 3],
-        {RulePlot::invalidFiniteOption}
+        {RulePlot::invalidOptionChoice}
       ],
 
       (** VertexCoordinates **)
@@ -218,7 +218,7 @@
 
       testUnevaluated[
         RulePlot[WolframModel[{{1, 2, 3}} -> {{3, 4, 5}}], Frame -> "Invalid"],
-        {RulePlot::invalidFiniteOption}
+        {RulePlot::invalidOptionChoice}
       ],
 
       (** FrameStyle **)

--- a/Tests/WolframModel.wlt
+++ b/Tests/WolframModel.wlt
@@ -1610,7 +1610,7 @@
 
       testUnevaluated[
         WolframModel[{{1, 2, 3}} -> {{1, 2, 3}}, {{1, 2, 3}}, 1, "IncludePartialGenerations" -> $$$invalid$$$],
-        {WolframModel::invalidFiniteOption}
+        {WolframModel::invalidOptionChoice}
       ],
 
       testUnevaluated[
@@ -1620,13 +1620,13 @@
           1,
           {"FinalState", "AtomsCountFinal"},
           "IncludePartialGenerations" -> $$$invalid$$$],
-        {WolframModel::invalidFiniteOption}
+        {WolframModel::invalidOptionChoice}
       ],
 
       With[{evolution = WolframModel[{{1, 2, 3}} -> {{1, 2, 3}}, {{1, 2, 3}}, 1]},
         testUnevaluated[
           evolution["AtomsCountFinal", "IncludePartialGenerations" -> $$$invalid$$$],
-          {WolframModelEvolutionObject::invalidFiniteOption}
+          {WolframModelEvolutionObject::invalidOptionChoice}
         ]
       ],
 
@@ -1645,7 +1645,7 @@
 
       testUnevaluated[
         WolframModel[{{1, 2}} -> {{1, 2}}, {{1, 1}}, 1, "EventsCount", "IncludeBoundaryEvents" -> $$$invalid$$$],
-        {WolframModel::invalidFiniteOption}
+        {WolframModel::invalidOptionChoice}
       ],
 
       VerificationTest[

--- a/Tests/WolframModel.wlt
+++ b/Tests/WolframModel.wlt
@@ -46,17 +46,17 @@
 
       testUnevaluated[
         WolframModel[x, y],
-        {WolframModel::invalidRules}
+        {WolframModel::invalidWolframModelRules}
       ],
 
       testUnevaluated[
         WolframModel[x, y, z],
-        {WolframModel::invalidRules}
+        {WolframModel::invalidWolframModelRules}
       ],
 
       testUnevaluated[
         WolframModel[x, y, z, w],
-        {WolframModel::invalidRules}
+        {WolframModel::invalidWolframModelRules}
       ],
 
       testUnevaluated[
@@ -226,7 +226,7 @@
 
       testUnevaluated[
         WolframModel[<|"PatternRule" -> 1 -> 2|>][{1}],
-        {WolframModel::invalidRules}
+        {WolframModel::invalidWolframModelRules}
       ],
 
       testUnevaluated[
@@ -236,7 +236,7 @@
 
       testUnevaluated[
         WolframModel[<|"PatternRules" -> 1 -> 2, "f" -> 2|>][{1}],
-        {WolframModel::invalidRules}
+        {WolframModel::invalidWolframModelRules}
       ],
 
       testUnevaluated[
@@ -1025,12 +1025,12 @@
 
       testUnevaluated[
         WolframModel[{1}, 1 -> 2],
-        {WolframModel::invalidRules}
+        {WolframModel::invalidWolframModelRules}
       ],
 
       testUnevaluated[
         WolframModel[1, 1 -> 2],
-        {WolframModel::invalidRules}
+        {WolframModel::invalidWolframModelRules}
       ],
 
       testUnevaluated[

--- a/Tests/WolframModel.wlt
+++ b/Tests/WolframModel.wlt
@@ -61,47 +61,47 @@
 
       testUnevaluated[
         WolframModel[x, y, z, w, a],
-        {WolframModel::argb}
+        {WolframModel::nonopt}
       ],
 
       testUnevaluated[
         WolframModel[x, y, z, w, a, b],
-        {WolframModel::argb}
+        {WolframModel::nonopt}
       ],
 
       testUnevaluated[
         WolframModel[f -> 3],
-        {WolframModel::argb}
-      ],
-
-      testUnevaluated[
-        WolframModel[x, f -> 3],
         {}
       ],
 
       testUnevaluated[
+        WolframModel[x, f -> 3],
+        {WolframModel::optx}
+      ],
+
+      testUnevaluated[
         WolframModel[x, y, f -> 3],
-        {WolframModel::invalidRules}
+        {WolframModel::optx}
       ],
 
       testUnevaluated[
         WolframModel[x, y, z, f -> 3],
-        {WolframModel::invalidRules}
+        {WolframModel::optx}
       ],
 
       testUnevaluated[
         WolframModel[x, y, z, w, f -> 3],
-        {WolframModel::invalidRules}
+        {WolframModel::optx}
       ],
 
       testUnevaluated[
         WolframModel[x, y, z, w, a, f -> 3],
-        {WolframModel::argb}
+        {WolframModel::nonopt}
       ],
 
       testUnevaluated[
         WolframModel[x, y, z, w, a, b, f -> 3],
-        {WolframModel::argb}
+        {WolframModel::nonopt}
       ],
 
       testUnevaluated[
@@ -141,7 +141,7 @@
 
       testUnevaluated[
         WolframModel[1 -> 2, 4, g -> 2],
-        {WolframModel::invalidState}
+        {WolframModel::optx}
       ],
 
       testUnevaluated[
@@ -226,7 +226,7 @@
 
       testUnevaluated[
         WolframModel[<|"PatternRule" -> 1 -> 2|>][{1}],
-        {}
+        {WolframModel::invalidRules}
       ],
 
       testUnevaluated[
@@ -236,7 +236,7 @@
 
       testUnevaluated[
         WolframModel[<|"PatternRules" -> 1 -> 2, "f" -> 2|>][{1}],
-        {}
+        {WolframModel::invalidRules}
       ],
 
       testUnevaluated[

--- a/Tests/WolframModelEvolutionObject.wlt
+++ b/Tests/WolframModelEvolutionObject.wlt
@@ -255,7 +255,7 @@
       With[{evo = WolframModel[{{1, 2}} -> {{1, 2}}, {{1, 1}}, 1]},
         testUnevaluated[
           evo["EventsCount", "IncludeBoundaryEvents" -> $$$invalid$$$],
-          {WolframModelEvolutionObject::invalidFiniteOption}
+          {WolframModelEvolutionObject::invalidOptionChoice}
         ]
       ],
 

--- a/Tests/WolframModelEvolutionObject.wlt
+++ b/Tests/WolframModelEvolutionObject.wlt
@@ -2109,7 +2109,7 @@
 
       With[{evo = WolframModel[{{1, 2}} -> {{1, 3}, {3, 2}}, {{1, 1}}, <|"MaxEvents" -> 30|>]}, testUnevaluated[
         evo["FinalStatePlot", VertexSize -> x],
-        {HypergraphPlot::invalidSize}
+        {WolframModelEvolutionObject::invalidSize}
       ]],
 
       With[{evolution = WolframModel[{{{1, 2}, {2, 3}} -> {{1, 3}}, {{1, 2}, {1, 2}} -> {}},
@@ -2153,7 +2153,7 @@
 
       With[{evo = WolframModel[{{1, 2}} -> {{1, 3}, {3, 2}}, {{1, 1}}, <|"MaxEvents" -> 30|>]}, testUnevaluated[
         evo["StatesPlotsList", VertexSize -> x],
-        {HypergraphPlot::invalidSize}
+        {WolframModelEvolutionObject::invalidSize}
       ]],
 
       With[{evolution = WolframModel[{{{1, 2}, {2, 3}} -> {{1, 3}}, {{1, 2}, {1, 2}} -> {}},
@@ -2209,7 +2209,7 @@
 
       With[{evo = WolframModel[{{1, 2}} -> {{1, 3}, {3, 2}}, {{1, 1}}, <|"MaxEvents" -> 30|>]}, testUnevaluated[
         evo["EventsStatesPlotsList", VertexSize -> x],
-        {HypergraphPlot::invalidSize}
+        {WolframModelEvolutionObject::invalidSize}
       ]],
 
       VerificationTest[


### PR DESCRIPTION
## Changes

* Functions in `argumentsChecking.m` now throw exceptions instead of printing messages.
* `HypergraphPlot`, `RulePlot`, `WolframModel`, `WolframModelEvolutionObject` and `GeneralizedGridGraph` were updated to use `messages.m` and exceptions.

## Comments

* The main goal here is to change `knownOptionsQ` and `supportedOptionQ` to throw exceptions, as they are useful for implementing properties.

## Examples

* The only change to functionality is that `WolframModelEvolutionObject` plotting functions now correctly print messages from `WolframModelEvolutonObject` instead of `HypergraphPlot`:

<img width="821" alt="image" src="https://user-images.githubusercontent.com/1479325/127400912-45f71004-1eaf-4821-b684-94b91b4bf952.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/666)
<!-- Reviewable:end -->
