### PR TITLE
Rename causal graph styles to TEG styles

### DIFF
--- a/Kernel/A0$style.m
+++ b/Kernel/A0$style.m
@@ -27,12 +27,12 @@ PackageScope["$setReplaceTypeDisplayFunctionVersioned"]
 PackageScope["$destroyedEdgeStyle"]
 PackageScope["$createdEdgeStyle"]
 PackageScope["$destroyedAndCreatedEdgeStyle"]
-PackageScope["$causalGraphVertexStyle"]
-PackageScope["$expressionVertexStyle"]
-PackageScope["$causalGraphInitialVertexStyle"]
-PackageScope["$causalGraphFinalVertexStyle"]
-PackageScope["$causalGraphEdgeStyle"]
-PackageScope["$causalGraphBackground"]
+PackageScope["$eventVertexStyle"]
+PackageScope["$tokenVertexStyle"]
+PackageScope["$initialEventVertexStyle"]
+PackageScope["$finalEventVertexStyle"]
+PackageScope["$causalEdgeStyle"]
+PackageScope["$tokenEventGraphBackground"]
 PackageScope["$vertexSize"]
 PackageScope["$arrowheadLengthFunction"]
 PackageScope["$edgeArrowheadShape"]
@@ -132,20 +132,20 @@ $styleNames = KeySort /@ KeySort @ <|
     combinedOptionsProperties[Graph][VertexStyle -> $vertexStyle, EdgeStyle -> $edgeLineStyle]
   |>,
   "CausalGraph" -> <|
-    "VertexStyle" -> $causalGraphVertexStyle,
-    "InitialVertexStyle" -> $causalGraphInitialVertexStyle,
-    "FinalVertexStyle" -> $causalGraphFinalVertexStyle,
-    "EdgeStyle" -> $causalGraphEdgeStyle,
-    "Background" -> $causalGraphBackground,
-    combinedOptionsProperties[Graph][VertexStyle -> $causalGraphVertexStyle, EdgeStyle -> $causalGraphEdgeStyle]
+    "VertexStyle" -> $eventVertexStyle,
+    "InitialVertexStyle" -> $initialEventVertexStyle,
+    "FinalVertexStyle" -> $finalEventVertexStyle,
+    "EdgeStyle" -> $causalEdgeStyle,
+    "Background" -> $tokenEventGraphBackground,
+    combinedOptionsProperties[Graph][VertexStyle -> $eventVertexStyle, EdgeStyle -> $causalEdgeStyle]
   |>,
   "ExpressionsEventsGraph" -> <|
-    "EventVertexStyle" -> $causalGraphVertexStyle,
-    "ExpressionVertexStyle" -> $expressionVertexStyle,
-    "InitialVertexStyle" -> $causalGraphInitialVertexStyle,
-    "FinalVertexStyle" -> $causalGraphFinalVertexStyle,
-    "EdgeStyle" -> $causalGraphEdgeStyle,
-    "Background" -> $causalGraphBackground
+    "EventVertexStyle" -> $eventVertexStyle,
+    "ExpressionVertexStyle" -> $tokenVertexStyle,
+    "InitialVertexStyle" -> $initialEventVertexStyle,
+    "FinalVertexStyle" -> $finalEventVertexStyle,
+    "EdgeStyle" -> $causalEdgeStyle,
+    "Background" -> $tokenEventGraphBackground
   |>,
   "Rule" -> <|
     "SharedElementHighlight" -> $sharedRuleElementsHighlight,
@@ -190,7 +190,7 @@ $styleNames = KeySort /@ KeySort @ <|
   "EvolutionCausalGraph" -> <|
     "StateVertexStyle" -> $statesGraphVertexStyle,
     "EvolutionEdgeStyle" -> $evolutionCausalGraphEvolutionEdgeStyle,
-    "EventVertexStyle" -> $causalGraphVertexStyle,
+    "EventVertexStyle" -> $eventVertexStyle,
     "CausalEdgeStyle" -> $evolutionCausalGraphCausalEdgeStyle
   |>,
   "BranchialGraph" -> <|
@@ -288,14 +288,14 @@ style[$lightTheme] = <|
   $destroyedAndCreatedEdgeStyle -> Directive[Hue[0.02, 0.94, 0.83], Thick, AbsoluteDashing[{1, 3}]],
 
   (* Causal graph *)
-  $causalGraphVertexStyle -> Directive[Hue[0.11, 1, 0.97], EdgeForm[{Hue[0.11, 1, 0.97], Opacity[1]}]],
-  $expressionVertexStyle ->
+  $eventVertexStyle -> Directive[Hue[0.11, 1, 0.97], EdgeForm[{Hue[0.11, 1, 0.97], Opacity[1]}]],
+  $tokenVertexStyle ->
     Directive[Hue[0.63, 0.66, 0.81], Opacity[0.1], EdgeForm[Directive[Hue[0.63, 0.7, 0.5], Opacity[0.7]]]],
-  $causalGraphInitialVertexStyle ->
+  $initialEventVertexStyle ->
     Directive[RGBColor[{0.259, 0.576, 1}], EdgeForm[{RGBColor[{0.259, 0.576, 1}], Opacity[1]}]],
-  $causalGraphFinalVertexStyle -> Directive[White, EdgeForm[{Hue[0.11, 1, 0.97], Opacity[1]}]],
-  $causalGraphEdgeStyle -> Hue[0, 1, 0.56],
-  $causalGraphBackground -> None,
+  $finalEventVertexStyle -> Directive[White, EdgeForm[{Hue[0.11, 1, 0.97], Opacity[1]}]],
+  $causalEdgeStyle -> Hue[0, 1, 0.56],
+  $tokenEventGraphBackground -> None,
 
   (* HypergraphPlot *)
   $vertexSize -> 0.06,

--- a/Kernel/Multihistory.m
+++ b/Kernel/Multihistory.m
@@ -23,12 +23,12 @@ objectType[Multihistory[type_, _]] := type;
 $genericMultihistoryIcon = GraphPlot[
   {DirectedEdge[0, 1], DirectedEdge[1, 2], DirectedEdge[1, 3]},
   GraphLayout -> "LayeredDigraphEmbedding",
-  VertexStyle -> {1 -> style[$lightTheme][$expressionVertexStyle], style[$lightTheme][$causalGraphVertexStyle]},
-  EdgeStyle -> Directive[style[$lightTheme][$causalGraphEdgeStyle], Arrowheads[0]],
+  VertexStyle -> {1 -> style[$lightTheme][$tokenVertexStyle], style[$lightTheme][$eventVertexStyle]},
+  EdgeStyle -> Directive[style[$lightTheme][$causalEdgeStyle], Arrowheads[0]],
   VertexCoordinates -> {{0, 1}, {0, 0}, {0, -1} . RotationMatrix[Pi / 4], {0, -1} . RotationMatrix[-Pi / 4]},
   VertexSize -> 0.5,
   PlotRange -> {{-1.3, 1.3}, {-1.3, 1.3}},
-  Background -> style[$lightTheme][$causalGraphBackground]];
+  Background -> style[$lightTheme][$tokenEventGraphBackground]];
 
 Multihistory /: MakeBoxes[object : Multihistory[_, _], format_] := ModuleScope[
   type = objectType[object];

--- a/Kernel/WolframModelEvolutionObject.m
+++ b/Kernel/WolframModelEvolutionObject.m
@@ -771,16 +771,16 @@ propertyEvaluate[True, boundary : includeBoundaryEventsPattern][
     VertexStyle -> Replace[
       OptionValue[allOptionValues, VertexStyle],
       Automatic :> Join[
-        {{"Event", _} -> style[$lightTheme][$causalGraphVertexStyle],
-         {"Expression", _} -> style[$lightTheme][$expressionVertexStyle]},
+        {{"Event", _} -> style[$lightTheme][$eventVertexStyle],
+         {"Expression", _} -> style[$lightTheme][$tokenVertexStyle]},
         Cases[
           graphVertices,
           v : {"Event", e : 0 | Infinity} :> v -> style[$lightTheme][Switch[e,
-            0, $causalGraphInitialVertexStyle,
-            Infinity, $causalGraphFinalVertexStyle]],
+            0, $initialEventVertexStyle,
+            Infinity, $finalEventVertexStyle]],
           {1}]]],
     EdgeStyle -> Replace[
-      OptionValue[allOptionValues, EdgeStyle], Automatic :> style[$lightTheme][$causalGraphEdgeStyle]],
+      OptionValue[allOptionValues, EdgeStyle], Automatic :> style[$lightTheme][$causalEdgeStyle]],
     VertexLabels -> Replace[
       OptionValue[allOptionValues, VertexLabels], {
         automaticVertexLabelsPattern :> Replace[graphVertices, {
@@ -799,7 +799,7 @@ propertyEvaluate[True, boundary : includeBoundaryEventsPattern][
           2 ("TotalGenerationsCount" - "EdgeGenerationsList")} /.
             p_String :> propertyEvaluate[True, boundary][obj, caller, p]]}],
     Background -> Replace[
-      OptionValue[allOptionValues, Background], Automatic :> style[$lightTheme][$causalGraphBackground]],
+      OptionValue[allOptionValues, Background], Automatic :> style[$lightTheme][$tokenEventGraphBackground]],
     allOptionValues]
 ];
 
@@ -825,13 +825,13 @@ propertyEvaluate[True, boundary : includeBoundaryEventsPattern][
     VertexStyle -> Replace[
       OptionValue[allOptionValues, VertexStyle],
       Automatic -> Select[Head[#] =!= Rule || MatchQ[#[[1]], Alternatives @@ Keys[eventsToOutputs]] &] @ {
-        style[$lightTheme][$causalGraphVertexStyle],
-        0 -> style[$lightTheme][$causalGraphInitialVertexStyle],
-        Infinity -> style[$lightTheme][$causalGraphFinalVertexStyle]}],
+        style[$lightTheme][$eventVertexStyle],
+        0 -> style[$lightTheme][$initialEventVertexStyle],
+        Infinity -> style[$lightTheme][$finalEventVertexStyle]}],
     EdgeStyle -> Replace[
-      OptionValue[allOptionValues, EdgeStyle], Automatic -> style[$lightTheme][$causalGraphEdgeStyle]],
+      OptionValue[allOptionValues, EdgeStyle], Automatic -> style[$lightTheme][$causalEdgeStyle]],
     Background -> Replace[
-      OptionValue[allOptionValues, Background], Automatic -> style[$lightTheme][$causalGraphBackground]],
+      OptionValue[allOptionValues, Background], Automatic -> style[$lightTheme][$tokenEventGraphBackground]],
     allOptionValues]
 ];
 


### PR DESCRIPTION
## Changes

* Renames outdated style names such as `$causalGraphVertexStyle` to modern TEG names such as `$eventVertexStyle`.
* Does not change names used in `SetReplaceStyleData` to preserve backward compatibility for now.

## Comments

* I only changed the TEG-related style names for now, as I need them for the `TokenEventGraph` property.

## Examples

* No functionality is affected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/667)
<!-- Reviewable:end -->
