### PR TITLE
Fix and pin dependencies to unblock CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ jobs:
 
             python3 -m venv .venv
             . .venv/bin/activate
-            pip install cpplint
+            pip install cpplint==1.5.5
 
       - run:
           name: Lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,7 @@ jobs:
 
       - run:
           name: Test
+          no_output_timeout: 20m
           command: ./.circleci/test.sh # This assumes parallelism: 4 and would not run all tests otherwise
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
 
   cpp-test:
     docker:
-      - image: alpine:3.13.5
+      - image: alpine:3.21.2
         auth:
           username: maxitg
           password: $DOCKERHUB_PASSWORD
@@ -65,15 +65,19 @@ jobs:
       - run:
           name: Install Required Tools
           command: |
-            apk add --no-cache bash git g++ make cmake clang py-pip shellcheck grep npm
+            apk add --no-cache bash git g++ make cmake clang clang-extra-tools py-pip shellcheck grep npm
             apk add --no-cache shfmt --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community
-            pip install cpplint
             npm install -g markdownlint-cli
+
+            python3 -m venv .venv
+            . .venv/bin/activate
+            pip install cpplint
 
       - run:
           name: Lint
           command: |
             set +eo pipefail
+            . .venv/bin/activate
             ./lint.sh
             if [ $? -ne 0 ]
             then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,7 +137,7 @@ jobs:
       - run:
           name: Install CMake
           command: |
-            cmakeURL="https://github.com/Kitware/CMake/releases/download/v3.18.6/cmake-3.18.6-Darwin-x86_64.tar.gz"
+            cmakeURL="https://github.com/Kitware/CMake/releases/download/v3.31.5/cmake-3.31.5-macos-universal.tar.gz"
             curl -L --output cmake.tar.gz $cmakeURL
             tar xf cmake.tar.gz
             cmakeDir=$(ls | grep cmake-*)
@@ -173,7 +173,7 @@ jobs:
       - run:
           name: Install CMake
           command: |
-            cmakeURL="https://github.com/Kitware/CMake/releases/download/v3.18.6/cmake-3.18.6-win64-x64.zip"
+            cmakeURL="https://github.com/Kitware/CMake/releases/download/v3.31.5/cmake-3.31.5-windows-x86_64.zip"
             curl -L --output cmake.zip $cmakeURL
             unzip -q cmake.zip
             cmakeDir=$(dir -1 | findstr -i cmake-*)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,14 +6,24 @@ orbs:
 jobs:
   wolfram-language-paclet-test:
     docker:
-      - image: maxitg/set-replace-wl-ci:12.3.0
-        auth:
-          username: maxitg
-          password: $DOCKERHUB_PASSWORD
+      - image: wolframresearch/wolframengine:12.3.0
+        user: root
     parallelism: 4
 
     steps:
       - checkout
+
+      - run:
+          name: Install Required Tools
+          command: |
+            apt-get update
+            apt-get install -y g++ git
+
+      - run:
+          name: Activate Wolfram Engine
+          command: |
+            wolframscript -authenticate maxitg@icloud.com "${WOLFRAM_PASSWORD}"
+            wolframscript -activate
 
       - run:
           name: Build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ jobs:
           command: |
             apk add --no-cache bash git g++ make cmake clang clang-extra-tools py-pip shellcheck grep npm
             apk add --no-cache shfmt --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community
-            npm install -g markdownlint-cli
+            npm install -g markdownlint-cli@0.37.0
 
             python3 -m venv .venv
             . .venv/bin/activate

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
 
       - run:
           name: Test
-          command: ./.circleci/test.sh  # This assumes parallelism: 4 and would not run all tests otherwise
+          command: ./.circleci/test.sh # This assumes parallelism: 4 and would not run all tests otherwise
 
       - run:
           name: Performance Test
@@ -129,7 +129,7 @@ jobs:
 
   macos-build:
     macos:
-      xcode: 12.2.0
+      xcode: 16.2.0
 
     steps:
       - checkout
@@ -141,9 +141,9 @@ jobs:
             curl -L --output cmake.tar.gz $cmakeURL
             tar xf cmake.tar.gz
             cmakeDir=$(ls | grep cmake-*)
-            mkdir -p /usr/local/bin /usr/local/share
-            cp -r $cmakeDir/CMake.app/Contents/bin/* /usr/local/bin/
-            cp -r $cmakeDir/CMake.app/Contents/share/* /usr/local/share/
+            sudo mkdir -p /usr/local/bin /usr/local/share
+            sudo cp -r $cmakeDir/CMake.app/Contents/bin/* /usr/local/bin/
+            sudo cp -r $cmakeDir/CMake.app/Contents/share/* /usr/local/share/
 
       - run:
           name: Build arm64

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@
 
 *.nb
 
+# Python environments
+
+.venv/
+
 # Sublime text
 
 *.sublime-workspace

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,7 +116,7 @@ if(SET_REPLACE_BUILD_TESTING)
   FetchContent_Declare(
     googletest
     GIT_REPOSITORY https://github.com/google/googletest.git
-    GIT_TAG master
+    GIT_TAG main
   )
 
   set(CMAKE_POLICY_DEFAULT_CMP0048 NEW) # google test raises warning about it


### PR DESCRIPTION
## Changes

* Introduce the minimal set of changes to make CI pass again for the first time since the last successful build in 2021.
* Update some of the pinned dependencies:
    * macOS executor 12.2.0 -> 16.2.0;
    * CMake 3.18.6 -> 3.31.5;
    * alpine (on x86_64) 3.13.5 -> 3.21.2.
* Pin some dependencies to avoid introducing compatibility issues:
    * cpplint to 1.5.5;
    * markdown-cli to 0.37.0.
* Update the googletest branch `master` -> `main`.
* Use the official `wolframresearch/wolframengine` Docker image instead of the custom one.
* Increase the timeout for Wolfram Language tests 10 min -> 20 min.

## Comments

* cpplint is pinned to 1.5.5 because newer versions require headers to be in a directory by default. The refactor will be done in a separate PR.
* `markdownlint-cli` is pinned to 0.37.0 because newer versions require alt text for images by default. The alt text will be added in a separate PR.
* Wolfram Language version is kept at 12.3.0. It will be upgraded in a separate PR.

## Examples

Observe CI now passing:

<img width="986" alt="Screenshot 2025-01-25 at 22 21 39" src="https://github.com/user-attachments/assets/11023faa-15e6-4d28-9705-f63433619988" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/SetReplace/670)
<!-- Reviewable:end -->