### PR TITLE
cpplint 2.0.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ jobs:
 
             python3 -m venv .venv
             . .venv/bin/activate
-            pip install cpplint==1.5.5
+            pip install cpplint==2.0.0
 
       - run:
           name: Lint

--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -2,5 +2,8 @@ linelength=120
 
 filter=-build/c++11
 filter=-build/c++14
+filter=-build/include_subdir
 
 filter=-legal/copyright
+
+filter=-whitespace/indent_namespace # https://github.com/cpplint/cpplint/issues/293

--- a/libSetReplace/test/HypergraphSubstitutionSystem_test.cpp
+++ b/libSetReplace/test/HypergraphSubstitutionSystem_test.cpp
@@ -2,6 +2,8 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
+#include <limits>
 #include <unordered_map>
 #include <vector>
 


### PR DESCRIPTION
## Changes

* Update cpplint 1.5.5 -> 2.0.0.
* Add missing C++ Standard Library includes.
* Disable `build/include_subdir` as we don't currently have subdirectories in the C++ code.
* Disable `whitespace/indent_namespace` due to https://github.com/cpplint/cpplint/issues/293.

## Comments

* I'm keeping the version pinned so that builds are reproducible.
* The plan is to switch to [Trunk](https://trunk.io/code-quality) in the future to make local linting reproducible as well.

## Examples

```console
$ cpplint libSetReplace/*.cpp libSetReplace/*.hpp libSetReplace/test/*.cpp
Done processing libSetReplace/AtomsIndex.cpp
Done processing libSetReplace/AtomsIndex.hpp
Done processing libSetReplace/HypergraphMatcher.cpp
Done processing libSetReplace/HypergraphMatcher.hpp
Done processing libSetReplace/HypergraphSubstitutionSystem.cpp
Done processing libSetReplace/HypergraphSubstitutionSystem.hpp
Done processing libSetReplace/IDTypes.hpp
Done processing libSetReplace/Parallelism.cpp
Done processing libSetReplace/Parallelism.hpp
Done processing libSetReplace/Rule.hpp
Done processing libSetReplace/TokenEventGraph.cpp
Done processing libSetReplace/TokenEventGraph.hpp
Done processing libSetReplace/WolframLanguageAPI.cpp
Done processing libSetReplace/WolframLanguageAPI.hpp
Done processing libSetReplace/test/HypergraphSubstitutionSystem_test.cpp
Done processing libSetReplace/test/Parallelism_tests.cpp
Done processing libSetReplace/test/profile_tests.cpp
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/SetReplace/671)
<!-- Reviewable:end -->
