### PR TITLE
Add alt text to README.md and CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -376,15 +376,30 @@ Also please name the patterns in `SyntaxInformation`. If you do that, you can tu
 the Front End (`Null` has to do with options, and unfortunately renaming them causes the corresponding template to be
 displayed if no options are specified):
 
-<img src="/Documentation/Images/HighlightMissingArgumentsWithTemplate.png" width="362.4">
+<img src="/Documentation/Images/HighlightMissingArgumentsWithTemplate.png"
+     width="362.4"
+     alt="In[] := WolframModel[rules, init, stepSpec, property, Null]">
 
 Functions must handle invalid inputs correctly. For example, if you try to evaluate
 
-<img src="/Documentation/Images/ArgumentChecks.png" width="469">
+<img src="/Documentation/Images/ArgumentChecks.png"
+     width="469"
+     alt="
+       In[] := WolframModel[1 -> 2, 1]
+       [...] WolframModel: The initial state specification 1 should be a List.
+       Out[] = WolframModel[1 -> 2, 1]
+     ">
 
 you would get a helpful error message. If we did not do any checks here, we would instead have the code go haywire:
 
-<img src="/Documentation/Images/NoArgumentChecks.png" width="582">
+<img src="/Documentation/Images/NoArgumentChecks.png"
+     width="582"
+     alt="
+       In[] := WolframModel[1 -> 2, 1]
+       [...] First: Nonatomic expression expected at position 1 in First[2].
+       [...] First: Nonatomic expression expected at position 1 in First[0].
+       ... (many more errors) ...
+     ">
 
 and the function would not even terminate, which is confusing and hostile to the user.
 
@@ -797,7 +812,7 @@ and saving them as .png files to [Documentation/Images](/Documentation/Images) (
 directory of the corresponding research note. They should then be inserted using the code similar to this:
 
   ```html
-  <img src="/Documentation/Images/image.png" width="xxx">
+  <img src="/Documentation/Images/image.png" width="xxx" alt="description">
   ```
 
 where the `width` should be computed as

--- a/README.md
+++ b/README.md
@@ -54,7 +54,9 @@ In[] := HypergraphPlot[{{1, 2, 3}, {2, 4, 5}, {4, 6, 7}},
  VertexLabels -> Automatic]
 ```
 
-<img src="Documentation/Images/BasicHypergraphPlot.png" width="478">
+<img src="Documentation/Images/BasicHypergraphPlot.png"
+     width="478"
+     alt="Out[] = ... a plot showing 3 triangles connected at vertices labeled 2 and 4 ...">
 
 We can then have a rule which would pick a subset of these hyperedges related through common vertices (much like a join
 query) and replace them with something else:
@@ -76,7 +78,9 @@ In[] := HypergraphPlot[SetReplace[{{1, 2, 3}, {2, 4, 5}, {4, 6, 7}},
  VertexLabels -> Automatic]
 ```
 
-<img src="Documentation/Images/EvolutionResult1Step.png" width="478">
+<img src="Documentation/Images/EvolutionResult1Step.png"
+     width="478"
+     alt="Out[] = ... {{4, 6, 7}, {5, v11, 1}, {v11, 4, 2}, {4, 5, 3}} ...">
 
 After 10 steps, we get a more complicated structure:
 
@@ -87,7 +91,9 @@ In[] := HypergraphPlot[SetReplace[{{1, 2, 3}, {2, 4, 5}, {4, 6, 7}},
  VertexLabels -> Automatic]
 ```
 
-<img src="Documentation/Images/EvolutionResult10Steps.png" width="478">
+<img src="Documentation/Images/EvolutionResult10Steps.png"
+     width="478"
+     alt="Out[] = ... {{7, 2, v13}, {7, v18, 6}, {v18, v15, 4}, {v15, 7, v12}, {3, v19, v16}, <<7>>, {7, 6, v15}} ...">
 
 And after 100 steps, it gets even more elaborate:
 
@@ -97,7 +103,9 @@ In[] := HypergraphPlot[SetReplace[{{1, 2, 3}, {2, 4, 5}, {4, 6, 7}},
    Module[{v6}, {{v5, v6, v1}, {v6, v4, v2}, {v4, v5, v3}}], 100]]
 ```
 
-<img src="Documentation/Images/EvolutionResult100Steps.png" width="478">
+<img src="Documentation/Images/EvolutionResult100Steps.png"
+     width="478"
+     alt="Out[] = ... hypergraph with 103 hyperedges ...">
 
 Exploring the hypergraph models of this variety is the primary purpose of this package.
 


### PR DESCRIPTION
## Changes

* Add alt text to all images in the main README and CONTRIBUTING.md.

## Comments

* This is needed to update markdownlint-cli to the latest version 0.44.0 without disabling rules.

## Examples

README is now more readable without images:
<img width="794" alt="Screenshot 2025-01-26 at 22 41 11" src="https://github.com/user-attachments/assets/c67145f2-cda9-4544-be84-2e25672ebfd2" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/SetReplace/674)
<!-- Reviewable:end -->
