### PR TITLE
Retry WolframScript activation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,9 +21,7 @@ jobs:
 
       - run:
           name: Activate Wolfram Engine
-          command: |
-            wolframscript -authenticate maxitg@icloud.com "${WOLFRAM_PASSWORD}"
-            wolframscript -activate
+          command: ./scripts/activateWolframScript.sh
 
       - run:
           name: Build

--- a/scripts/activateWolframScript.sh
+++ b/scripts/activateWolframScript.sh
@@ -1,0 +1,22 @@
+# Activation is flaky, try up to 3 times.
+n=0
+until [ $n -ge 3 ]
+do
+  ((n++))
+  echo "Attempt $n..."
+
+  # Run the activation
+  if wolframscript -authenticate "maxitg@icloud.com" "${WOLFRAM_PASSWORD}" && wolframscript -activate; then
+    echo "Activation succeeded on attempt $n."
+    break
+  fi
+
+  echo "Activation failed on attempt $n. Retrying..."
+  sleep 5
+done
+
+# If after the loop it's still not activated, fail the build
+if [ $n -eq 3 ]; then
+  echo "Activation failed after 3 attempts."
+  exit 1
+fi

--- a/scripts/activateWolframScript.sh
+++ b/scripts/activateWolframScript.sh
@@ -1,22 +1,23 @@
+#!/usr/bin/env bash
+
 # Activation is flaky, try up to 3 times.
 n=0
-until [ $n -ge 3 ]
-do
+until [[ ${n} -ge 3 ]]; do
   ((n++))
-  echo "Attempt $n..."
+  echo "Attempt ${n}..."
 
   # Run the activation
   if wolframscript -authenticate "maxitg@icloud.com" "${WOLFRAM_PASSWORD}" && wolframscript -activate; then
-    echo "Activation succeeded on attempt $n."
+    echo "Activation succeeded on attempt ${n}."
     break
   fi
 
-  echo "Activation failed on attempt $n. Retrying..."
+  echo "Activation failed on attempt ${n}. Retrying..."
   sleep 5
 done
 
 # If after the loop it's still not activated, fail the build
-if [ $n -eq 3 ]; then
+if [[ ${n} -eq 3 ]]; then
   echo "Activation failed after 3 attempts."
   exit 1
 fi

--- a/scripts/activateWolframScript.sh
+++ b/scripts/activateWolframScript.sh
@@ -7,7 +7,7 @@ until [[ ${n} -ge 3 ]]; do
   echo "Attempt ${n}..."
 
   # Run the activation
-  if wolframscript -authenticate "maxitg@icloud.com" "${WOLFRAM_PASSWORD}" && wolframscript -activate; then
+  if wolframscript -authenticate "${WOLFRAM_ID}" "${WOLFRAM_PASSWORD}" && wolframscript -activate; then
     echo "Activation succeeded on attempt ${n}."
     break
   fi


### PR DESCRIPTION
## Changes

* Try WolframScript activation up to 3 times before failing.

## Comments

* WolframScript activation [keeps failing](https://app.circleci.com/pipelines/github/maxitg/SetReplace/2125/workflows/a937820e-d49c-4bfe-b3fe-21fe60fb4aec/jobs/5523) intermittently because it "could not connect to https://www.wolframcloud.com/". We cannot avoid doing it, however, we can decrease the probability of failure by retrying a few times.

## Examples

* Passing wrong `WOLFRAM_ID` and `WOLFRAM_PASSWORD`:

   ```console
   $ export WOLFRAM_ID="test@test.test"
   $ export WOLFRAM_PASSWORD="123"
   $ ./scripts/activateWolframScript.sh 
   Attempt 1...
   Incorrect username or password
   Activation failed on attempt 1. Retrying...
   Attempt 2...
   Incorrect username or password
   Activation failed on attempt 2. Retrying...
   Attempt 3...
   Incorrect username or password
   Activation failed on attempt 3. Retrying...
   Activation failed after 3 attempts.
   $ echo $?
   1
   ```

* [CI job](https://app.circleci.com/pipelines/github/maxitg/SetReplace/2138/workflows/dd8dffc9-0bcd-4e77-bf8f-be73c98e6018/jobs/5588/parallel-runs/0/steps/0-103) for this PR:

   ```console
   $ #!/bin/bash -eo pipefail
   $ ./scripts/activateWolframScript.sh
   Attempt 1...
   Success. Saving connection data.
   Wolfram Engine activated. See https://www.wolfram.com/wolframscript/ for more information.
   Activation succeeded on attempt 1.
   ```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/SetReplace/677)
<!-- Reviewable:end -->
