### PR TITLE
Add alt text to all Yellowstone documentation pages

### DIFF
--- a/Documentation/Generators/GenerateMultihistory.md
+++ b/Documentation/Generators/GenerateMultihistory.md
@@ -12,11 +12,15 @@ In[] := multihistory = GenerateMultihistory[
   MultisetSubstitutionSystem[{a_, b_} :> {a + b}], MaxDestroyerEvents -> 3, MaxEvents -> 10] @ {1, 2, 3, 4}
 ```
 
-<img src="/Documentation/Images/MultisetMultihistory.png" width="426.6">
+<img src="/Documentation/Images/MultisetMultihistory.png"
+     width="426.6"
+     alt="Out[] = Multihistory[... MultisetSubstitutionSystem v0 ...]">
 
 ```wl
 In[] := #["ExpressionsEventsGraph", VertexLabels -> Placed[Automatic, After]] & @
   SetReplaceTypeConvert[WolframModelEvolutionObject] @ multihistory
 ```
 
-<img src="/Documentation/Images/GenerateMultihistoryExample.png" width="478.2">
+<img src="/Documentation/Images/GenerateMultihistoryExample.png"
+     width="478.2"
+     alt="Out[] = ... {1, 2} -> {3 (* token 5 *)}, {2, 1} -> {3 (* token 6 *)}, {1, 3 (* init *)} -> {4}, <<7>> ...">

--- a/Documentation/Generators/GenerateMultihistory.md
+++ b/Documentation/Generators/GenerateMultihistory.md
@@ -23,4 +23,6 @@ In[] := #["ExpressionsEventsGraph", VertexLabels -> Placed[Automatic, After]] & 
 
 <img src="/Documentation/Images/GenerateMultihistoryExample.png"
      width="478.2"
-     alt="Out[] = ... {1, 2} -> {3 (* token 5 *)}, {2, 1} -> {3 (* token 6 *)}, {1, 3 (* init *)} -> {4}, <<7>> ...">
+     alt="Out[] = Graph[...
+       {1, 2} -> {3 (* token 5 *)}, {2, 1} -> {3 (* token 6 *)}, {1, 3 (* init *)} -> {4}, <<7>>
+     ...]">

--- a/Documentation/Generators/GenerateSingleHistory.md
+++ b/Documentation/Generators/GenerateSingleHistory.md
@@ -11,14 +11,24 @@ In[] := multihistory = GenerateSingleHistory[
   MultisetSubstitutionSystem[{a_, b_} :> {a + b, a - b, a * b}], MaxEvents -> 10] @ {1, 2}
 ```
 
-<img src="/Documentation/Images/MultisetMultihistory.png" width="426.6">
+<img src="/Documentation/Images/MultisetMultihistory.png"
+     width="426.6"
+     alt="Out[] = Multihistory[... MultisetSubstitutionSystem v0 ...]">
 
 ```wl
 In[] := #["ExpressionsEventsGraph", VertexLabels -> Placed[Automatic, After]] & @
   SetReplaceTypeConvert[WolframModelEvolutionObject] @ multihistory
 ```
 
-<img src="/Documentation/Images/GenerateSingleHistoryExample.png" width="478.2">
+<img src="/Documentation/Images/GenerateSingleHistoryExample.png"
+     width="478.2"
+     alt="Out[] = ...
+       token-event graph where all tokens have out degrees less or equal than 1:
+       {1, 2 (* init *)} -> {3, -1, 2 (* gen 1 *)},
+       {3, -1} -> {2 (* gen 2 *), 4 (* gen 2 *), -3},
+       {2 (* gen 1 *), 2 (* gen 2 *)} -> {4 (* gen 3 sum *), 0, 4 (* gen 3 product *)},
+       <<7>>
+     ...">
 
 Note that there is a distinction between single-history and single-path systems. Single-path systems are defined as ones
 where there is only one event possible from every state. A Turing machine would be an example of a single-path system.

--- a/Documentation/Generators/GenerateSingleHistory.md
+++ b/Documentation/Generators/GenerateSingleHistory.md
@@ -22,13 +22,13 @@ In[] := #["ExpressionsEventsGraph", VertexLabels -> Placed[Automatic, After]] & 
 
 <img src="/Documentation/Images/GenerateSingleHistoryExample.png"
      width="478.2"
-     alt="Out[] = ...
+     alt="Out[] = Graph[...
        token-event graph where all tokens have out degrees less or equal than 1:
        {1, 2 (* init *)} -> {3, -1, 2 (* gen 1 *)},
        {3, -1} -> {2 (* gen 2 *), 4 (* gen 2 *), -3},
        {2 (* gen 1 *), 2 (* gen 2 *)} -> {4 (* gen 3 sum *), 0, 4 (* gen 3 product *)},
        <<7>>
-     ...">
+     ...]">
 
 Note that there is a distinction between single-history and single-path systems. Single-path systems are defined as ones
 where there is only one event possible from every state. A Turing machine would be an example of a single-path system.

--- a/Documentation/Generators/MaxDestroyerEvents.md
+++ b/Documentation/Generators/MaxDestroyerEvents.md
@@ -10,7 +10,9 @@ In[] := #["ExpressionsEventsGraph", VertexLabels -> Placed[Automatic, After]] & 
     GenerateMultihistory[MultisetSubstitutionSystem[{a_, b_} :> {a + b}], MaxDestroyerEvents -> 1] @ {1, 2, 3}
 ```
 
-<img src="/Documentation/Images/MaxDestroyerEvents1.png" width="322.2">
+<img src="/Documentation/Images/MaxDestroyerEvents1.png"
+     width="322.2"
+     alt="Out[] = ... {1, 2} -> {3 (* gen 1 *)}, {3 (* init *), 3 (* gen 1 *)} -> 6 ...">
 
 If unset (which defaults to [`Infinity`](https://reference.wolfram.com/language/ref/Infinity.html)), it will generate a
 full multihistory object subject to other selection and stopping parameters:
@@ -22,7 +24,9 @@ In[] := #["ExpressionsEventsGraph", VertexLabels -> Placed[Automatic, After]] & 
       MultisetSubstitutionSystem[{a_, b_} :> {a + b}], MaxDestroyerEvents -> Infinity, MaxGeneration -> 1] @ {1, 2, 3}
 ```
 
-<img src="/Documentation/Images/MaxDestroyerEventsInfinity.png" width="478.2">
+<img src="/Documentation/Images/MaxDestroyerEventsInfinity.png"
+     width="478.2"
+     alt="Out[] = ... {1, 2} -> {3 (* 1 + 2 *)}, {2, 1} -> {3 (* 2 + 1 *)}, {1, 3 (* init *)} -> {4}, <<3>> ...">
 
 If set to a finite number, it will generate a partial multihistory:
 
@@ -32,6 +36,8 @@ In[] := #["ExpressionsEventsGraph", VertexLabels -> Placed[Automatic, After]] & 
     GenerateMultihistory[MultisetSubstitutionSystem[{a_, b_} :> {a + b}], MaxDestroyerEvents -> 5] @ {1, 2, 3}
 ```
 
-<img src="/Documentation/Images/MaxDestroyerEvents5.png" width="478.2">
+<img src="/Documentation/Images/MaxDestroyerEvents5.png"
+     width="478.2"
+     alt="Out[] = ... token-event graph containing tokens with out degrees up to 5 ...">
 
 Note that results generally depend on the event order in this case, similar to single histories.

--- a/Documentation/Generators/MaxDestroyerEvents.md
+++ b/Documentation/Generators/MaxDestroyerEvents.md
@@ -12,7 +12,7 @@ In[] := #["ExpressionsEventsGraph", VertexLabels -> Placed[Automatic, After]] & 
 
 <img src="/Documentation/Images/MaxDestroyerEvents1.png"
      width="322.2"
-     alt="Out[] = ... {1, 2} -> {3 (* gen 1 *)}, {3 (* init *), 3 (* gen 1 *)} -> 6 ...">
+     alt="Out[] = Graph[... {1, 2} -> {3 (* gen 1 *)}, {3 (* init *), 3 (* gen 1 *)} -> 6 ...]">
 
 If unset (which defaults to [`Infinity`](https://reference.wolfram.com/language/ref/Infinity.html)), it will generate a
 full multihistory object subject to other selection and stopping parameters:
@@ -26,7 +26,7 @@ In[] := #["ExpressionsEventsGraph", VertexLabels -> Placed[Automatic, After]] & 
 
 <img src="/Documentation/Images/MaxDestroyerEventsInfinity.png"
      width="478.2"
-     alt="Out[] = ... {1, 2} -> {3 (* 1 + 2 *)}, {2, 1} -> {3 (* 2 + 1 *)}, {1, 3 (* init *)} -> {4}, <<3>> ...">
+     alt="Out[] = Graph[... {1, 2} -> {3 (* 1 + 2 *)}, {2, 1} -> {3 (* 2 + 1 *)}, {1, 3 (* init *)} -> {4}, <<3>> ...]">
 
 If set to a finite number, it will generate a partial multihistory:
 
@@ -38,6 +38,6 @@ In[] := #["ExpressionsEventsGraph", VertexLabels -> Placed[Automatic, After]] & 
 
 <img src="/Documentation/Images/MaxDestroyerEvents5.png"
      width="478.2"
-     alt="Out[] = ... token-event graph containing tokens with out degrees up to 5 ...">
+     alt="Out[] = Graph[... token-event graph containing tokens with out degrees up to 5 ...]">
 
 Note that results generally depend on the event order in this case, similar to single histories.

--- a/Documentation/Generators/MaxEvents.md
+++ b/Documentation/Generators/MaxEvents.md
@@ -9,6 +9,8 @@ In[] := #["ExpressionsEventsGraph"] & @
     GenerateMultihistory[MultisetSubstitutionSystem[{a_, b_} /; a < b :> {a + b}], MaxEvents -> 9] @ {1, 2, 3, 4}
 ```
 
-<img src="/Documentation/Images/MaxEventsExample.png" width="478.2">
+<img src="/Documentation/Images/MaxEventsExample.png"
+     width="478.2"
+     alt="Out[] = ... token-event graph with 9 events ...">
 
 Compare to [`MaxGeneration`](MaxGeneration.md), which controls the depth of the evaluation instead.

--- a/Documentation/Generators/MaxEvents.md
+++ b/Documentation/Generators/MaxEvents.md
@@ -11,6 +11,6 @@ In[] := #["ExpressionsEventsGraph"] & @
 
 <img src="/Documentation/Images/MaxEventsExample.png"
      width="478.2"
-     alt="Out[] = ... token-event graph with 9 events ...">
+     alt="Out[] = Graph[... token-event graph with 9 events ...]">
 
 Compare to [`MaxGeneration`](MaxGeneration.md), which controls the depth of the evaluation instead.

--- a/Documentation/Generators/MaxGeneration.md
+++ b/Documentation/Generators/MaxGeneration.md
@@ -19,7 +19,9 @@ In[] := #["ExpressionsEventsGraph",
                          MaxEvents -> 3] @ {1, 2, 3}
 ```
 
-<img src="/Documentation/Images/TokenEventGraphGenerations.png" width="444.6">
+<img src="/Documentation/Images/TokenEventGraphGenerations.png"
+     width="444.6"
+     alt="Out[] = ... token-event graph with 9 tokens arranged in 3 layers, and 3 events in 2 layers in between ...">
 
 Restricting the number of generations to one will prevent the last two events from occurring. Note, however, that
 another event is created instead:
@@ -30,7 +32,9 @@ In[] := #["ExpressionsEventsGraph"] & @ SetReplaceTypeConvert[WolframModelEvolut
                        MaxGeneration -> 1, MaxEvents -> 3] @ {1, 2, 3}
 ```
 
-<img src="/Documentation/Images/MaxGeneration.png" width="478.2">
+<img src="/Documentation/Images/MaxGeneration.png"
+     width="478.2"
+     alt="Out[] = ... token-event graph with 2 layers of tokens and a single layer of events ...">
 
 `MaxGeneration` is an event selection parameter, not a stopping condition. That is, the evolution of the system won't
 stop if a match (tentative event) with a generation greater than the constraint is encountered. Instead, it will ignore

--- a/Documentation/Generators/MaxGeneration.md
+++ b/Documentation/Generators/MaxGeneration.md
@@ -21,7 +21,9 @@ In[] := #["ExpressionsEventsGraph",
 
 <img src="/Documentation/Images/TokenEventGraphGenerations.png"
      width="444.6"
-     alt="Out[] = ... token-event graph with 9 tokens arranged in 3 layers, and 3 events in 2 layers in between ...">
+     alt="Out[] = Graph[...
+       token-event graph with 9 tokens arranged in 3 layers, and 3 events in 2 layers in between
+     ...]">
 
 Restricting the number of generations to one will prevent the last two events from occurring. Note, however, that
 another event is created instead:
@@ -34,7 +36,7 @@ In[] := #["ExpressionsEventsGraph"] & @ SetReplaceTypeConvert[WolframModelEvolut
 
 <img src="/Documentation/Images/MaxGeneration.png"
      width="478.2"
-     alt="Out[] = ... token-event graph with 2 layers of tokens and a single layer of events ...">
+     alt="Out[] = Graph[... token-event graph with 2 layers of tokens and a single layer of events ...]">
 
 `MaxGeneration` is an event selection parameter, not a stopping condition. That is, the evolution of the system won't
 stop if a match (tentative event) with a generation greater than the constraint is encountered. Instead, it will ignore

--- a/Documentation/Generators/MinEventInputs.md
+++ b/Documentation/Generators/MinEventInputs.md
@@ -14,7 +14,9 @@ In[] := #["ExpressionsEventsGraph", VertexLabels -> Placed[Automatic, After]] & 
 
 <img src="/Documentation/Images/MinEventInputs0.png"
      width="367.8"
-     alt="Out[] = ... {} -> {0}, {1 (* init *)} -> {1 (* gen 1 *)}, {2 (* init *)} -> {2 (* gen 1 *)}, <<7>> ...">
+     alt="Out[] = Graph[...
+       {} -> {0}, {1 (* init *)} -> {1 (* gen 1 *)}, {2 (* init *)} -> {2 (* gen 1 *)}, <<7>>
+     ...]">
 
 and `MinEventInputs -> 2`:
 
@@ -27,4 +29,4 @@ In[] := #["ExpressionsEventsGraph", VertexLabels -> Placed[Automatic, After]] & 
 
 <img src="/Documentation/Images/MinEventInputs2.png"
      width="478.2"
-     alt="Out[] = ... {1, 2} -> {3 (* 1 + 2 *)}, {2, 1} -> {3 (* 2 + 1 *)}, {1, 3 (* init *)} -> {4}, <<7>> ...">
+     alt="Out[] = Graph[... {1, 2} -> {3 (* 1 + 2 *)}, {2, 1} -> {3 (* 2 + 1 *)}, {1, 3 (* init *)} -> {4}, <<7>> ...]">

--- a/Documentation/Generators/MinEventInputs.md
+++ b/Documentation/Generators/MinEventInputs.md
@@ -12,7 +12,9 @@ In[] := #["ExpressionsEventsGraph", VertexLabels -> Placed[Automatic, After]] & 
       MultisetSubstitutionSystem[{a___} :> {Total[{a}]}], MinEventInputs -> 0, MaxEvents -> 10] @ {1, 2, 3}
 ```
 
-<img src="/Documentation/Images/MinEventInputs0.png" width="367.8">
+<img src="/Documentation/Images/MinEventInputs0.png"
+     width="367.8"
+     alt="Out[] = ... {} -> {0}, {1 (* init *)} -> {1 (* gen 1 *)}, {2 (* init *)} -> {2 (* gen 1 *)}, <<7>> ...">
 
 and `MinEventInputs -> 2`:
 
@@ -23,4 +25,6 @@ In[] := #["ExpressionsEventsGraph", VertexLabels -> Placed[Automatic, After]] & 
       MultisetSubstitutionSystem[{a___} :> {Total[{a}]}], MinEventInputs -> 2, MaxEvents -> 10] @ {1, 2, 3}
 ```
 
-<img src="/Documentation/Images/MinEventInputs2.png" width="478.2">
+<img src="/Documentation/Images/MinEventInputs2.png"
+     width="478.2"
+     alt="Out[] = ... {1, 2} -> {3 (* 1 + 2 *)}, {2, 1} -> {3 (* 2 + 1 *)}, {1, 3 (* init *)} -> {4}, <<7>> ...">

--- a/Documentation/Generators/README.md
+++ b/Documentation/Generators/README.md
@@ -28,7 +28,7 @@ In[] := #["ExpressionsEventsGraph", VertexLabels -> Placed[Automatic, After]] & 
 
 <img src="/Documentation/Images/MultisetSubstitutionSystemExample.png"
      width="444.6"
-     alt="Out[] = ... {1, 2} -> {3 (* gen 1 *)}, {3 (* init *), 4} -> {7}, {3 (* gen 1 *), 7} -> {10} ...">
+     alt="Out[] = Graph[... {1, 2} -> {3 (* gen 1 *)}, {3 (* init *), 4} -> {7}, {3 (* gen 1 *), 7} -> {10} ...]">
 
 We can also use a more general [`GenerateMultihistory`](GenerateMultihistory.md) and specify
 [`MaxDestroyerEvents`](MaxDestroyerEvents.md) manually.
@@ -42,13 +42,13 @@ In[] := #["ExpressionsEventsGraph", VertexLabels -> Placed[Automatic, After]] & 
 
 <img src="/Documentation/Images/MultisetSubstitutionSystemPartialMultihistory.png"
      width="478.2"
-     alt="Out[] = ...
+     alt="Out[] = Graph[...
        {1, 2} -> {3 (* gen 1 *)},
        {1, 3 (* init *)} -> {4 (* gen 1 *)},
        {2, 3 (* init *)} -> {5},
        {3 (* gen 1 *), 4 (* init *)} -> {7},
        {4 (* init *), 5} -> {9}
-     ...">
+     ...]">
 
 The same generators support multiple systems. In addition to
 [`MultisetSubstitutionSystem`](/Documentation/Systems/MultisetSubstitutionSystem.md), other examples include

--- a/Documentation/Generators/README.md
+++ b/Documentation/Generators/README.md
@@ -26,7 +26,9 @@ In[] := #["ExpressionsEventsGraph", VertexLabels -> Placed[Automatic, After]] & 
     GenerateSingleHistory[MultisetSubstitutionSystem[{a_, b_} /; a < b :> {a + b}]] @ {1, 2, 3, 4}
 ```
 
-<img src="/Documentation/Images/MultisetSubstitutionSystemExample.png" width="444.6">
+<img src="/Documentation/Images/MultisetSubstitutionSystemExample.png"
+     width="444.6"
+     alt="Out[] = ... {1, 2} -> {3 (* gen 1 *)}, {3 (* init *), 4} -> {7}, {3 (* gen 1 *), 7} -> {10} ...">
 
 We can also use a more general [`GenerateMultihistory`](GenerateMultihistory.md) and specify
 [`MaxDestroyerEvents`](MaxDestroyerEvents.md) manually.
@@ -38,7 +40,15 @@ In[] := #["ExpressionsEventsGraph", VertexLabels -> Placed[Automatic, After]] & 
       MultisetSubstitutionSystem[{a_, b_} /; a < b :> {a + b}], MaxDestroyerEvents -> 2] @ {1, 2, 3, 4}
 ```
 
-<img src="/Documentation/Images/MultisetSubstitutionSystemPartialMultihistory.png" width="478.2">
+<img src="/Documentation/Images/MultisetSubstitutionSystemPartialMultihistory.png"
+     width="478.2"
+     alt="Out[] = ...
+       {1, 2} -> {3 (* gen 1 *)},
+       {1, 3 (* init *)} -> {4 (* gen 1 *)},
+       {2, 3 (* init *)} -> {5},
+       {3 (* gen 1 *), 4 (* init *)} -> {7},
+       {4 (* init *), 5} -> {9}
+     ...">
 
 The same generators support multiple systems. In addition to
 [`MultisetSubstitutionSystem`](/Documentation/Systems/MultisetSubstitutionSystem.md), other examples include

--- a/Documentation/Systems/AtomicStateSystem.md
+++ b/Documentation/Systems/AtomicStateSystem.md
@@ -9,7 +9,9 @@ In[] := #["ExpressionsEventsGraph", VertexLabels -> Placed[Automatic, After]] & 
     GenerateMultihistory[AtomicStateSystem[{n_ :> n + 1, n_ :> n - 1}], MaxGeneration -> 4][0]
 ```
 
-<img src="/Documentation/Images/AtomicStateSystemExample.png" width="858.6">
+<img src="/Documentation/Images/AtomicStateSystemExample.png"
+     width="858.6"
+     alt="Out[] = ... 0 -> Rule 1 -> 1, 0 -> Rule 2 -> -1, 1 -> Rule 1 -> 2, <<26>>, -3 -> Rule 2 -> -4 ...">
 
 Note that spacelike separation is not possible in the `AtomicStateSystem`. As a result, branching due to overlaps of
 different subsets of input tokens cannot occur. And, since events cannot produce branchlike-separated outputs and there

--- a/Documentation/Systems/AtomicStateSystem.md
+++ b/Documentation/Systems/AtomicStateSystem.md
@@ -11,7 +11,7 @@ In[] := #["ExpressionsEventsGraph", VertexLabels -> Placed[Automatic, After]] & 
 
 <img src="/Documentation/Images/AtomicStateSystemExample.png"
      width="858.6"
-     alt="Out[] = ... 0 -> Rule 1 -> 1, 0 -> Rule 2 -> -1, 1 -> Rule 1 -> 2, <<26>>, -3 -> Rule 2 -> -4 ...">
+     alt="Out[] = Graph[... 0 -> Rule 1 -> 1, 0 -> Rule 2 -> -1, 1 -> Rule 1 -> 2, <<26>>, -3 -> Rule 2 -> -4 ...]">
 
 Note that spacelike separation is not possible in the `AtomicStateSystem`. As a result, branching due to overlaps of
 different subsets of input tokens cannot occur. And, since events cannot produce branchlike-separated outputs and there

--- a/Documentation/Systems/MultisetSubstitutionSystem.md
+++ b/Documentation/Systems/MultisetSubstitutionSystem.md
@@ -24,7 +24,7 @@ In[] := #["ExpressionsEventsGraph", VertexLabels -> Placed[Automatic, After]] & 
 
 <img src="/Documentation/Images/MultisetSubstitutionSystemExample.png"
      width="444.6"
-     alt="Out[] = ... {1, 2} -> {3 (* gen 1 *)}, {3 (* init *), 4} -> {7}, {3 (* gen 1 *), 7} -> {10} ...">
+     alt="Out[] = Graph[... {1, 2} -> {3 (* gen 1 *)}, {3 (* init *), 4} -> {7}, {3 (* gen 1 *), 7} -> {10} ...]">
 
 Arbitrary Wolfram Language patterns are supported including
 [conditions](https://reference.wolfram.com/language/ref/Condition.html) such as `{a_ /; a > 0, b_}` and
@@ -42,10 +42,10 @@ In[] := #["ExpressionsEventsGraph", VertexLabels -> Placed[Automatic, After]] & 
 
 <img src="/Documentation/Images/MultisetSubstitutionSystemConditionsAndSequences.png"
      width="478.2"
-     alt="Out[] = ...
+     alt="Out[] = Graph[...
        generation 1: {1, 2} -> {3}, {1, 4} -> {5}, {2, 3} -> {5}, {3, 4} -> {7}, {1, 2, 4} -> {7},
        generation 2: {2, 5} -> {7}, {3 (* gen 1 *), 4} -> {7}
-     ...">
+     ...]">
 
 Note, however, that the system cannot recognize if the code on the right-hand side is nondeterministic, so only the
 first output will be used for each assignment of pattern variables.

--- a/Documentation/Systems/MultisetSubstitutionSystem.md
+++ b/Documentation/Systems/MultisetSubstitutionSystem.md
@@ -22,7 +22,9 @@ In[] := #["ExpressionsEventsGraph", VertexLabels -> Placed[Automatic, After]] & 
     GenerateSingleHistory[MultisetSubstitutionSystem[{a_, b_} /; a < b :> {a + b}]] @ {1, 2, 3, 4}
 ```
 
-<img src="/Documentation/Images/MultisetSubstitutionSystemExample.png" width="444.6">
+<img src="/Documentation/Images/MultisetSubstitutionSystemExample.png"
+     width="444.6"
+     alt="Out[] = ... {1, 2} -> {3 (* gen 1 *)}, {3 (* init *), 4} -> {7}, {3 (* gen 1 *), 7} -> {10} ...">
 
 Arbitrary Wolfram Language patterns are supported including
 [conditions](https://reference.wolfram.com/language/ref/Condition.html) such as `{a_ /; a > 0, b_}` and
@@ -38,7 +40,12 @@ In[] := #["ExpressionsEventsGraph", VertexLabels -> Placed[Automatic, After]] & 
       MinEventInputs -> 2, MaxEventInputs -> 4] @ {1, 2, 3, 4}
 ```
 
-<img src="/Documentation/Images/MultisetSubstitutionSystemConditionsAndSequences.png" width="478.2">
+<img src="/Documentation/Images/MultisetSubstitutionSystemConditionsAndSequences.png"
+     width="478.2"
+     alt="Out[] = ...
+       generation 1: {1, 2} -> {3}, {1, 4} -> {5}, {2, 3} -> {5}, {3, 4} -> {7}, {1, 2, 4} -> {7},
+       generation 2: {2, 5} -> {7}, {3 (* gen 1 *), 4} -> {7}
+     ...">
 
 Note, however, that the system cannot recognize if the code on the right-hand side is nondeterministic, so only the
 first output will be used for each assignment of pattern variables.

--- a/Documentation/TypeSystem/$SetReplaceTypeGraph.md
+++ b/Documentation/TypeSystem/$SetReplaceTypeGraph.md
@@ -10,10 +10,10 @@ In[] := $SetReplaceTypeGraph
 
 <img src="/Documentation/Images/$SetReplaceTypeGraph.png"
      width="787.8"
-     alt="Out[] = ...
+     alt="Out[] = Graph[...
        AtomicStateSystem v0 -> MultisetSubstitutionSystem v0,
        MultisetSubstitutionSystem v0 -> WolframModelEvolutionObject v2
-     ...">
+     ...]">
 
 It is a [`Graph`](https://reference.wolfram.com/language/ref/Graph.html) representation of a directed hypergraph with
 types and properties as vertices and implementations of translations and properties as edges.

--- a/Documentation/TypeSystem/$SetReplaceTypeGraph.md
+++ b/Documentation/TypeSystem/$SetReplaceTypeGraph.md
@@ -8,7 +8,12 @@
 In[] := $SetReplaceTypeGraph
 ```
 
-<img src="/Documentation/Images/$SetReplaceTypeGraph.png" width="787.8">
+<img src="/Documentation/Images/$SetReplaceTypeGraph.png"
+     width="787.8"
+     alt="Out[] = ...
+       AtomicStateSystem v0 -> MultisetSubstitutionSystem v0,
+       MultisetSubstitutionSystem v0 -> WolframModelEvolutionObject v2
+     ...">
 
 It is a [`Graph`](https://reference.wolfram.com/language/ref/Graph.html) representation of a directed hypergraph with
 types and properties as vertices and implementations of translations and properties as edges.

--- a/Documentation/TypeSystem/$SetReplaceTypes.md
+++ b/Documentation/TypeSystem/$SetReplaceTypes.md
@@ -6,4 +6,8 @@
 In[] := $SetReplaceTypes
 ```
 
-<img src="/Documentation/Images/$SetReplaceTypes.png" width="791.4">
+<img src="/Documentation/Images/$SetReplaceTypes.png"
+     width="791.4"
+     alt="Out[] = {
+       [... AtomicStateSystem v0 ...], [... MultisetSubstitutionSystem v0 ...], [... WolframModelEvolutionObject v2 ...]
+     }">

--- a/Documentation/TypeSystem/$SetReplaceTypes.md
+++ b/Documentation/TypeSystem/$SetReplaceTypes.md
@@ -9,5 +9,7 @@ In[] := $SetReplaceTypes
 <img src="/Documentation/Images/$SetReplaceTypes.png"
      width="791.4"
      alt="Out[] = {
-       [... AtomicStateSystem v0 ...], [... MultisetSubstitutionSystem v0 ...], [... WolframModelEvolutionObject v2 ...]
+       SetReplaceType[... AtomicStateSystem v0 ...],
+       SetReplaceType[... MultisetSubstitutionSystem v0 ...],
+       SetReplaceType[... WolframModelEvolutionObject v2 ...]
      }">

--- a/Documentation/TypeSystem/SetReplaceObjectQ.md
+++ b/Documentation/TypeSystem/SetReplaceObjectQ.md
@@ -3,7 +3,9 @@
 **`SetReplaceObjectQ`** yields [`True`](https://reference.wolfram.com/language/ref/True.html) for *SetReplace* objects
 and [`False`](https://reference.wolfram.com/language/ref/False.html) otherwise:
 
-<img src="/Documentation/Images/SetReplaceObjectQOfMultihistory.png" width="595.2">
+<img src="/Documentation/Images/SetReplaceObjectQOfMultihistory.png"
+     width="595.2"
+     alt="In[] := SetReplaceObjectQ @ Multihistory[... MultisetSubstitutionSystem v0 ...]">
 
 ```wl
 Out[] = True

--- a/Documentation/TypeSystem/SetReplaceObjectType.md
+++ b/Documentation/TypeSystem/SetReplaceObjectType.md
@@ -3,4 +3,9 @@
 **`SetReplaceObjectType`** yields [the type](/Documentation/Types/README.md) of an object. Note that the type
 specification usually contains its version:
 
-<img src="/Documentation/Images/SetReplaceObjectTypeOfMultihistory.png" width="628.2">
+<img src="/Documentation/Images/SetReplaceObjectTypeOfMultihistory.png"
+     width="628.2"
+     alt="
+       In[] := SetReplaceObjectType @ Multihistory[... MultisetSubstitutionSystem v0 ...]
+       Out[] = [... MultisetSubstitutionSystem v0 ...]
+     ">

--- a/Documentation/TypeSystem/SetReplaceObjectType.md
+++ b/Documentation/TypeSystem/SetReplaceObjectType.md
@@ -7,5 +7,5 @@ specification usually contains its version:
      width="628.2"
      alt="
        In[] := SetReplaceObjectType @ Multihistory[... MultisetSubstitutionSystem v0 ...]
-       Out[] = [... MultisetSubstitutionSystem v0 ...]
+       Out[] = SetReplaceType[... MultisetSubstitutionSystem v0 ...]
      ">

--- a/Documentation/TypeSystem/SetReplaceTypeConvert.md
+++ b/Documentation/TypeSystem/SetReplaceTypeConvert.md
@@ -11,8 +11,20 @@ For example, one can convert an
 [`AtomicStateSystem` multihistory](/Documentation/Types/Multihistory/AtomicStateSystem0.md) to a
 [`MultisetSubstitutionSystem` multihistory](/Documentation/Types/Multihistory/MultisetSubstitutionSystem0.md):
 
-<img src="/Documentation/Images/AtomicStateToMultisetMultihistory.png" width="517.8">
+<img src="/Documentation/Images/AtomicStateToMultisetMultihistory.png"
+     width="517.8"
+     alt="
+       In[] := SetReplaceTypeConvert[MultisetSubstitutionSystem] @ Multihistory[... AtomicStateSystem v0 ...]
+       Out[] = Multihistory[... MultisetSubstitutionSystem v0 ...]
+     ">
 
 To convert to a specific version of a type, one can use the full type specification:
 
-<img src="/Documentation/Images/AtomicStateToMultisetMultihistoryVersioned.png" width="693.0">
+<img src="/Documentation/Images/AtomicStateToMultisetMultihistoryVersioned.png"
+     width="693.0"
+     alt="
+       In[] := SetReplaceTypeConvert[
+         SetReplaceType[MultisetSubstitutionSystem, 0]
+       ] @ Multihistory[... AtomicStateSystem v0 ...]
+       Out[] = Multihistory[... MultisetSubstitutionSystem v0 ...]
+     ">

--- a/Documentation/Types/Multihistory/AtomicStateSystem0.md
+++ b/Documentation/Types/Multihistory/AtomicStateSystem0.md
@@ -8,7 +8,9 @@
 In[] := GenerateMultihistory[AtomicStateSystem[a_ :> a + 1], MaxEvents -> 10][0]
 ```
 
-<img src="/Documentation/Images/AtomicStateMultihistory.png" width="378.6">
+<img src="/Documentation/Images/AtomicStateMultihistory.png"
+     width="378.6"
+     alt="Out[] = Multihistory[... AtomicStateSystem v0 ...]">
 
 Internally, [`AtomicStateSystem`](/Documentation/Systems/AtomicStateSystem.md) is implemented by running a special case
 of the [`MultisetSubstitutionSystem`](/Documentation/Systems/MultisetSubstitutionSystem.md). The object contains a

--- a/Documentation/Types/Multihistory/MultisetSubstitutionSystem0.md
+++ b/Documentation/Types/Multihistory/MultisetSubstitutionSystem0.md
@@ -8,7 +8,9 @@ object is returned by [generators](/Documentation/Generators/README.md) of the
 In[] := GenerateMultihistory[MultisetSubstitutionSystem[{a_, b_} :> {a + b}], MaxEvents -> 10] @ {1, 2, 3}
 ```
 
-<img src="/Documentation/Images/MultisetMultihistory.png" width="426.6">
+<img src="/Documentation/Images/MultisetMultihistory.png"
+     width="426.6"
+     alt="Out[] = Multihistory[... MultisetSubstitutionSystem v0 ...]">
 
 It is implemented as an [`Association`](https://reference.wolfram.com/language/guide/Associations.html) of
 [data structures](https://reference.wolfram.com/language/ref/DataStructure.html) containing information about the rules,

--- a/Documentation/Types/Multihistory/README.md
+++ b/Documentation/Types/Multihistory/README.md
@@ -9,7 +9,9 @@ For example, for a [`MultisetSubstitutionSystem`](/Documentation/Systems/Multise
 In[] := GenerateMultihistory[MultisetSubstitutionSystem[{a_, b_} :> {a + b}], MaxEvents -> 10] @ {1, 2, 3}
 ```
 
-<img src="/Documentation/Images/MultisetMultihistory.png" width="426.6">
+<img src="/Documentation/Images/MultisetMultihistory.png"
+     width="426.6"
+     alt="Out[] = Multihistory[... MultisetSubstitutionSystem v0 ...]">
 
 You will be able to use [`properties`](/Documentation/Properties/README.md) to extract information about multihistories,
 but we have not implemented any properties yet.


### PR DESCRIPTION
## Changes

* Add alt text to all images in the _Yellowstone_ documentation.

## Comments

* This is needed to update markdownlint-cli to the latest version 0.44.0 without disabling rules.
* I tried to describe images in a way that the pages can be understood within seeing the images. In some cases that involved explicitly listing events in a token-event graph, which made the alt text pretty long. However, it's difficult to make them understandable otherwise. If you have a better idea, please let me know.

## Examples

It is now possible to read the documentation in links:
<img width="794" alt="Screenshot 2025-01-26 at 22 38 23" src="https://github.com/user-attachments/assets/dae9f222-fe72-4615-b500-62011902e41e" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/SetReplace/673)
<!-- Reviewable:end -->
