### PR TITLE
Enable compiler optimizations for WolframScript builds.

### DIFF
--- a/DevUtils/BuildLibSetReplace.m
+++ b/DevUtils/BuildLibSetReplace.m
@@ -173,11 +173,11 @@ $warningsFlags = {
 
 $compileOptions = Switch[$OperatingSystem,
   "Windows",
-    {"/std:c++17", "/EHsc"},
+    {"/std:c++17 /O3", "/EHsc"},
   "MacOSX",
-    Join[{"-std=c++17"}, $warningsFlags, {"-mmacosx-version-min=10.12"}], (* for std::shared_mutex support *)
+    Join[{"-std=c++17 -O3"}, $warningsFlags, {"-mmacosx-version-min=10.12"}], (* for std::shared_mutex support *)
   "Unix",
-    Join[{"-std=c++17"}, $warningsFlags]
+    Join[{"-std=c++17 -O3"}, $warningsFlags]
 ];
 
 flushLibrariesIfFull[libraryDirectory_] := Scope[


### PR DESCRIPTION
## Changes

I noticed that the `WolframModel` evolutions were taking an extremely long time to evaluate. I also noticed that the fairly straightforward evaluation of `RandomWolframModel` was completely locking up my computer. After looking at the dylib produced by `DevUtils/BuildLibSetReplace.m` I noticed that it was not being build with compiler optimizations, so I added them.

## Comments

Fairly simple, low risk change here assuming we trust the compiler. Should yield more performance for all who want to use this library. :)

## Examples

Run `./install.wls` to build with compiler optimizations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/setreplace/668)
<!-- Reviewable:end -->
