### PR TITLE
Fix const correctness in TokenEventGraph

### DIFF
--- a/libSetReplace/TokenEventGraph.cpp
+++ b/libSetReplace/TokenEventGraph.cpp
@@ -88,7 +88,7 @@ class TokenEventGraph::Implementation {
     return SeparationType::Spacelike;
   }
 
-  uint64_t destroyerEventsCount(const TokenID id) { return tokenIDsToDestroyerEventsCount_[id]; }
+  uint64_t destroyerEventsCount(const TokenID id) const { return tokenIDsToDestroyerEventsCount_[id]; }
 
  private:
   std::vector<TokenID> createTokens(const EventID creatorEvent, const int count) {


### PR DESCRIPTION
## Summary
- mark `TokenEventGraph::Implementation::destroyerEventsCount` as `const`
- run lint and tests

## Testing
- `./lint.sh -f`
- `cmake .. -DSET_REPLACE_BUILD_TESTING=ON`
- `cmake --build .`
- `../libSetReplaceTest.sh`

------
https://chatgpt.com/codex/tasks/task_e_6879d4935a6c832c96f1dfe4b0750152

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxitg/SetReplace/681)
<!-- Reviewable:end -->
