### PR TITLE
Fix typo in temporary directory usage

### DIFF
--- a/DevUtils/init.m
+++ b/DevUtils/init.m
@@ -22,7 +22,7 @@ $DevUtilsRoot is the directory from which the DevUtils package was loaded.
 $DevUtilsRoot = FileNameDrop[$InputFileName, -1];
 
 SetUsage @ "
-$DevUtilsTemporaryDirectory is the temprary directory that DevUtils uses.
+$DevUtilsTemporaryDirectory is the temporary directory that DevUtils uses.
 ";
 
 $DevUtilsTemporaryDirectory := EnsureDirectory @ FileNameJoin[{$TemporaryDirectory, "SetReplace"}];


### PR DESCRIPTION
## Summary
- fix a typo in `$DevUtilsTemporaryDirectory` usage message in `DevUtils/init.m`

## Testing
- `./test.wls` *(fails: `wolframscript` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879d8260e8c832cadbf937f423bbf54

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/SetReplace/680)
<!-- Reviewable:end -->
